### PR TITLE
docs: sync README from release 7.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NVIDIA TAO Skill Bank
+# NVIDIA [TAO Skill Bank](https://github.com/NVIDIA-TAO/tao-skills-bank)
 
-Portable agent skills for training, evaluating, and running inference on NVIDIA TAO models. Works with Claude Code, Codex, Gemini CLI, or any coding agent that speaks the [Agent Skills open standard](https://agentskills.io). **Zero Python required** for local docker workflows — install the plugin, install docker + nvidia-container-toolkit, and an agent can run every skill by constructing `docker run` commands directly. For advanced features (job tracking, multi-node, Lepton access, S3 I/O wrapping), an optional Python layer — the [TAO Execution SDK](#optional-python-layer) — sits on top.
+Portable agent skills for training, evaluating, and running inference on NVIDIA TAO models. Works with Claude Code, Codex, Gemini CLI, or any coding agent that speaks the [Agent Skills open standard](https://agentskills.io). **Zero Python required** for local docker workflows — install the plugin, install docker + nvidia-container-toolkit, and an agent can run every skill by constructing `docker run` commands directly. For advanced features (job tracking, multi-node, S3 I/O wrapping), an optional Python layer — the [TAO Execution SDK](#optional-python-layer) — sits on top.
 
 ## Install
 
@@ -15,50 +15,89 @@ In a Claude Code session, add the marketplace and install the plugin:
 /plugin install tao-skills@tao-skill-bank
 ```
 
-That's it — no `git clone`, no `pip install`. The `tao-skills` plugin bundles all 56 skills (every model, data, platform, and application). The plugin's [`SessionStart`](hooks/session_start.sh) hook loads the [`AGENTS.md`](AGENTS.md) identity at the start of every session.
+That's it — no `git clone`, no `pip install`. The TAO Skill Bank plugin bundles all 56 skills (every model, data, platform, and application). The plugin's [`SessionStart`](hooks/session_start.sh) hook loads the [`AGENTS.md`](AGENTS.md) identity at the start of every session.
 
 ### Codex
 
 Codex setup has **two independent pieces** — the plugin (which surfaces the skills to Codex) and `AGENTS.md` (which loads the agent identity). You need both for parity with Claude Code.
 
-#### 1. Install the plugin
+#### One command (recommended)
 
-**Option A — VS Code Codex extension (recommended for VS Code users).** Open the extension's plugin UI, add the marketplace URL, and install `tao-skill-bank` — all from the UI. Most discoverable, one click.
+```bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA-TAO/tao-skills-bank/main/scripts/install-codex-agents.sh | bash
+```
 
-**Option B — CLI + TUI.** Add the marketplace from the shell, then install the plugin from inside the Codex TUI (no CLI `install` subcommand exists yet — [openai/codex#17431](https://github.com/openai/codex/issues/17431)):
+…or, if you've already cloned or extracted the repo from a zip, run
+`scripts/install-codex-agents.sh` from that directory. The script registers the
+marketplace, installs the TAO Skill Bank plugin, and copies `AGENTS.md` to
+`~/.codex/AGENTS.md` so the TAO identity loads in every Codex session. It's
+idempotent and backs up any existing `~/.codex/AGENTS.md` before overwriting.
+Override the source with `TAO_SKILL_BANK_MARKETPLACE=…` and
+`TAO_SKILL_BANK_REF=…` to use a fork, pinned ref, or local absolute path:
+
+```bash
+cd /absolute/path/to/tao-skills-external
+TAO_SKILL_BANK_MARKETPLACE=/absolute/path/to/tao-skills-external \
+  scripts/install-codex-agents.sh
+```
+
+#### Manual steps
+
+If you'd rather drive each step yourself:
+
+**1. Install the plugin.** Either use the VS Code Codex extension's plugin UI (select **TAO Skill Bank**), or from the CLI:
 
 ```bash
 codex plugin marketplace add git@github.com:NVIDIA-TAO/tao-skills-bank.git
-codex                # opens TUI
-/plugins             # then: select tao-skill-bank → Install plugin
+codex plugin add tao-skill-bank@tao-local-plugins
 ```
 
-Either path installs the bundle to `~/.codex/plugins/cache/<marketplace>/tao-skill-bank/<version>/` (the `<marketplace>` segment comes from the `name` field in `.agents/plugins/marketplace.json`).
+This installs the bundle to `~/.codex/plugins/cache/tao-local-plugins/tao-skill-bank/<version>/` (the `tao-local-plugins` segment comes from the `name` field in `.agents/plugins/marketplace.json`).
 
-#### 2. Load the agent identity (`AGENTS.md`)
+For a local zip or clone, use the absolute path instead of the Git URL:
 
-The plugin install does **not** auto-load [`AGENTS.md`](AGENTS.md) — Codex's `AGENTS.md` discovery walks down from the project root, not into the plugin cache (see [openai/codex#16430](https://github.com/openai/codex/issues/16430) for why plugin-bundled `SessionStart` hooks don't fix this yet). Pick one:
+```bash
+codex plugin marketplace add /absolute/path/to/tao-skills-external
+codex plugin add tao-skill-bank@tao-local-plugins
+```
 
-- **Per-project (preferred)**: `git clone` this repo and launch `codex` from inside the clone. Codex auto-loads `AGENTS.md` from the project root per the [agents.md](https://agents.md/) cross-runtime spec.
-- **Globally** (one-time copy): `cp ~/.codex/plugins/cache/<marketplace>/tao-skill-bank/<version>/AGENTS.md ~/.codex/AGENTS.md`. The identity then loads in every Codex session, anywhere.
+**2. Load the agent identity (`AGENTS.md`).** The plugin install does **not** auto-load [`AGENTS.md`](AGENTS.md) — Codex's `AGENTS.md` discovery walks down from the project root, not into the plugin cache (see [openai/codex#16430](https://github.com/openai/codex/issues/16430) for why plugin-bundled `SessionStart` hooks don't fix this yet). Pick one:
+
+- **Per-project**: `git clone` this repo and launch `codex` from inside the clone. Codex auto-loads `AGENTS.md` from the project root per the [agents.md](https://agents.md/) cross-runtime spec.
+- **Globally** (one-time copy): `cp ~/.codex/plugins/cache/tao-local-plugins/tao-skill-bank/<version>/AGENTS.md ~/.codex/AGENTS.md`. The identity then loads in every Codex session, anywhere.
 
 Once Codex starts honoring plugin-bundled hooks, the identity will install automatically alongside the plugin — until then, this manual step is needed.
 
 ### Credentials
 
-On first session start, the plugin looks for `~/.config/tao/.env` and auto-loads it. To set up:
+The skill bank reads credentials from the **session environment** — export what you need in your shell **before launching**, and the session inherits them:
 
 ```bash
-mkdir -p ~/.config/tao
-cp "${CLAUDE_PLUGIN_ROOT}/.env.example" ~/.config/tao/.env  # template ships in the plugin
-# Edit ~/.config/tao/.env and fill in NGC_KEY, LEPTON_*, S3 keys, etc.
+export NGC_KEY=...            # nvcr.io image pulls
+export HF_TOKEN=...           # gated HuggingFace models
 ```
 
-The `.env.example` is also at the [repo root](.env.example) for direct reference. The agent never reads credential values — it only checks presence.
+The vars each skill looks for (export only the ones your workflow needs):
+
+| Var | Used for |
+|---|---|
+| `NGC_KEY` | `nvcr.io` image pulls — required by almost everything |
+| `HF_TOKEN` | gated HuggingFace models / `push_to_hub` |
+| `BREV_API_TOKEN` | `tao-run-on-brev` (optional — `brev login` also works) |
+| `ACCESS_KEY`, `SECRET_KEY`, `S3_BUCKET_NAME`, `S3_ENDPOINT_URL`, `CLOUD_REGION` | S3 / object-storage I/O via `script_runner` |
+| `WANDB_API_KEY`, `WANDB_PROJECT` | WandB experiment logging (AutoML / HF fine-tune) |
+
+The plugin does **not** create, load, or source any credentials file. On session start the hook reports which of these it detects in the environment (names only). The agent never reads credential values — it only checks presence.
+
+When a workflow needs Hugging Face access, get a token from [Hugging Face settings](https://huggingface.co/settings/tokens) and accept the model or dataset license before launch.
+
+If a readiness check reports a missing CLI, container image, backbone, or credential, the TAO skills can often install or stage the missing piece after you approve the action. Ask the agent to continue the original workflow after a blocker is resolved; it should rerun preflight and proceed from the same task.
+
+> **Persisting secrets is your own responsibility.** If you'd rather not re-export each session, persist the exports yourself (shell rc, a sourced file, or a secrets manager) — the skill bank will not manage a credentials file on your behalf.
 
 ### When does the SDK get installed?
 
-The TAO SDK is **opt-in** and installed lazily. Most skills (any model or data skill) run with just `docker run` and need no Python. Only `skills/platform/tao-run-on-lepton` (`tao-run-on-lepton`), `skills/platform/tao-run-platform` (`tao-run-platform`), the managed-platform skills (slurm/kubernetes/docker), and `skills/applications/tao-run-automl` (`tao-run-automl`) require the SDK; their Preflight blocks tell the agent to `pip install` the right extra the first time the skill is invoked. The SDK is on public PyPI; the exact pinned version lives in [`versions.yaml`](versions.yaml) and each Preflight resolves it via `scripts/resolve_versions_key.py`.
+The TAO SDK is **opt-in** and installed lazily. Most skills (any model or data skill) run with just `docker run` and need no Python. Only `skills/platform/tao-run-platform` (`tao-run-platform`), the managed-platform skills (slurm/kubernetes/docker), and `skills/applications/tao-run-automl` (`tao-run-automl`) require the SDK; their Preflight blocks tell the agent to `pip install` the right extra the first time the skill is invoked. The SDK is on public PyPI; the exact pinned version lives in [`versions.yaml`](versions.yaml) and each Preflight resolves it via `scripts/resolve_versions_key.py`.
 
 ### Updating
 
@@ -105,9 +144,14 @@ In a Claude Code session with the plugin installed, ask:
 
 > *"Run Visual ChangeNet inference on this sample image: /tmp/sample.png. Write results to /tmp/vcn-out/."*
 
-The agent will read `skills/models/tao-train-visual-changenet/SKILL.md` (skill name `tao-train-visual-changenet`, plus its `references/skill_info.yaml` if present), construct a `docker run --gpus all ...` invocation, and execute via Bash. **No Python needed.** No SDK install. Just docker + the plugin.
+The agent will read `skills/models/tao-train-visual-changenet/SKILL.md` (skill name `tao-train-visual-changenet`, plus its `references/skill_info.yaml` if present), construct a `docker run --gpus all ...` invocation, and execute via Bash. **No Python needed.** No SDK install. Just docker + the plugin. For classify mode, expect per-image PASS/NO_PASS-style predictions and result files under `/tmp/vcn-out/`. For segment mode, expect binary change-mask outputs under the requested results directory.
 
-For more complex workflows (iterative fine-tuning with synthetic data augmentation), see `skills/applications/tao-run-deft-aoi/SKILL.md` (`tao-run-deft-aoi`).
+For more complex workflows, see `skills/applications/tao-run-deft-aoi/SKILL.md`
+(`tao-run-deft-aoi`) for iterative fine-tuning with synthetic data augmentation
+and `skills/applications/tao-run-automl/SKILL.md` (`tao-run-automl`) for
+hyperparameter optimization. AutoML launch reviews should show the number of
+recommendations, metric, search space, expected runtime, and resolved train
+image before long-running jobs start.
 
 ## What's in the bank
 
@@ -115,7 +159,7 @@ For more complex workflows (iterative fine-tuning with synthetic data augmentati
 |---|---|---|
 | `skills/models/` | Network-centric skills: containers, commands, data formats, checkpoints | `tao-finetune-cosmos-reason`, `tao-train-visual-changenet`, `tao-finetune-clip`, `tao-train-dino`, `tao-train-segformer`, … |
 | `skills/data/` | Data preparation, analysis, and enhancement | `tao-mine-aoi-images`, `tao-analyze-gaps-visual-changenet`, `tao-route-visual-changenet-samples`, `tao-analyze-gaps-vlm-bcq`, `tao-convert-dataset-format`, `tao-validate-dataset-format`, `tao-generate-image-grounding`, `tao-generate-referring-expressions`, `tao-generate-video-reasoning-annotations` |
-| `skills/platform/` | Where and how jobs run | `tao-run-on-docker` (conventions), `tao-run-on-brev` (instance-based GPU), `tao-run-on-lepton` (DGX Cloud API), `tao-run-on-slurm` (remote SLURM cluster), `tao-run-on-kubernetes` (k8s), `tao-run-on-local-docker` (local Docker daemon), `tao-run-platform` (optional Python SDK) |
+| `skills/platform/` | Where and how jobs run | `tao-run-on-docker` (conventions), `tao-run-on-brev` (instance-based GPU), `tao-run-on-slurm` (remote SLURM cluster), `tao-run-on-kubernetes` (k8s), `tao-run-on-local-docker` (local Docker daemon), `tao-run-platform` (optional Python SDK) |
 | `skills/applications/` | End-to-end workflows composing the layers above | `tao-run-deft-aoi`, `tao-run-automl-deft-pipeline`, `tao-analyze-changenet-rca`, `tao-train-single-step`, `tao-run-automl`, `tao-finetune-huggingface-model`, `tao-port-huggingface-model`, `tao-run-inference-service` |
 
 Each skill is a directory with `SKILL.md` (agent-readable instructions). Optional `references/skill_info.yaml` provides structured metadata for SDK-orchestrated execution; optional `scripts/` bundles supporting code.
@@ -124,23 +168,22 @@ The `skills/core/` directory is not a second copy of the skill bank. It is the C
 
 ## Optional Python layer
 
-For users who want job handles, S3 I/O wrapping via `script_runner`, state persistence, multi-node distributed training, Lepton access, or failure analysis, the [TAO Execution SDK](https://pypi.org/project/nvidia-tao-sdk/) provides a single wheel with optional extras, published on public PyPI. The pinned version is centralized in [`versions.yaml`](versions.yaml) (`wheels.tao_sdk*`); resolve it rather than hardcoding a tag:
+For users who want job handles, S3 I/O wrapping via `script_runner`, state persistence, multi-node distributed training, or failure analysis, the [TAO Execution SDK](https://pypi.org/project/nvidia-tao-sdk/) provides a single wheel with optional extras, published on public PyPI. The pinned version is centralized in [`versions.yaml`](versions.yaml) (`wheels.tao_sdk*`); resolve it rather than hardcoding a tag:
 
 ```shell
 # Resolve the pinned spec from versions.yaml (single source of truth):
 SB="${TAO_SKILL_BANK_PATH:-~/tao-skills-external}"
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk)"             # core
-pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_lepton)"      # + Lepton (required — no docker-run equivalent)
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_brev)"        # + Brev (wraps brev CLI with Job handles)
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_slurm)"       # + SLURM
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_kubernetes)"  # + Kubernetes
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_docker)"      # + local Docker
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_all)"         # all platforms
 
-# Or pin directly, e.g.: pip install "nvidia-tao-sdk[lepton]==7.0.0"
+# Or pin directly, e.g.: pip install "nvidia-tao-sdk[brev]==7.0.0"
 ```
 
-You don't have to pre-install — the relevant skills (`tao-run-on-lepton`, `tao-run-platform`, `tao-run-automl`) run a Preflight that prompts the agent to install the right extra on first use. If you're running locally on your own GPU or on Brev via `brev exec`, you don't need the SDK at all.
+You don't have to pre-install — the relevant skills (`tao-run-platform`, `tao-run-automl`) run a Preflight that prompts the agent to install the right extra on first use. If you're running locally on your own GPU or on Brev via `brev exec`, you don't need the SDK at all.
 
 ## Contributing a new skill
 
@@ -164,12 +207,11 @@ tao-skills-external/
 │   └── plugin.json                   # plugin manifest (fallback when loaded directly)
 ├── hooks/
 │   ├── hooks.json                    # SessionStart hook registration
-│   └── session_start.sh              # emits agent guidance; sources ~/.config/tao/.env
+│   └── session_start.sh              # emits agent guidance; reports credential vars present in the env
 ├── .codex-plugin/
 │   └── plugin.json                   # Codex plugin manifest
 ├── .agents/
 │   └── plugins/marketplace.json      # Codex marketplace entry
-├── .env.example                      # credential template (copy to ~/.config/tao/.env)
 ├── versions.yaml                     # single source of truth: container images + SDK wheel versions
 ├── README.md
 ├── docs/
@@ -179,13 +221,14 @@ tao-skills-external/
 ├── scripts/
 │   ├── validate-skills.sh            # CI validator
 │   ├── verify-standalone.sh          # end-to-end smoke (docker-only path)
+│   ├── install-codex-agents.sh       # one-shot Codex install: marketplace + plugin + AGENTS.md
 │   └── migrate-to-version-keys.py    # one-shot: literal nvcr.io paths → versions.yaml keys
 └── skills/
-    ├── applications/                 # 12 skills
-    ├── data/                         # 9 skills
-    ├── models/                       # 53 skills
-    ├── platform/                     # 8 skills
-    └── core/                         # 2 skills — Codex helper/router skills only; no mirrored skill symlinks
+    ├── applications/                 # 12 end-to-end workflow skills
+    ├── data/                         # 10 data preparation/analysis skills
+    ├── models/                       # 53 network-centric skills
+    ├── platform/                     # 7 compute backend / runtime skills
+    └── core/                         # 2 Codex helper/router skills; no mirrored skill symlinks
 ```
 
 ## CI
@@ -202,7 +245,7 @@ PRs must pass all three before merge.
 
 - **Docker-native first.** Every model/data skill should be runnable with just `docker run` + the contents of `SKILL.md`. SDK invocation is an optional enhancement, documented in `skills/platform/tao-run-platform`.
 - **Generic docker conventions live once** in `skills/platform/tao-run-on-docker`. Other skills defer to it for `--gpus`, NGC auth, mount patterns, data-root relocation, etc.
-- **No SDK leaks in model/data/application skills.** `tao_sdk`-specific imports, `sdk.create_job` calls, and credential-file references belong only in `skills/platform/tao-run-platform` and (for platform-specific reasons) `skills/platform/tao-run-on-lepton`.
+- **No SDK leaks in model/data/application skills.** `tao_sdk`-specific imports, `sdk.create_job` calls, and credential-file references belong only in `skills/platform/tao-run-platform`.
 - **Minimum-viable skill is `SKILL.md` only.** Add `references/skill_info.yaml` only when SDK orchestration or multi-action structured metadata earn their keep.
 - **One canonical location per skill.** Model, data, platform, and application skills live only in their layer directories; `skills/core/` is for Codex helper/router skills, not mirrored copies.
 - **Prefer portability over cleverness.** A skill that works across three coding agents is more valuable than a skill that works perfectly in one.


### PR DESCRIPTION
## Summary
- Sync only README.md from GitLab origin/release/7.0.1 into public GitHub main
- Preserve the README links as-authored; no gitlab-to-github sed rewrite was applied
- Includes the Codex one-command installer guidance for scripts/install-codex-agents.sh

## Validation
- Confirmed README.md matches GitLab origin/release/7.0.1 exactly
- Confirmed only README.md changed