### PR TITLE
Sync non-skill files (docs, AGENTS.md, hooks, .gitignore) from release/7.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 
 .DS_Store
+
+validation-reports/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,11 @@ need no Python.
 ## Discovery flow
 
 0. **Preflight the chosen platform.** Open `skills/platform/<chosen>/SKILL.md` and run
-   its Preflight section. Bail if anything's missing — do not draft launch
-   commands against an unconfigured environment.
+   its Preflight section. If a missing prerequisite is a Python package that can
+   be installed with `python -m pip install ...`, install it in the active
+   Python environment, then rerun preflight. Bail on missing non-Python/system
+   prerequisites — do not draft launch commands against an unconfigured
+   environment.
 
 1. **Read the task skill.** `skills/models/<arch>/SKILL.md` (network specifics),
    `skills/data/<name>/SKILL.md` (transforms), or `skills/applications/<name>/SKILL.md`
@@ -47,7 +50,7 @@ need no Python.
 
 6. **Confirm with the user**, then dispatch via the chosen platform's pattern:
    - Local docker / Brev / local-docker: `docker run …` via Bash.
-   - Managed (Lepton, Kubernetes, SLURM, Brev with SDK tracking):
+   - Managed (Kubernetes, SLURM, Brev with SDK tracking):
      `<Platform>SDK.create_job(image, command, gpu_count, …)`. The agent
      calls `build_entrypoint(...)` first to bake the spec heredoc + invocation
      into `command`.
@@ -62,29 +65,40 @@ Reach for the SDK only when the user wants one of:
 - Job tracking (status persistence, logs, failure analysis)
 - S3 I/O wrapping (`inputs` / `outputs` automatic up/download)
 - Multi-node training
-- A managed platform: **Lepton, Kubernetes, SLURM, Brev**
+- A managed platform: **Kubernetes, SLURM, Brev**
 
 Each platform skill's Preflight tells you which SDK extra to install
-(`pip install 'nvidia-tao-sdk[<platform>]'`). The five platform SDKs are
+(`python -m pip install 'nvidia-tao-sdk[<platform>]'`). Install missing pip
+requirements automatically, then rerun preflight. The four platform SDKs are
 equal-class peers — **no default**. If the user hasn't chosen, ask.
 
 ## Never do
 
-- **Never write flat dotted spec keys.** Specs are **nested dicts**:
-  `{"train": {"num_epochs": 12}}`, not `{"train.num_epochs": 12}`. This is
-  the most common agent mistake against the SDK boundary.
+- **Never write flat dotted spec keys in the actual spec.** Specs passed to
+  `build_entrypoint`, SDK job creation, config files, or containers are
+  **nested dicts**: `{"train": {"num_epochs": 12}}`, not
+  `{"train.num_epochs": 12}`. AutoMLRunner's `spec_overrides` argument is the
+  one exception: it accepts dotted path keys as an override map and expands them
+  into the nested spec before launch. Do not pass that override map directly to
+  SDK/container boundaries.
 - **Never default to one platform** when several would fit. If the user hasn't
-  said Lepton vs. SLURM vs. Brev vs. Docker vs. Kubernetes, ask. Five SDKs are
-  equal-class peers; biasing toward one (especially Lepton) is wrong.
+  said SLURM vs. Brev vs. Docker vs. Kubernetes, ask. Four SDKs are
+  equal-class peers; biasing toward one is wrong.
 - **Never start a side-effecting action without user confirmation.** This
   means: `docker run`, `sdk.create_job`, `git push`, file mutations outside
-  the working directory.
-- **Never ask for API keys, tokens, or passwords via chat.** Credentials live
-  in `~/.config/tao/.env` and are loaded into the session env by the plugin's
-  hook.
+  the working directory. Missing Python-package prerequisites installed with
+  `python -m pip install ...` are an explicit exception for TAO workflows:
+  install them by default and report what was installed.
+- **Never ask for API keys, tokens, or passwords via chat.** Credentials come
+  from the **session environment** — the user exports them in their own shell
+  before launching. If a required var is missing, tell the user which one to
+  `export`; do not collect the value yourself. The skill bank does not read or
+  load any credentials file.
 - **Never read credential values.** To verify a var is set:
   `[ -n "$VAR_NAME" ] && echo SET || echo UNSET`. Never `cat`, `Read`,
-  `grep`, or `head` on `.env` or `~/.config/tao/.env`.
+  `grep`, or `head` a credentials file (e.g. any `.env` the user may have
+  created).
 - **Never assume the SDK is installed.** Model and data skills must be
-  runnable with just docker. Run the chosen platform's Preflight first; reach
-  for the SDK only when the user explicitly opts in.
+  runnable with just docker. Run the chosen platform's Preflight first; when
+  the SDK path is selected and its pip package/extra is missing, install it by
+  default and rerun preflight.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -1,5 +1,28 @@
 # Authoring a new skill
 
+## Contents
+
+- 0. Decide the layer
+- 1. Minimum viable skill
+- 2. Frontmatter
+  - Required fields
+  - Optional fields (validator warns when missing)
+  - Body must be agent-runnable
+- 3. Body structure (DAFT-style)
+- 4. When to add `references/`
+  - Version references
+  - Skills that require the SDK
+  - `references/skill_info.yaml` schema
+- 5. Optional: `example/` reference output
+- 6. Templates
+- 7. Add to `marketplace.json`
+- 8. Validate
+- 9. Test locally
+- Checklist
+- Common pitfalls
+- Agent identity (cross-cutting)
+
+
 The minimum viable skill is a single `SKILL.md`. Everything else — `references/skill_info.yaml`, `scripts/`, `example/`, templates, defaults — is optional and only added when it earns its keep.
 
 ## 0. Decide the layer
@@ -8,7 +31,7 @@ The minimum viable skill is a single `SKILL.md`. Everything else — `references
 |---|---|---|
 | `skills/models/` | A trainable network with `train` / `evaluate` / `inference` / `export` actions | `tao-finetune-cosmos-reason`, `tao-train-visual-changenet`, `tao-finetune-clip` |
 | `skills/data/` | A data transformation — preparation, analysis, embedding, filtering | `omniverse-sdg`, `mining`, `changenet-data-prepare` |
-| `skills/platform/` | A compute backend or runtime convention (where/how jobs run) | `tao-run-on-docker`, `tao-run-on-brev`, `tao-run-on-lepton`, `tao-run-platform` |
+| `skills/platform/` | A compute backend or runtime convention (where/how jobs run) | `tao-run-on-docker`, `tao-run-on-brev`, `tao-run-on-slurm`, `tao-run-platform` |
 | `skills/applications/` | A workflow composing multiple skills (orchestrator) | `tao-run-deft-aoi`, `tao-train-single-step` |
 
 If you're unsure: produces a trained model artifact → model. Transforms data → data. Infrastructure → platform. Orchestrates → application.
@@ -95,14 +118,13 @@ allowed-tools: Read Bash
 
 **`compatibility:`** — runtime requirements only. Tools, packages, env vars, services the skill needs.
 
-> **Important:** the skill bank is **agent-harness-agnostic**. Do NOT prefix `compatibility:` with "Designed for Claude Code" or any specific harness — the same skill must work in Claude Code, Codex, Gemini CLI, and any Agent Skills compatible agent. Describe runtime requirements only.
+> **Important:** the skill bank is **agent-harness-agnostic**. Do NOT prefix `compatibility:` with "Designed for <runtime>" or any specific harness — the same skill must work in any Agent Skills compatible agent. Describe runtime requirements only.
 
 | Skill type | Recommended `compatibility:` value |
 |---|---|
 | Containerized model/data | `Requires docker + nvidia-container-toolkit + NGC API key.` |
 | `skills/platform/tao-run-on-docker` | `Requires docker + nvidia-container-toolkit.` |
 | `skills/platform/tao-run-on-brev` | `Requires the brev CLI (https://github.com/brevdev/brev-cli) and an active brev login.` |
-| `skills/platform/tao-run-on-lepton` | `Requires the nvidia-tao-sdk Python package with the lepton extra (pip install 'nvidia-tao-sdk[lepton]') plus LEPTON_WORKSPACE_ID and LEPTON_AUTH_TOKEN.` |
 | `skills/platform/tao-run-platform` | `Requires Python 3.10+ and the nvidia-tao-sdk package (pip install nvidia-tao-sdk).` |
 | Local Python script (no container) | `Requires Python 3.8+ and Pillow.` (or whatever) |
 | Agent-prompt-driven | `Standalone — no external runtime requirements.` or omit the field. |
@@ -111,7 +133,7 @@ allowed-tools: Read Bash
 
 **`metadata.version`** — skill version (NOT tool/model version). Start at `"0.1"` for new skills; bump when the SKILL.md materially changes (new actions, schema changes, etc.).
 
-**`allowed-tools`** — pre-approves tools so Claude doesn't prompt the user per use. Whitespace-separated list. Common values: `Read Bash`, `Read Bash Write`. Use sparingly — only for tools the skill genuinely needs frequently.
+**`allowed-tools`** — declares frequently used tools for compatible runtimes. Whitespace-separated list. Common values: `Read Bash`, `Read Bash Write`. Use sparingly — only for tools the skill genuinely needs frequently.
 
 **`tags`** — list of short keywords for documentation, browsing, and our own catalog tooling. Examples:
 
@@ -123,7 +145,7 @@ tags:
   - classification
 ```
 
-Tags are NOT used by Claude Code for skill auto-invocation — that's driven by `description` (and trigger phrases within it). Tags exist for human browsing and tooling. Lives in `SKILL.md` frontmatter only — `references/skill_info.yaml` does NOT carry tags (single source of truth).
+Tags are NOT used for skill auto-invocation — that's driven by `description` (and trigger phrases within it). Tags exist for human browsing and tooling. Lives in `SKILL.md` frontmatter only — `references/skill_info.yaml` does NOT carry tags (single source of truth).
 
 ### Body must be agent-runnable
 
@@ -132,7 +154,7 @@ Body must contain at least one of:
 - A `docker run` code block
 - A `references/skill_info.yaml` file on disk
 - A `scripts/` or `hooks/` directory on disk
-- An SDK invocation example (`sdk.create_job`, `LeptonSDK`, etc.) — for skills like `skills/platform/tao-run-platform`
+- An SDK invocation example (`sdk.create_job`, `BrevSDK`, etc.) — for skills like `skills/platform/tao-run-platform`
 
 The validator enforces this.
 
@@ -175,6 +197,7 @@ Add a `references/` directory when one or more applies:
 | Add this file | When |
 |---|---|
 | `references/skill_info.yaml` | Multi-action skill (train/evaluate/inference) AND/OR you want SDK-orchestrated execution. The TAO SDK reads this for structured action metadata. |
+| `deploy/skill_info.yaml` | Deploy-only metadata paired with a `deploy/SKILL.md`. It follows the same schema and validator rules as `references/skill_info.yaml`. |
 | `references/spec_template_<action>.yaml` | Action takes a config file (YAML/TOML) and you want users to start from a known-good default. |
 | `references/scripts/<file>.py` | The skill ships a reference implementation of a script that runs inside the container. |
 
@@ -215,15 +238,15 @@ To bump an RC, change one line — that's the entire diff.
 
 ### Skills that require the SDK
 
-Most skills run with just docker (no Python SDK). A few skills are SDK-orchestrated by design (e.g., `skills/platform/tao-run-platform` (`tao-run-platform`), `skills/platform/tao-run-on-lepton` (`tao-run-on-lepton`), `skills/applications/tao-run-automl` (`tao-run-automl`)). These need a **preflight** block at the top of `SKILL.md`:
+Most skills run with just docker (no Python SDK). A few skills are SDK-orchestrated by design (e.g., `skills/platform/tao-run-platform` (`tao-run-platform`), `skills/applications/tao-run-automl` (`tao-run-automl`)). These need a **preflight** block at the top of `SKILL.md`:
 
 ````markdown
 ## Preflight
 
-This skill needs the TAO SDK. `nvidia-tao-sdk` is on public PyPI and pinned in `versions.yaml`; Preflight blocks resolve the pin via `scripts/resolve_versions_key.py` (swap `wheels.tao_sdk_lepton` for the extra you need — `_brev`, `_docker`, `_slurm`, `_kubernetes`, `_all`):
+This skill needs the TAO SDK. `nvidia-tao-sdk` is on public PyPI and pinned in `versions.yaml`; Preflight blocks resolve the pin via `scripts/resolve_versions_key.py` (swap `wheels.tao_sdk_brev` for the extra you need — `_docker`, `_slurm`, `_kubernetes`, `_all`):
 
 ```bash
-PIN=$("${TAO_SKILL_BANK_PATH:?}/scripts/resolve_versions_key.py" wheels.tao_sdk_lepton)
+PIN=$("${TAO_SKILL_BANK_PATH:?}/scripts/resolve_versions_key.py" wheels.tao_sdk_brev)
 python -c "import tao_sdk" 2>/dev/null || {
   echo "MISSING: nvidia-tao-sdk not installed. Run:"
   echo "  pip install \"$PIN\""
@@ -249,10 +272,18 @@ actions:
   train:
     command: visual_changenet train -e {config_path}
     config_format: yaml
+    mode: config
     inputs:
       dataset.train_csv: { type: file }
     outputs:
       results_dir: { type: folder }
+    upload_excludes:
+      - inputs/
+
+# Action mode controls how launch tooling serializes the spec:
+# - config: write a YAML/TOML/JSON spec file and substitute {config_path}
+# - args: build command arguments from actions.<action>.args
+# - passthrough: run the command as declared, without generated config or args
 
 # Models only — parallelism wiring for SDK orchestration
 gpu_spec_key: train.num_gpus
@@ -263,7 +294,7 @@ stages:
   - { skill: omniverse-sdg, action: generate, condition: always }
 
 # Platform skills
-sdk_module: tao_sdk.platforms.lepton.sdk
+sdk_module: tao_sdk.platforms.brev.sdk
 features: [tracking, multi-node, lustre]
 
 tags: [classification, my-domain]
@@ -331,6 +362,9 @@ Errors (fail CI):
 - `SKILL.md` body must have runnable info (Quick Start, docker run, scripts/, hooks/, or `references/skill_info.yaml`).
 - No `tao_sdk` symbol leaks into model/data/application skills (skills/platform/* exempt; tao-run-automl exempted as SDK-native workflow).
 - Hook paths in frontmatter must resolve.
+- Any `skill_info.yaml` or `model_info.yaml` parses, including `deploy/skill_info.yaml`.
+- Container image keys resolve through `versions.yaml` (top-level and action-level).
+- Model/data action contracts declare `command`, `mode`, `inputs`, `outputs`, and `upload_excludes`.
 
 Warnings (printed but don't fail CI):
 
@@ -342,9 +376,8 @@ CI runs the same script — fix errors before opening a PR; address warnings opp
 
 ## 9. Test locally
 
-```bash
-claude --plugin-dir /path/to/tao-skills-external
-```
+Use the applicable local plugin/runtime command for the target environment and
+point it at `/path/to/tao-skills-external`.
 
 Start a session, ask the agent to exercise the skill. Verify the agent reads it, constructs a valid invocation, and produces the expected output.
 
@@ -355,18 +388,18 @@ Start a session, ask the agent to exercise the skill. Verify the agent reads it,
 - [ ] Optional: `compatibility`, `metadata.author`, `metadata.version`, `allowed-tools` populated.
 - [ ] Body has Quick Start (or scripts/, hooks/, references/skill_info.yaml) — agent-runnable.
 - [ ] If the skill is non-trivial: External Dependencies, CLI Reference, Output Structure, Known Pitfalls sections present.
-- [ ] If using `references/skill_info.yaml`: `container_image` set, `actions.<name>.command` set per action.
+- [ ] If using `skill_info.yaml`: `container_image` set, each model/data action has `command`, `mode`, `inputs`, `outputs`, and `upload_excludes`.
 - [ ] No SDK symbols (`tao_sdk`, `sdk.create_job`, etc.) in model/data/application skills (allowed in `skills/platform/*`).
-- [ ] Added to `.claude-plugin/marketplace.json` under the right plugin(s).
+- [ ] Added to the marketplace manifest under the right plugin(s), when the packaging surface requires it.
 - [ ] No mirrored copy or symlink added under `skills/core/`.
 - [ ] `scripts/validate-skills.sh` passes (no errors; warnings are informational).
-- [ ] Tested locally via `claude --plugin-dir .`.
+- [ ] Tested locally with the applicable plugin/runtime harness.
 
 ## Common pitfalls
 
-**Naming the skill file wrong.** It must be `SKILL.md` (uppercase, exact). Files like `dino.md` or `<skill_name>.md` are NOT picked up by Claude Code's plugin system — they're treated as supporting docs.
+**Naming the skill file wrong.** It must be `SKILL.md` (uppercase, exact). Files like `dino.md` or `<skill_name>.md` are NOT discovered as skills by plugin runtimes — they're treated as supporting docs.
 
-**Mentioning the agent harness in `compatibility`.** The skill bank is harness-agnostic. Don't write "Designed for Claude Code." Restrict the `compatibility` field to runtime requirements.
+**Mentioning the agent harness in `compatibility`.** The skill bank is harness-agnostic. Don't write "Designed for <runtime>." Restrict the `compatibility` field to runtime requirements.
 
 **Abstract description.** "Visual Changenet model" is bad. "Fine-tune Visual ChangeNet for PCB defect detection. Use when the user asks to 'train ChangeNet', 'PCB defect detection', or mentions 'siamese classification'." is good.
 
@@ -378,11 +411,11 @@ Start a session, ask the agent to exercise the skill. Verify the agent reads it,
 
 **Assuming the SDK is available.** Write the skill to be runnable with just docker. SDK usage should be in an "Optional: via TAO SDK" section, not the primary path.
 
-**Stale `references/skill_info.yaml`.** When you change the docker command in `SKILL.md`, update the YAML too. The SDK reads the YAML; if they drift, agent and SDK diverge.
+**Stale `skill_info.yaml`.** When you change the docker command in `SKILL.md`, update the YAML too, including deploy metadata under `deploy/skill_info.yaml`. The SDK reads the YAML; if they drift, agent and SDK diverge.
 
 ## Agent identity (cross-cutting)
 
-The agent's identity — who it is, the discovery flow, what it must never do — lives in **`AGENTS.md`** at the repo root. This is the cross-runtime instruction-loading file per the [agents.md](https://agents.md/) spec. Codex auto-loads `AGENTS.md` from the project root (and from `~/.codex/AGENTS.md`). Claude Code reads the same file via the plugin's `hooks/session_start.sh` (which `cat`s `${CLAUDE_PLUGIN_ROOT}/AGENTS.md`). One file drives both runtimes.
+The agent's identity — who it is, the discovery flow, what it must never do — lives in **`AGENTS.md`** at the repo root. This is the cross-runtime instruction-loading file per the [agents.md](https://agents.md/) spec. Compatible runtimes should load the same file from the project root or plugin hook so one file drives all runtimes.
 
 **Edit `AGENTS.md`, not the hooks or plugin manifests.** When you add a new runtime (e.g., once Codex's plugin-bundled `SessionStart` hook is wired up — see [openai/codex#16430](https://github.com/openai/codex/issues/16430)), make it `cat AGENTS.md` from `${<RUNTIME>_PLUGIN_ROOT}/AGENTS.md`. Do not duplicate the prompt inline in a hook or in a plugin manifest's `description` / `longDescription` / `defaultPrompt` field — duplicating means future drift across runtimes.
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,5 +1,16 @@
 # Maintenance — bumping container images
 
+## Contents
+
+- Bumping a container image
+  - Verify the bump
+  - Commit + PR
+- Bumping an SDK/AutoML wheel
+- Adding a new image
+- When to use absolute paths instead of keys
+- Related: Python wheel install matrix
+
+
 All TAO container image tags **and** Python wheel pins live in **one file**: [`versions.yaml`](../versions.yaml) at the repo root. RC bumps and upgrades are a one-line edit there for both.
 
 Container images live under `images:`, Python wheels under `wheels:`. Skills resolve both by dotted key via `scripts/resolve_versions_key.py` — there are no hardcoded image tags or `pip install` URLs in skill bodies. See "Bumping an SDK/AutoML wheel" below.
@@ -47,8 +58,8 @@ CI runs `validate-skills.sh` automatically. Merge once green.
 ```diff
 # versions.yaml
 wheels:
--   tao_sdk_lepton:     nvidia-tao-sdk[lepton]==7.0.0
-+   tao_sdk_lepton:     nvidia-tao-sdk[lepton]==7.1.0rc1
+-   tao_sdk_brev:     nvidia-tao-sdk[brev]==7.0.0
++   tao_sdk_brev:     nvidia-tao-sdk[brev]==7.1.0rc1
 ```
 
 Every skill Preflight resolves its wheel key via `scripts/resolve_versions_key.py wheels.<key>`, so the new pin propagates automatically — no per-skill grep, no hardcoded URLs.
@@ -101,7 +112,6 @@ Users install the SDK by resolving the pin from `versions.yaml` (wheels are on p
 ```bash
 SB="${TAO_SKILL_BANK_PATH:-~/tao-skills-external}"
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk)"             # core only
-pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_lepton)"      # + Lepton handler deps
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_brev)"        # + Brev handler
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_slurm)"       # + SLURM handler
 pip install "$($SB/scripts/resolve_versions_key.py wheels.tao_sdk_kubernetes)"  # + Kubernetes handler

--- a/hooks/session_start.sh
+++ b/hooks/session_start.sh
@@ -9,17 +9,20 @@
 #
 # Responsibilities:
 #   1. Emit TAO orchestration guidance (the agent's identity + discovery flow).
-#   2. Persist user credentials from ~/.config/tao/.env into the session via
-#      $CLAUDE_ENV_FILE. The agent never reads values; only checks presence.
+#   2. Report which credential env vars are present in the session (names only).
+#      This hook does NOT read or load any credentials file — users export
+#      credentials in their own shell; the session inherits that environment.
 #   3. Surface clear setup hints if docker is missing.
 #
 # This hook does NOT install Python packages. The TAO SDK is opt-in and
-# installed lazily by the skills that need it (skills/platform/tao-run-on-lepton, skills/platform/tao-run-platform,
+# installed lazily by the skills that need it (skills/platform/tao-run-platform,
 # skills/applications/tao-run-automl) via their Preflight blocks.
 
 set -u
 
-# Idempotency guard: emit the guidance only on the first invocation per session.
+# Idempotency guard: both `tao-skills` and `deft-aoi-loop-plugin` share the
+# same source dir, so hook auto-discovery fires this script once per enabled
+# plugin. Emit the guidance only on the first invocation per session.
 if [[ -n "${TAO_SESSION_INIT_DONE:-}" ]]; then
   exit 0
 fi
@@ -47,34 +50,38 @@ if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -n "${CLAUDE_ENV_FILE:-}" ]]; then
 fi
 
 # ─── 2. Credentials ───────────────────────────────────────────────────────
-TAO_ENV_FILE="${HOME}/.config/tao/.env"
-if [[ -f "$TAO_ENV_FILE" ]]; then
-  # Persist to the session env file so subsequent Bash tool calls inherit them.
-  if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
-    cat "$TAO_ENV_FILE" >> "$CLAUDE_ENV_FILE"
-  fi
-  echo "## Credentials"
-  echo
-  echo "Loaded from \`~/.config/tao/.env\`. The following vars are now in the session:"
-  # List only NAMES — never values.
-  awk -F= '/^[[:space:]]*(export[[:space:]]+)?[A-Z_][A-Z0-9_]*=/ {
-    sub(/^[[:space:]]*export[[:space:]]+/, "")
-    split($0, a, "=")
-    print "- " a[1]
-  }' "$TAO_ENV_FILE" | sort -u
-  echo
+# This hook does NOT read or load any credentials file. Export credentials in
+# your own shell (or shell rc / secrets manager) before launching; the session
+# inherits that environment. Whether and how to persist secrets to disk is the
+# user's own responsibility — the skill bank neither writes nor reads a
+# credentials file. The agent only checks presence (names), never values.
+echo "## Credentials"
+echo
+# Known credential vars across the platform/model skills. Names only.
+_tao_cred_vars="NGC_KEY BREV_API_TOKEN \
+ACCESS_KEY SECRET_KEY S3_BUCKET_NAME S3_ENDPOINT_URL HF_TOKEN WANDB_API_KEY"
+_tao_present=""
+for _v in $_tao_cred_vars; do
+  [[ -n "${!_v:-}" ]] && _tao_present="${_tao_present} ${_v}"
+done
+if [[ -n "${_tao_present// /}" ]]; then
+  echo "Detected in this session's environment (names only):"
+  for _v in $_tao_present; do echo "- $_v"; done
 else
-  echo "## Credentials"
-  echo
-  echo "No \`~/.config/tao/.env\` found. To set up:"
-  echo "\`\`\`bash"
-  echo "mkdir -p ~/.config/tao"
-  echo "cp \"\${CLAUDE_PLUGIN_ROOT}/.env.example\" ~/.config/tao/.env"
-  echo "# Edit ~/.config/tao/.env and fill in values."
-  echo "\`\`\`"
-  echo "Future sessions will auto-load it."
-  echo
+  echo "No TAO credential vars detected in this session's environment."
 fi
+echo
+echo "Credentials are read from the environment — export what you need in your"
+echo "shell **before launching**, e.g.:"
+echo "\`\`\`bash"
+echo "export NGC_KEY=...            # nvcr.io image pulls"
+echo "export HF_TOKEN=...           # gated HuggingFace models"
+echo "# platform-specific: BREV_API_TOKEN, ACCESS_KEY/SECRET_KEY/S3_*"
+echo "\`\`\`"
+echo "See the Credentials section of the skill bank README for the full var list."
+echo "The skill bank does not create or load a credentials file; persisting"
+echo "secrets to disk is your own responsibility."
+echo
 
 # ─── 3. Docker preflight ──────────────────────────────────────────────────
 if ! command -v docker >/dev/null 2>&1; then


### PR DESCRIPTION
The public bank only had its `skills/` folder synced, so these non-skill files drifted behind the GitLab `tao-skills-external` source. This updates them from release/7.0.1:

- `docs/authoring.md`, `docs/maintenance.md`
- `AGENTS.md`
- `hooks/session_start.sh`
- `.gitignore`

Not touched here (handled separately): `skills/`, `marketplace.json`, `versions.yaml` (the public bank's release-patched versions.yaml is correct). No internal GitLab URLs introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)