### PR TITLE
ci: add tao-pr-bot PR reminder (thin caller → org reusable)

### DIFF
--- a/.github/workflows/pr-reminder.yml
+++ b/.github/workflows/pr-reminder.yml
@@ -1,0 +1,19 @@
+name: PR Reminder
+
+# Thin caller — all logic lives in the org-wide reusable workflow.
+# To roll this out to another NVIDIA-TAO repo, copy this file verbatim.
+# Requires org-level secrets TAO_PR_BOT_APP_ID / TAO_PR_BOT_PRIVATE_KEY
+# (inherited below).
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, edited]
+
+concurrency:
+  group: pr-reminder-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  remind:
+    uses: NVIDIA-TAO/.github/.github/workflows/pr-reminder.yml@main
+    secrets: inherit


### PR DESCRIPTION
Thin caller for the org-wide PR reminder. All logic lives in the reusable workflow **NVIDIA-TAO/.github#1** (`pr-reminder.yml`); this repo carries only the ~15-line `pull_request_target` caller (`uses: … secrets: inherit`).

**Merge order:** land NVIDIA-TAO/.github#1 first, then this. Reminder goes live on PRs opened *after* this merges to main (`pull_request_target` runs the default-branch workflow).

**Prereq:** org-level secrets `TAO_PR_BOT_APP_ID` / `TAO_PR_BOT_PRIVATE_KEY` (so `secrets: inherit` resolves org-wide). Currently set at *repo* level on tao-skill-bank; promote to org for fleet rollout.

Behavior: internal PR→main = `/build` reminder; external PR→main = maintainer-vetting note; PR→release/* = retarget-to-main + backport-label nudge. Comment-only, posts as `tao-pr-bot[bot]`, never runs PR code.