### PR TITLE
[TAO-0000][CI] Run Visual ChangeNet skill-eval smoke test

### DIFF
--- a/skills/models/tao-train-visual-changenet/.ci-eval-smoke
+++ b/skills/models/tao-train-visual-changenet/.ci-eval-smoke
@@ -1,0 +1,2 @@
+skill-eval CI smoke trigger for tao-train-visual-changenet
+triggered: 2026-08-03T21:42:53Z


### PR DESCRIPTION
Smoke test for the skill-eval Jenkins CI. Touches `skills/models/tao-train-visual-changenet/` (a `.ci-eval-smoke` marker) so the pipeline's `detect` phase selects **only** that skill and the eval fan-out runs `tao-train-visual-changenet × [claude, codex]` on the Colossus agents (real train→evaluate→inference, data from `s3://computex/skill-eval-ci/vcn/`).

Trigger with `/build`. **Do not merge.**