### PR TITLE
ci: deploy trunk-based-dev bots (PR reminder + cherry-pick)

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,15 @@
+name: Cherry-pick to release
+
+# Thin caller for the org-wide cherry-pick bot (logic in NVIDIA-TAO/.github).
+# Requires org-level secrets TAO_CHERRY_PICK_BOT_APP_ID / TAO_CHERRY_PICK_BOT_PRIVATE_KEY.
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cherry-pick:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    uses: NVIDIA-TAO/.github/.github/workflows/cherry-pick.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-reminder.yml
+++ b/.github/workflows/pr-reminder.yml
@@ -1,0 +1,16 @@
+name: PR Reminder
+
+# Thin caller for the org-wide reminder (logic in NVIDIA-TAO/.github).
+# Requires org-level secrets TAO_PR_BOT_APP_ID / TAO_PR_BOT_PRIVATE_KEY.
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, edited]
+
+concurrency:
+  group: pr-reminder-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  remind:
+    uses: NVIDIA-TAO/.github/.github/workflows/pr-reminder.yml@main
+    secrets: inherit


### PR DESCRIPTION
Deploys the two trunk-based-dev bots as thin callers of the org-wide reusables in NVIDIA-TAO/.github (already validated on tao-reference):
- **PR Reminder** (tao-pr-bot): /build reminder + backport-label tip for internal PRs, maintainer-vetting note for external PRs, retarget nudge for release/* PRs.
- **Cherry-pick to release** (tao-cherry-pick-bot): on merge to main, backports the commit to each release/X.Y.Z-labeled branch (clean -> push, conflict -> draft PR tagging the author).

Secrets inherited at org level; app installs + ruleset bypasses already org-wide.