### PR TITLE
docs: expand CONTRIBUTING (workflow, /build, backports, license, DCO)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,41 @@
-#### Signing Your Work
+# Contributing to TAO Skill Bank
+
+Thanks for contributing! Two requirements are enforced by CI on every pull request and must pass before it can merge:
+
+1. **SPDX license header** on source files — checked by the `license header` hook in the **Static Tests** workflow.
+2. **DCO sign-off** on every commit — checked by the **DCO** workflow.
+
+Both run automatically on your PR. See [Running the checks locally](#running-the-checks-locally) to catch failures before you push.
+
+## License headers
+
+Every source file must carry an **SPDX license header** near the top. Add these two lines, **below** any shebang (`#!`) line, replacing `<year>` with the current year:
+
+```
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+```
+
+Use the comment style for the file's language. The check passes as long as **both** a copyright line (`SPDX-FileCopyrightText:` or `Copyright`) **and** an `SPDX-License-Identifier:` line appear within the **first 10 lines** of the file.
+
+**Python / shell / YAML** (an optional shebang may sit above the header):
+
+```python
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+```
+
+**C / C++ / JavaScript / Go** (`//` comments):
+
+```c
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+```
+
+Files that legitimately cannot carry a header (e.g. generated files or data) may be listed, one repo-relative path per line, in `.github/hooks/license_header_exclude.txt`.
+
+## Signing your work (DCO)
 
 * We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
 
@@ -11,6 +48,12 @@
   This will append the following to your commit message:
   ```
   Signed-off-by: Your Name <your@email.com>
+  ```
+
+* Already committed without a sign-off? Add one with:
+  ```bash
+  git commit --amend -s --no-edit      # fixes the most recent commit
+  git rebase --signoff origin/main     # signs off a range of commits
   ```
 
 * Full text of the DCO (https://developercertificate.org/):
@@ -51,3 +94,19 @@
         maintained indefinitely and may be redistributed consistent with
         this project or the open source license(s) involved.
   ```
+
+## Running the checks locally
+
+Both checks also run in CI, but you can catch failures before pushing:
+
+```bash
+pip install pre-commit
+
+# check only the files your branch changed vs main:
+pre-commit run --from-ref origin/main --to-ref HEAD
+
+# or check everything:
+pre-commit run --all-files
+```
+
+The `license header` and `dco-signoff` hooks (plus the lint/docstring checks) are defined in `.pre-commit-config.yaml`. Run `pre-commit install` once to have them run automatically on every `git commit`.


### PR DESCRIPTION
Rewrites CONTRIBUTING.md into a full contributor guide. **Draft for review — do not merge yet.**

**How we work**
- **Trunk-based development and backports** — open PRs against `main`; add a `release/X.Y.Z` label to backport; how `tao-cherry-pick-bot` handles clean vs conflict (draft PR, assigns + @-mentions author); the retarget nudge + `release-only` exception.
- **Running CI (`/build`)** — internal devs comment `/build` (re-run per push, head-pinned); external contributors wait for a maintainer to trigger CI after review.

**Requirements (CI-enforced)**
- **License headers** — SPDX format, per-language comment styles, first-10-lines rule, exclusion file.
- **Signing your work (DCO)** — sign-off + `--amend -s` / `rebase --signoff` fix-ups.
- **Running the checks locally** — pre-commit.

Self-check: this PR's own commits are DCO signed-off and pass Static Tests.