### PR TITLE
test(ci): multi-eval-smoke 3-case reporting verification (DO NOT MERGE)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,6 +61,7 @@
         "./skills/models/tao-finetune-cosmos-embed",
         "./skills/models/tao-finetune-nv-tesseract-ad-diffusion",
         "./skills/models/tao-finetune-nv-tesseract-forecasting",
+        "./skills/platform/multi-eval-smoke",
         "./skills/platform/tao-run-on-brev",
         "./skills/platform/tao-run-on-docker",
         "./skills/platform/tao-run-on-kubernetes",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In a Claude Code session, add the marketplace and install the plugin:
 /plugin install tao-skills@tao-skill-bank
 ```
 
-That's it — no `git clone`, no `pip install`. The TAO Skill Bank plugin bundles all 59 skills (every model, data, platform, and application). The plugin's [`SessionStart`](hooks/session_start.sh) hook loads the [`AGENTS.md`](AGENTS.md) identity at the start of every session.
+That's it — no `git clone`, no `pip install`. The TAO Skill Bank plugin bundles all 60 skills (every model, data, platform, and application). The plugin's [`SessionStart`](hooks/session_start.sh) hook loads the [`AGENTS.md`](AGENTS.md) identity at the start of every session.
 
 ### Codex
 

--- a/skills/platform/multi-eval-smoke/SKILL.md
+++ b/skills/platform/multi-eval-smoke/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: multi-eval-smoke
+description: CI smoke skill that exercises skill-eval's multi-case reporting path. Each eval case writes and reads back a small text file, so CI can confirm every case is reported separately. Use only for skill-eval CI validation.
+license: Apache-2.0
+compatibility: No external dependencies; runs anywhere bash is available.
+metadata:
+  version: "0.1.0"
+  author: NVIDIA Corporation
+allowed-tools: Read Bash Write
+tags:
+- ci
+- smoke
+- testing
+---
+
+# multi-eval-smoke
+
+A trivial skill used only to validate skill-eval's **multi-case** CI reporting. It has no
+model, no container, and no external dependency — each eval case just writes a small text
+file and reads it back.
+
+## Quick Start
+
+Create a text file and confirm its contents:
+
+```bash
+echo 'case ok' > ./out.txt
+cat ./out.txt
+```
+
+That is the entire skill. The real work lives in `eval.config`, which defines three
+independent cases so CI can confirm all three are evaluated and reported as separate rows.

--- a/skills/platform/multi-eval-smoke/eval.config
+++ b/skills/platform/multi-eval-smoke/eval.config
@@ -1,0 +1,20 @@
+{
+  "evals": [
+    {
+      "id": "smoke-case-one",
+      "prompt": "Create a file at {artifacts_dir}/case_one.txt containing exactly the line 'case-one ok'. Then read the file back and confirm it contains that text.",
+      "expected_outcome": "A file case_one.txt exists in the artifacts directory and contains 'case-one ok'."
+    },
+    {
+      "id": "smoke-case-two",
+      "prompt": "Create a file at {artifacts_dir}/case_two.txt containing exactly the line 'case-two ok'. Then read the file back and confirm it contains that text.",
+      "expected_outcome": "A file case_two.txt exists in the artifacts directory and contains 'case-two ok'."
+    },
+    {
+      "id": "smoke-case-three",
+      "prompt": "Create a file at {artifacts_dir}/case_three.txt containing exactly the line 'case-three ok'. Then read the file back and confirm it contains that text.",
+      "expected_outcome": "A file case_three.txt exists in the artifacts directory and contains 'case-three ok'."
+    }
+  ],
+  "credentials": []
+}

--- a/skills/platform/multi-eval-smoke/evals/evals.json
+++ b/skills/platform/multi-eval-smoke/evals/evals.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "multi-eval-smoke-basic",
+    "question": "A user request: \"Run the multi-eval smoke skill.\" Identify which TAO skill applies and, reading only that skill's documentation, outline what it does. Do NOT run any commands, scripts, web searches, or other tools — describe the plan only.",
+    "expected_skill": "multi-eval-smoke",
+    "expected_script": null,
+    "ground_truth": "Identify multi-eval-smoke as the applicable skill and summarize that it is a CI-only smoke skill which writes and reads back small text files across three independent eval cases, with no model, container, or external dependency.",
+    "expected_behavior": [
+      "Identifies multi-eval-smoke as the relevant skill",
+      "Explains it is a CI smoke skill that writes and reads back small text files",
+      "Does not run commands, scripts, or web searches"
+    ]
+  }
+]


### PR DESCRIPTION
Verifies the skill-eval **multi-case reporting** fix: `skills/platform/multi-eval-smoke` defines a 3-case `eval.config`, so the TAO Skill Execution Eval Summary should post **one row + one report per case** (new `Eval Case` column). Dummy skill, no model/container. **Do not merge.**