### PR TITLE
feat: DEFT-AOI make HTML report rendering deterministic

### DIFF
--- a/scripts/tests/test_deft_versions_contract.py
+++ b/scripts/tests/test_deft_versions_contract.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guard DEFT image references against release-tag drift."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFT_SKILLS = {
+    REPO_ROOT / "skills/applications/tao-run-deft-aoi": (
+        "images.tao_toolkit.pyt",
+        "images.tao_toolkit.data_services",
+        "images.metropolis_sdg.paidf_anomalygen",
+    ),
+    REPO_ROOT / "skills/applications/tao-run-deft-aoi-cosmos3": (
+        "images.tao_toolkit.cosmos_rl",
+        "images.tao_toolkit.data_services",
+        "images.metropolis_sdg.paidf_anomalygen",
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("skill_root", "image_keys"),
+    DEFT_SKILLS.items(),
+    ids=("changenet", "cosmos3"),
+)
+def test_preflight_resolves_images_from_versions_yaml(
+    skill_root: Path, image_keys: tuple[str, ...]
+) -> None:
+    text = (skill_root / "references/preflight.md").read_text(encoding="utf-8")
+
+    assert text.count("resolve_versions_key.py") >= len(image_keys)
+    for key in image_keys:
+        assert key in text
+    for variable in ("TAO_PYT_IMAGE", "TAO_DS_IMAGE", "AG_IMAGE"):
+        assert not re.search(rf"(?:export\s+)?{variable}=nvcr\.io/", text)
+
+
+def test_active_deft_references_do_not_pin_anomalygen_release() -> None:
+    pinned = re.compile(r"nvcr\.io/nvidia/paidf-anomalygen:[^\s`'\"]+")
+    offenders: list[str] = []
+    for skill_root in DEFT_SKILLS:
+        for path in sorted((skill_root / "references").glob("*.md")):
+            if pinned.search(path.read_text(encoding="utf-8")):
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert not offenders, (
+        "DEFT references must resolve images.metropolis_sdg.paidf_anomalygen "
+        "from versions.yaml instead of pinning a tag: " + ", ".join(offenders)
+    )

--- a/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
@@ -30,10 +30,14 @@ tags:
 
 ## Installation
 
-Install this application together with the companion TAO skills listed in
-`eval.config` so they resolve as `~/.claude/{models,data,platform,core}/...`.
-Provision a host Python with `pyarrow` and `yaml`; run bundled validation with
-`python -m unittest tests.test_cosmos3_bare` (pytest is optional, not required).
+Install this application as part of the full TAO skill-bank root, not as only
+the companion skill folders: `TAO_SKILL_BANK_PATH` must point at a directory
+containing `versions.yaml`, `scripts/resolve_versions_key.py`, and the
+`skills/{applications,models,data,platform,core}/...` tree listed in
+`eval.config`. Run bundled validation with the skill Python so dependencies
+match runtime: `PYTHON=$(scripts/deft_python.sh); "$PYTHON" -m unittest
+tests.test_cosmos3_bare`. If that Python lacks `pyarrow` or `yaml`, install the
+small helper dependency there and rerun validation.
 
 ## Execution Contract
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
@@ -51,7 +51,9 @@ Treat a run as a disk-backed state machine.
    launch review plus this skill's Pre-Flight Summary. Wait for one explicit
    approval.
 5. After approval, initialize `${RESULTS_DIR}/deft_state.json` exactly once
-   with `scripts/init_deft_state.py`. Never reinitialize a resumed run or edit
+   with `scripts/init_deft_state.py`. Pass the exact GPU model reported by the
+   selected platform's Preflight through `--gpu-model` (include accelerator
+   memory when available). Never reinitialize a resumed run or edit
    `deft_state.json` / `loop_log.jsonl` by hand.
 6. Before every stage, after context compaction, and before a completion claim,
    run:
@@ -71,7 +73,10 @@ Treat a run as a disk-backed state machine.
    `PENDING RUNNING COMPLETE ERROR CANCELED UNKNOWN`.
 8. Commit every completed or failed DEFT stage with
    `scripts/commit_stage.py`. It updates state and log atomically, then runs the
-   audit and rolls back on inconsistency.
+   audit and rolls back on inconsistency. Every commit requires a positive,
+   measured `--duration-sec`: use backend elapsed wall time for submitted jobs
+   and a host wall-clock timer for inline stages. Missing or zero durations are
+   rejected.
 9. Claim completion only after this exits zero:
 
    ```bash

--- a/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
@@ -292,10 +292,15 @@ For each `iterN` when the frozen Benchmark gate is unmet:
 9. `evaluate_proxy` — only when the loop continues.
 10. `proxy_rcca`
 
-After every iteration, render `DEFT_Loop_Report.html` with the reporter agent.
-Stop when the Benchmark contract passes, `max_iterations` is reached, or a
-hard stop occurs. Commit `loop_stop`, run the completion audit, then render one
-final report.
+`init_deft_state.py` writes the first `DEFT_Loop_Report.html`; every successful
+`commit_stage.py` call then refreshes it through the deterministic
+`scripts/render_report.py` post-commit hook. Stop when the Benchmark contract
+passes, `max_iterations` is reached, or a hard stop occurs. Commit `loop_stop`,
+run `render_report.py --require-terminal` after optional token alignment, then
+run the completion audit. The Cosmos-only report addition is a bounded prompt
+showcase sourced from recorded annotations; keep every other visual convention
+aligned with ChangeNet. See `references/REPORT_RENDERING.md`. Never delegate or
+hand-author report rendering.
 
 ## Stage References
 
@@ -307,7 +312,7 @@ final report.
 | Routing / mining | Proxy gaps + `tao-mine-aoi-images` | `references/tao-mine-aoi-images.md` |
 | AnomalyGen | `paidf-anomalygen`, `mode=inference_only` | `references/paidf-anomalygen.md` |
 | Assemble / validate | bundled bare ShareGPT scripts | `references/aoi-annotation.md` |
-| State/log/report | bundled commit/audit scripts + reporter | `references/scripts-and-agents.md` |
+| State/log/report | bundled commit/audit scripts + deterministic report hook | `references/scripts-and-agents.md` |
 
 ## Hard Stops
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/agents/reporter.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/agents/reporter.md
@@ -1,31 +1,23 @@
-# Cosmos3 DEFT Reporter Agent
+# Cosmos3 DEFT Reporter Compatibility Wrapper
 
-Render `${RESULTS_DIR}/DEFT_Loop_Report.html` for
-`tao-run-deft-aoi-cosmos3`.
+Use this wrapper only when a runtime explicitly invokes the legacy reporter
+agent. Normal workflow execution renders automatically from
+`init_deft_state.py` and the `commit_stage.py` post-commit hook.
 
 Inputs:
 
-- `results_dir`: absolute run directory;
-- `skill_root`: absolute skill directory;
-- `trigger`: `iteration-complete` or `loop-end`.
+- `results_dir`: absolute Cosmos3 DEFT run directory;
+- `skill_root`: absolute `tao-run-deft-aoi-cosmos3` skill directory;
+- `trigger`: optional legacy value.
 
-Procedure:
+Run exactly one command:
 
-1. Run `scripts/deft_python.sh scripts/audit_deft_run.py --json` against
-   `results_dir`. Stop on `INVALID`.
-2. Read `references/REPORT_RENDERING.md`.
-3. Read canonical `deft_state.json`, `loop_log.jsonl`, and only the artifact
-   files referenced by state.
-4. Render the required tables. Treat Proxy as RCCA-only and Benchmark as
-   stop-gate-only. Report annotation mode as `bare_okng`. Attribute training
-   records to their producer — mined real pairs or synthetic AnomalyGen pairs —
-   and render a skipped `anomalygen` stage as the documented skip it is, with
-   its reason, not as a missing artifact. The run's terminal
-   iteration has Benchmark evidence but no Proxy artifacts by design; render
-   those cells as `not run (terminal iteration)` and never as a missing
-   artifact or an incomplete iteration.
-5. Write a temporary sibling HTML file, verify it is non-empty and contains all
-   required section headings, then atomically replace the report.
+```bash
+"${skill_root}/scripts/deft_python.sh" \
+  "${skill_root}/scripts/render_report.py" \
+  --results-dir "${results_dir}"
+```
 
-Never edit state/log, inspect credential files, use prior assistant prose as
-evidence, or invent missing values.
+When `trigger` is `loop-end`, append `--require-terminal`. Return the script's
+status line and exit with the same status. Do not read state, assemble HTML,
+edit the template, or write the report yourself.

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/DEFT_Loop_Report.html
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/DEFT_Loop_Report.html
@@ -98,13 +98,10 @@
   .hero .meta-item .value { color: var(--nvidia-green); font-weight: 700; }
 
   .kpi-banner { margin-top: 24px; padding: 18px 22px; background: rgba(118,185,0,0.12); border: 1px solid rgba(118,185,0,0.4); border-radius: 10px; display: flex; align-items: flex-start; gap: 14px; }
-  .kpi-banner.warn { background: rgba(255,188,1,0.10); border-color: rgba(255,188,1,0.35); }
   .kpi-banner.error { background: rgba(194,38,45,0.12); border-color: rgba(194,38,45,0.4); }
   .kpi-banner .icon { flex-shrink: 0; width: 34px; height: 34px; border-radius: 50%; background: var(--nvidia-green); color: #000; display: flex; align-items: center; justify-content: center; font-size: 18px; font-weight: 800; }
-  .kpi-banner.warn .icon { background: var(--nvidia-yellow); }
   .kpi-banner.error .icon { background: var(--nvidia-red); color: #fff; }
   .kpi-banner .title { font-size: 16px; font-weight: 700; color: var(--nvidia-green); margin-bottom: 3px; }
-  .kpi-banner.warn .title { color: var(--nvidia-yellow); }
   .kpi-banner.error .title { color: var(--nvidia-red); }
   .kpi-banner .body { color: var(--text-secondary); font-size: 15px; line-height: 1.5; }
 
@@ -172,10 +169,7 @@
       <div class="meta-item"><strong>Iterations</strong> &nbsp;<span class="value">{{ ITERATIONS_RUN }} / {{ MAX_ITERATIONS }}</span></div>
       <div class="meta-item"><strong>Run Status</strong> &nbsp;<span class="value">{{ RUN_STATUS }}</span></div>
     </div>
-    <div class="kpi-banner {{ BANNER_CLASS }}">
-      <div class="icon">{{ BANNER_ICON }}</div>
-      <div class="content"><div class="title">{{ KPI_STATUS }}</div><div class="body">{{ KPI_COPY }}</div></div>
-    </div>
+    {{ KPI_BANNER_HTML }}
   </header>
 
   <div class="grid">
@@ -191,6 +185,15 @@
         <div class="stat"><div class="stat-label">Best iteration</div><div class="stat-value green">{{ BEST_ITERATION }}</div></div>
         <div class="stat"><div class="stat-label">Best KPI</div><div class="stat-value green">{{ BEST_METRIC }}</div></div>
       </div>
+      <div class="chart-subtitle" style="margin-top:28px;margin-bottom:10px">DEFT Loop Experiment Summary</div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Item</th><th>Details</th></tr></thead><tbody>{{ RUN_SUMMARY_ROWS_HTML }}</tbody></table></div>
+      <div class="chart-subtitle" style="margin-top:28px;margin-bottom:10px">Training Set Growth</div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Iteration</th><th>KNN Raw Mined</th><th>SDG Generated</th><th>New Unique Images (After Dedup)</th><th>Training Set Total</th><th>Δ</th></tr></thead><tbody>{{ GROWTH_ROWS_HTML }}</tbody></table></div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Benchmark KPI Trend</div><div class="chart-subtitle">Only frozen Benchmark results carry a pass/fail verdict.</div></div></div>
+      <div class="chart">{{ METRIC_CHART_HTML }}</div>
     </section>
 
     <section class="card">
@@ -205,13 +208,8 @@
     </section>
 
     <section class="card">
-      <div class="header"><div><div class="chart-title">Benchmark KPI Trend</div><div class="chart-subtitle">Only frozen Benchmark results carry a pass/fail verdict.</div></div></div>
-      <div class="chart">{{ METRIC_CHART_HTML }}</div>
-    </section>
-
-    <section class="card">
       <div class="header"><div><div class="chart-title">Augmentation Volume</div><div class="chart-subtitle">Synthetic and mined contribution by iteration.</div></div></div>
-      <div class="table-wrap"><table class="data-table"><thead><tr><th>Iteration</th><th>SDG requested</th><th>AMP allocated</th><th>Generated</th><th>Defect types</th><th>Mining raw</th><th>Cosine-kept</th><th>New unique targets</th><th>Cumulative train</th></tr></thead><tbody>{{ AUGMENTATION_ROWS_HTML }}</tbody></table></div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Iteration</th><th>SDG requested</th><th>AMP allocated</th><th>Generated</th><th>Defect types</th><th>Mining raw</th><th>Cosine-kept</th><th>Batch unique targets</th><th>Cumulative train</th></tr></thead><tbody>{{ AUGMENTATION_ROWS_HTML }}</tbody></table></div>
     </section>
 
     <section class="card">

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/DEFT_Loop_Report.html
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/DEFT_Loop_Report.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>DEFT Loop Report — Cosmos Reason 3 AOI</title>
+<style>
+  :root {
+    --nvidia-green: #76b900;
+    --nvidia-green-light: #8ed100;
+    --nvidia-yellow: #ffbc01;
+    --nvidia-red: #c2262d;
+    --bg-dark: #1a1a1a;
+    --bg-card: #232323;
+    --bg-panel: #2a2a2a;
+    --bg-panel-2: #2f2f2f;
+    --text-primary: #ffffff;
+    --text-secondary: #b0b0b0;
+    --text-muted: #777777;
+    --border-soft: rgba(255,255,255,0.06);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { color-scheme: dark; }
+  body {
+    font-family: 'NVIDIA Sans', Inter, Arial, sans-serif;
+    background: var(--bg-dark);
+    color: var(--text-primary);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+    padding: 48px 0;
+    font-size: 16px;
+  }
+
+  /* Keep the Cosmos report on the same single-column visual skeleton as ChangeNet. */
+  .page, .grid { display: contents; }
+
+  .card {
+    width: 1280px;
+    background: var(--bg-card);
+    border-radius: 16px;
+    padding: 36px 48px 40px;
+    box-shadow: 0 8px 40px rgba(0,0,0,0.5);
+    position: relative;
+    overflow: hidden;
+  }
+  .card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--nvidia-green), var(--nvidia-green-light));
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 28px;
+  }
+  .chart-title {
+    font-size: 34px;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    color: var(--text-primary);
+    line-height: 1.2;
+  }
+  .chart-subtitle {
+    font-size: 17px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-top: 8px;
+  }
+
+  .hero {
+    width: 1280px;
+    background: linear-gradient(135deg, #1f1f1f 0%, #2a2a2a 100%);
+    border-radius: 16px;
+    padding: 40px 48px;
+    box-shadow: 0 8px 40px rgba(0,0,0,0.5);
+    position: relative;
+    overflow: hidden;
+  }
+  .hero::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--nvidia-green), var(--nvidia-green-light));
+  }
+  .eyebrow { color: var(--nvidia-green); font-size: 12px; font-weight: 800; letter-spacing: 1.6px; text-transform: uppercase; }
+  .hero h1 { font-size: 44px; font-weight: 800; letter-spacing: -0.8px; color: var(--text-primary); margin: 4px 0 10px; }
+  .subtitle { color: var(--text-secondary); font-size: 18px; font-weight: 500; }
+  .hero .meta { display: flex; gap: 32px; font-size: 15px; color: var(--text-secondary); margin-top: 20px; flex-wrap: wrap; }
+  .hero .meta-item strong { color: var(--text-primary); font-weight: 600; }
+  .hero .meta-item .value { color: var(--nvidia-green); font-weight: 700; }
+
+  .kpi-banner { margin-top: 24px; padding: 18px 22px; background: rgba(118,185,0,0.12); border: 1px solid rgba(118,185,0,0.4); border-radius: 10px; display: flex; align-items: flex-start; gap: 14px; }
+  .kpi-banner.warn { background: rgba(255,188,1,0.10); border-color: rgba(255,188,1,0.35); }
+  .kpi-banner.error { background: rgba(194,38,45,0.12); border-color: rgba(194,38,45,0.4); }
+  .kpi-banner .icon { flex-shrink: 0; width: 34px; height: 34px; border-radius: 50%; background: var(--nvidia-green); color: #000; display: flex; align-items: center; justify-content: center; font-size: 18px; font-weight: 800; }
+  .kpi-banner.warn .icon { background: var(--nvidia-yellow); }
+  .kpi-banner.error .icon { background: var(--nvidia-red); color: #fff; }
+  .kpi-banner .title { font-size: 16px; font-weight: 700; color: var(--nvidia-green); margin-bottom: 3px; }
+  .kpi-banner.warn .title { color: var(--nvidia-yellow); }
+  .kpi-banner.error .title { color: var(--nvidia-red); }
+  .kpi-banner .body { color: var(--text-secondary); font-size: 15px; line-height: 1.5; }
+
+  .stat-grid { background: var(--bg-panel); border-radius: 10px; padding: 20px 24px; border: 1px solid var(--border-soft); display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 24px; }
+  .stat { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .stat-label { font-size: 13px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-muted); }
+  .stat-value { font-size: 20px; font-weight: 700; color: var(--text-primary); overflow-wrap: anywhere; }
+  .stat-value.green { color: var(--nvidia-green); }
+
+  .table-wrap { overflow-x: auto; border-radius: 8px; }
+  .data-table { width: 100%; border-collapse: collapse; margin-top: 4px; font-size: 15px; }
+  .data-table th { text-align: left; padding: 12px 14px; font-size: 13px; font-weight: 700; letter-spacing: 0.8px; text-transform: uppercase; color: var(--text-muted); background: var(--bg-panel); border-bottom: 1px solid var(--border-soft); white-space: nowrap; }
+  .data-table td { padding: 13px 14px; color: var(--text-secondary); border-bottom: 1px solid var(--border-soft); vertical-align: middle; }
+  .data-table tr:last-child td { border-bottom: none; }
+  .data-table tr.best { background: rgba(118,185,0,0.06); }
+  .data-table tr.best td { color: var(--text-primary); }
+  .num { font-family: 'SF Mono', 'Fira Code', monospace; font-variant-numeric: tabular-nums; }
+  .path { max-width: 420px; overflow-wrap: anywhere; color: var(--nvidia-green); font-family: 'SF Mono', 'Fira Code', monospace; font-size: 13px; }
+  .badge { display: inline-block; padding: 3px 10px; border-radius: 10px; border: 1px solid var(--border-soft); font-size: 13px; font-weight: 700; letter-spacing: .3px; white-space: nowrap; }
+  .badge.good { color: var(--nvidia-green); background: rgba(118,185,0,.10); border-color: rgba(118,185,0,.28); }
+  .badge.warn { color: var(--nvidia-yellow); background: rgba(255,188,1,.08); border-color: rgba(255,188,1,.26); }
+  .badge.error { color: #ef8085; background: rgba(194,38,45,.10); border-color: rgba(194,38,45,.3); }
+  .badge.muted { color: var(--text-muted); }
+  .chart { min-height: 240px; display: grid; place-items: center; padding: 10px 0 0; }
+  .chart svg { width: 100%; height: auto; overflow: visible; }
+  .chart text { font-family: "NVIDIA Sans", Inter, Arial, sans-serif; }
+  .notice { padding: 15px 17px; border-left: 3px solid var(--nvidia-green); border-radius: 5px; background: rgba(118,185,0,.07); color: var(--text-secondary); }
+  .notice.warn { border-color: var(--nvidia-yellow); background: rgba(255,188,1,.06); }
+  .notice.error { border-color: var(--nvidia-red); background: rgba(194,38,45,.08); }
+  .notice + .notice { margin-top: 10px; }
+  .prompt-list { display: flex; flex-direction: column; gap: 14px; }
+  .prompt-example { padding: 18px 20px; border: 1px solid var(--border-soft); border-radius: 10px; background: var(--bg-panel); }
+  .prompt-meta { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
+  .prompt-role { color: var(--nvidia-green); font-size: 13px; font-weight: 700; letter-spacing: .8px; text-transform: uppercase; }
+  .prompt-text { color: var(--text-primary); font-size: 15px; line-height: 1.65; white-space: pre-wrap; overflow-wrap: anywhere; }
+  .prompt-truncated { display: block; margin-top: 8px; color: var(--text-muted); font-size: 12px; }
+  .prompt-response { display: flex; align-items: center; gap: 8px; margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border-soft); color: var(--text-muted); font-size: 13px; }
+  .prompt-response code { padding: 2px 8px; border-radius: 4px; background: rgba(118,185,0,.10); color: var(--nvidia-green); font: 700 13px/1.5 'SF Mono', 'Fira Code', monospace; }
+  .footer { width: 1280px; color: var(--text-muted); text-align: center; font-size: 12px; }
+  @media (max-width: 1320px) {
+    .hero, .card, .footer { width: calc(100vw - 40px); }
+  }
+  @media (max-width: 900px) {
+    body { gap: 20px; padding: 20px 0; }
+    .hero, .card { border-radius: 10px; padding: 25px 22px; }
+    h1 { font-size: 32px; }
+    .chart-title { font-size: 28px; }
+    .stat-grid { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media print {
+    body { background: white; }
+    .hero, .card { break-inside: avoid; box-shadow: none; }
+  }
+</style>
+</head>
+<body>
+<main class="page">
+  <header class="hero">
+    <div class="eyebrow">NVIDIA TAO · DEFT AOI</div>
+    <h1>Cosmos Reason 3 AOI Report</h1>
+    <p class="subtitle">Disk-backed improvement loop · bare OK/NG classification</p>
+    <div class="meta">
+      <div class="meta-item"><strong>Generated</strong> &nbsp;<span class="value">{{ GENERATED_DATE }}</span></div>
+      <div class="meta-item"><strong>KPI Target</strong> &nbsp;<span class="value">{{ KPI_TARGET }}</span></div>
+      <div class="meta-item"><strong>Iterations</strong> &nbsp;<span class="value">{{ ITERATIONS_RUN }} / {{ MAX_ITERATIONS }}</span></div>
+      <div class="meta-item"><strong>Run Status</strong> &nbsp;<span class="value">{{ RUN_STATUS }}</span></div>
+    </div>
+    <div class="kpi-banner {{ BANNER_CLASS }}">
+      <div class="icon">{{ BANNER_ICON }}</div>
+      <div class="content"><div class="title">{{ KPI_STATUS }}</div><div class="body">{{ KPI_COPY }}</div></div>
+    </div>
+  </header>
+
+  <div class="grid">
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Run Configuration &amp; Outcome</div><div class="chart-subtitle">Approved inputs and the current canonical outcome.</div></div></div>
+      <div class="stat-grid">
+        <div class="stat"><div class="stat-label">Platform</div><div class="stat-value">{{ PLATFORM }}</div></div>
+        <div class="stat"><div class="stat-label">Model</div><div class="stat-value">{{ MODEL }}</div></div>
+        <div class="stat"><div class="stat-label">Annotation mode</div><div class="stat-value">{{ ANNOTATION_MODE }}</div></div>
+        <div class="stat"><div class="stat-label">Compute</div><div class="stat-value">{{ COMPUTE_SHAPE }}</div></div>
+        <div class="stat"><div class="stat-label">Started</div><div class="stat-value">{{ STARTED_AT }}</div></div>
+        <div class="stat"><div class="stat-label">Last event</div><div class="stat-value">{{ FINISHED_AT }}</div></div>
+        <div class="stat"><div class="stat-label">Best iteration</div><div class="stat-value green">{{ BEST_ITERATION }}</div></div>
+        <div class="stat"><div class="stat-label">Best KPI</div><div class="stat-value green">{{ BEST_METRIC }}</div></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Dataset Isolation</div><div class="chart-subtitle">Proxy drives RCCA; frozen Benchmark alone owns the stop gate; Mining supplies training candidates.</div></div></div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Role / producer</th><th>Purpose</th><th>Records</th><th>OK / NG</th><th>Path / evidence</th></tr></thead><tbody>{{ DATASET_ROWS_HTML }}</tbody></table></div>
+      <div class="notice" style="margin-top:14px"><strong>Frozen Benchmark SHA-256:</strong> <span class="path">{{ BENCHMARK_HASH }}</span></div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Prompt Examples</div><div class="chart-subtitle">Representative inspection prompts from the recorded Proxy, Benchmark, and Mining annotations.</div></div></div>
+      <div class="prompt-list">{{ PROMPT_EXAMPLES_HTML }}</div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Benchmark KPI Trend</div><div class="chart-subtitle">Only frozen Benchmark results carry a pass/fail verdict.</div></div></div>
+      <div class="chart">{{ METRIC_CHART_HTML }}</div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Augmentation Volume</div><div class="chart-subtitle">Synthetic and mined contribution by iteration.</div></div></div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Iteration</th><th>SDG requested</th><th>AMP allocated</th><th>Generated</th><th>Defect types</th><th>Mining raw</th><th>Cosine-kept</th><th>New unique targets</th><th>Cumulative train</th></tr></thead><tbody>{{ AUGMENTATION_ROWS_HTML }}</tbody></table></div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Iteration Metrics</div><div class="chart-subtitle">Discrete OK/NG metrics with NG as the positive class.</div></div></div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Phase</th><th>Source</th><th>Accuracy</th><th>NG recall</th><th>NG precision</th><th>NG F1</th><th>False accepts</th><th>False rejects</th><th>Unknown</th><th>KPI</th></tr></thead><tbody>{{ METRIC_ROWS_HTML }}</tbody></table></div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Pipeline Execution</div><div class="chart-subtitle">Ordered events from loop_log.jsonl; durations are never inferred.</div></div></div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Seq</th><th>Phase</th><th>Stage</th><th>Status</th><th>Duration</th><th>Summary</th></tr></thead><tbody>{{ STAGE_ROWS_HTML }}</tbody></table></div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Artifacts</div><div class="chart-subtitle">Recorded lineage and evidence paths only; no untracked discovery or fabricated links.</div></div></div>
+      <div class="table-wrap"><table class="data-table"><thead><tr><th>Phase</th><th>Artifact</th><th>State</th><th>Path / value</th></tr></thead><tbody>{{ ARTIFACT_ROWS_HTML }}</tbody></table></div>
+    </section>
+
+    <section class="card">
+      <div class="header"><div><div class="chart-title">Hard Stops / Warnings</div><div class="chart-subtitle">Canonical audit findings and committed error events.</div></div></div>
+      {{ WARNING_ROWS_HTML }}
+    </section>
+  </div>
+  <div class="footer">Generated deterministically from deft_state.json, loop_log.jsonl, and recorded artifacts · NVIDIA TAO DEFT AOI</div>
+</main>
+</body>
+</html>

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/REPORT_RENDERING.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/REPORT_RENDERING.md
@@ -14,34 +14,54 @@ panels. Model-specific content and evidence differ, but the report must not
 introduce a separate grid, card geometry, or visual hierarchy. The renderer
 test compares these shared CSS properties across both source templates.
 
+Render a hero KPI banner only when the KPI is met or the run ends at a committed
+hard stop. For in-progress runs and terminal runs that remain short of target,
+render no banner. Never show an informational `i`, `BEST RESULT RECORDED`, or
+`from target after the approved iteration budget` callout; the outcome panel
+and metric tables already carry that evidence.
+
 Required sections:
 
 1. **Run Configuration & Outcome** — platform, model, bare mode, KPI contract,
-   GPU/node shape, timestamps, current/terminal status.
-2. **Dataset Isolation** — Proxy/Benchmark/Mining input paths, per-iteration
+   GPU/node shape and exact GPU model, timestamps, current/terminal status; a
+   two-column DEFT experiment summary with baseline/end KPI, routing, total and
+   average measured runtime, and SDG throughput; then a Training Set Growth
+   table with `Iteration`, `KNN Raw Mined`, `SDG Generated`, `New Unique Images
+   (After Dedup)`, `Training Set Total`, and `Δ`. `SDG Generated` comes from
+   the committed CSV row count. `assemble_summary.json.output_records` owns the
+   cumulative total; its difference from the preceding total owns both New
+   Unique and `Δ`. The committed JSON length is a compatibility fallback, while
+   `unique_target_images.new_after_dedup` remains a batch diagnostic in
+   Augmentation Volume.
+2. **Benchmark KPI Trend** — immediately follows Run Configuration & Outcome;
+   only frozen Benchmark results carry a pass/fail verdict.
+3. **Dataset Isolation** — Proxy/Benchmark/Mining input paths, per-iteration
    AnomalyGen output, generated Train artifacts by iteration, OK/NG counts,
    Benchmark SHA-256, and role ownership. Attribute every Train record to its
    producer: mined real pairs or synthetic AnomalyGen pairs.
-3. **Prompt Examples** — up to three distinct first-user prompts read from the
+4. **Prompt Examples** — up to three distinct first-user prompts read from the
    recorded Proxy, Benchmark, and Mining annotations. Group identical prompts
    across roles, show their record count and exact `OK`/`NG` response contract,
    escape file-derived text, and truncate only the displayed preview at 600
    characters. Do not embed the rest of an annotation record.
-4. **Iteration Metrics** — for baseline and every completed iteration:
+5. **Iteration Metrics** — for baseline and every completed iteration:
    accuracy, NG recall, NG precision, NG F1, false accepts, false rejects,
    unknowns, KPI pass/fail. Label every figure with its source split; only
    Benchmark figures carry the KPI verdict.
-5. **Pipeline Execution** — ordered committed stage events and durations from
-   `loop_log.jsonl`.
-6. **Augmentation Volume** — per iteration and per producer. Mining: raw
+6. **Pipeline Execution** — ordered committed stage events and positive,
+   measured durations from `loop_log.jsonl`. Summary totals exclude the
+   administrative `loop_stop` event and label partial historical logs instead
+   of interpreting zero as elapsed time.
+7. **Augmentation Volume** — per iteration and per producer. Mining: raw
    candidates, cosine-kept paths. AnomalyGen: requested `num_SDG`,
-   AMP-allocated, generated, and the per-defect-type breakdown, or the
-   documented skip and its reason. Then newly added unique target images and
-   cumulative training records by iteration.
-7. **Artifacts** — baseline base-model reference, iteration checkpoints,
-   Proxy/Benchmark results, RCCA, mining, AnomalyGen `SDG_result.csv` and
-   generated ShareGPT, assembled JSON, and validation-report links/paths.
-8. **Hard Stops / Warnings** — canonical audit warnings and error event, if
+   AMP-allocated (the sum of the committed `allocation.json`), generated, and
+   the per-defect-type breakdown, or the documented skip and its reason. Then
+   batch-unique target images and cumulative training records by iteration.
+8. **Artifacts** — baseline base-model reference, iteration checkpoints,
+   Proxy/Benchmark results, RCCA, mining, AnomalyGen `SDG_result.csv`,
+   `allocation.json`, and generated ShareGPT, assembled JSON, and
+   validation-report links/paths.
+9. **Hard Stops / Warnings** — canonical audit warnings and error event, if
    present.
 
 Cosmos3 bare mode is a discrete OK/NG classifier.

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/REPORT_RENDERING.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/REPORT_RENDERING.md
@@ -1,7 +1,18 @@
 # Cosmos3 DEFT Report Rendering
 
-Render one self-contained `${RESULTS_DIR}/DEFT_Loop_Report.html` from canonical
-disk evidence. Write to a temporary sibling and replace atomically.
+Use `scripts/render_report.py` as the only renderer for the source template at
+`references/DEFT_Loop_Report.html`. It writes one self-contained
+`${RESULTS_DIR}/DEFT_Loop_Report.html` from canonical disk evidence through a
+temporary sibling and atomic replacement. `init_deft_state.py` invokes it at
+loop start and `commit_stage.py` invokes it after every valid commit, so report
+freshness never depends on an agent remembering a final task.
+
+The Cosmos3 report intentionally shares the ChangeNet report's visual contract:
+the same 1280 px single-column hero and cards, NVIDIA dark palette, typography,
+32 px vertical rhythm, section headers, table treatment, KPI banner, and status
+panels. Model-specific content and evidence differ, but the report must not
+introduce a separate grid, card geometry, or visual hierarchy. The renderer
+test compares these shared CSS properties across both source templates.
 
 Required sections:
 
@@ -11,21 +22,26 @@ Required sections:
    AnomalyGen output, generated Train artifacts by iteration, OK/NG counts,
    Benchmark SHA-256, and role ownership. Attribute every Train record to its
    producer: mined real pairs or synthetic AnomalyGen pairs.
-3. **Iteration Metrics** — for baseline and every completed iteration:
+3. **Prompt Examples** — up to three distinct first-user prompts read from the
+   recorded Proxy, Benchmark, and Mining annotations. Group identical prompts
+   across roles, show their record count and exact `OK`/`NG` response contract,
+   escape file-derived text, and truncate only the displayed preview at 600
+   characters. Do not embed the rest of an annotation record.
+4. **Iteration Metrics** — for baseline and every completed iteration:
    accuracy, NG recall, NG precision, NG F1, false accepts, false rejects,
    unknowns, KPI pass/fail. Label every figure with its source split; only
    Benchmark figures carry the KPI verdict.
-4. **Pipeline Execution** — ordered committed stage events and durations from
+5. **Pipeline Execution** — ordered committed stage events and durations from
    `loop_log.jsonl`.
-5. **Augmentation Volume** — per iteration and per producer. Mining: raw
+6. **Augmentation Volume** — per iteration and per producer. Mining: raw
    candidates, cosine-kept paths. AnomalyGen: requested `num_SDG`,
    AMP-allocated, generated, and the per-defect-type breakdown, or the
    documented skip and its reason. Then newly added unique target images and
    cumulative training records by iteration.
-6. **Artifacts** — baseline base-model reference, iteration checkpoints,
+7. **Artifacts** — baseline base-model reference, iteration checkpoints,
    Proxy/Benchmark results, RCCA, mining, AnomalyGen `SDG_result.csv` and
    generated ShareGPT, assembled JSON, and validation-report links/paths.
-7. **Hard Stops / Warnings** — canonical audit warnings and error event, if
+8. **Hard Stops / Warnings** — canonical audit warnings and error event, if
    present.
 
 Cosmos3 bare mode is a discrete OK/NG classifier.

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/deft_state.json
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/deft_state.json
@@ -66,6 +66,7 @@
       "annotation_source": "generated_from_mining_and_anomalygen",
       "num_gpus": 1,
       "num_nodes": 1,
+      "gpu_model": "NVIDIA H100 80GB HBM3",
       "num_epochs": 10,
       "batch_size": 4,
       "learning_rate": 0.0001,

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/paidf-anomalygen.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/paidf-anomalygen.md
@@ -111,6 +111,7 @@ AnomalyGen writes one synthetic defect per row of `SDG_result.csv`:
 
 ```text
 <output_dir>/
+├── allocation.json                       # Phase 2 defect -> AMP count proof
 ├── SDG_result.csv
 ├── reconstructed_image/<T>+<A>_<idx>.png   # generated defect  -> images[0], the AOI board
 └── original_image/<T>+<A>_<idx>.png        # clean source      -> images[1], the golden reference
@@ -152,7 +153,8 @@ To skip, commit a documented branch skip instead of launching the generator:
 ```bash
 "$SKILL_ROOT/scripts/deft_python.sh" "$SKILL_ROOT/scripts/commit_stage.py" \
   --results-dir "$RESULTS_DIR" --iter-label "iter${N}" --stage anomalygen \
-  --skip --summary "no Proxy false accepts; synthetic defects not indicated"
+  --skip --duration-sec "$STAGE_DURATION_SEC" \
+  --summary "no Proxy false accepts; synthetic defects not indicated"
 ```
 
 The driving RCCA is `baseline` for `iter1` and `iter${N-1}` for later
@@ -192,15 +194,19 @@ be automatic.
 "$SKILL_ROOT/scripts/deft_python.sh" "$SKILL_ROOT/scripts/commit_stage.py" \
   --results-dir "$RESULTS_DIR" --iter-label "iter${N}" --stage anomalygen \
   --anomalygen-sdg "$RESULTS_DIR/iter${N}/anomalygen/sdg/SDG_result.csv" \
+  --anomalygen-allocation "$RESULTS_DIR/iter${N}/anomalygen/sdg/allocation.json" \
   --anomalygen-sharegpt "$RESULTS_DIR/iter${N}/anomalygen/sdg_sharegpt.json" \
+  --duration-sec "$STAGE_DURATION_SEC" \
   --summary "SDG: requested=N, AMP-allocated=M, generated=K by defect type"
 ```
 
-When `M < N`, report both requested and allocated counts — that gap is the
+`commit_stage.py` derives `M` by summing the committed defect-to-count
+`allocation.json` and the audit rechecks it from disk. When `M < N`, report
+both requested and allocated counts — that gap is the
 signal a reviewer needs to spot an allocation bottleneck rather than a
 generation one.
 
-Both artifacts must land under the stage's bound results directory. `--skip`
+All three artifacts must land under the stage's bound results directory. `--skip`
 and the two artifact flags are mutually exclusive; the audit rejects a phase
 that records both.
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/pipeline-and-state.md
@@ -144,5 +144,8 @@ For an ordinary stop, commit `loop_stop` after a completed
 For a hard stop, commit the failed stage with `--status error`, then commit
 `loop_stop`. A failed terminal run is not KPI completion.
 
-Render the report after each completed iteration and once at loop end. The
-final completion claim requires `audit_deft_run.py --require-complete`.
+The `commit_stage.py` post-commit hook refreshes the report after every stage,
+including `loop_stop`. After optional token alignment, run
+`render_report.py --require-terminal` once so the final artifact contains the
+aligned evidence. The final completion claim requires
+`audit_deft_run.py --require-complete`.

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/pipeline-and-state.md
@@ -62,7 +62,8 @@ count against `max_iterations`.
 1. Build `mining_targets.json` only from the preceding Proxy false-accept /
    false-reject artifacts. Never read Benchmark per-sample errors here.
 2. Run `paidf-anomalygen` in `inference_only` mode against the recorded
-   AnomalyGen project, then `emit_sdg_sharegpt.py` to turn each generated pair
+   AnomalyGen project. Commit Phase 2's defect-to-count `allocation.json` as
+   the canonical AMP-allocation evidence, then run `emit_sdg_sharegpt.py` to turn each generated pair
    into a bare `NG` record. When the driving Proxy RCCA recorded zero false
    accepts, commit `--skip` instead of launching the generator; the audit
    re-proves that against `false_accepts_json` on disk. See
@@ -116,6 +117,7 @@ All paths are absolute.
   --results-dir "$RESULTS_DIR" --iter-label iter1 --stage train \
   --best-ckpt "$RESULTS_DIR/iter1/train/safetensors/epoch_10" \
   --training-spec "$WORKSPACE/specs/train_spec.toml" \
+  --duration-sec "$STAGE_DURATION_SEC" \
   --summary "first mined-data Cosmos3 LoRA SFT completed"
 ```
 
@@ -127,6 +129,7 @@ All paths are absolute.
     "$RESULTS_DIR/baseline/benchmark_metrics/metrics_summary.json" \
   --metric-result \
     "$RESULTS_DIR/baseline/benchmark_metrics/metric_result.json" \
+  --duration-sec "$STAGE_DURATION_SEC" \
   --summary "frozen Benchmark KPI analyzed"
 ```
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
@@ -82,16 +82,22 @@ approval.
 Resolve, do not guess:
 
 ```bash
+: "${TAO_SKILL_BANK_PATH:?set TAO_SKILL_BANK_PATH to the installed TAO skill-bank root containing versions.yaml and scripts/resolve_versions_key.py}"
+test -f "$TAO_SKILL_BANK_PATH/versions.yaml" || { echo "missing $TAO_SKILL_BANK_PATH/versions.yaml" >&2; exit 2; }
+test -f "$TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" || { echo "missing $TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" >&2; exit 2; }
 COSMOS_RL_IMAGE=$(
   "$PYTHON" "$TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" \
+    --skill-bank "$TAO_SKILL_BANK_PATH" \
     images.tao_toolkit.cosmos_rl
 )
 TAO_DS_IMAGE=$(
   "$PYTHON" "$TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" \
+    --skill-bank "$TAO_SKILL_BANK_PATH" \
     images.tao_toolkit.data_services
 )
 AG_IMAGE=$(
   "$PYTHON" "$TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" \
+    --skill-bank "$TAO_SKILL_BANK_PATH" \
     images.metropolis_sdg.paidf_anomalygen
 )
 ```

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
@@ -236,7 +236,10 @@ present an unset `NGC_KEY` as a problem when the pull succeeds anyway.
 
 Record:
 
-- GPUs per node and node count;
+- GPUs per node, node count, and the exact GPU model plus memory reported by
+  the selected platform. Preserve that exact string for
+  `init_deft_state.py --gpu-model`; never report the local host's accelerator
+  for a remote Docker, Kubernetes, SLURM, Brev, or external-platform run;
 - `policy.parallelism.dp_shard_size` and `dp_replicate_size`;
 - LoRA rank/alpha/target modules;
 - epochs, batch size, learning rate;
@@ -279,7 +282,7 @@ record-then-launch ordering must be explicit.
 | Next Train | `train_iter_<N>.json`, created after Proxy RCA and Mining selection | workflow |
 | KPI | <metric operator target> + unknown_predictions <= 0 | user/default |
 | Iterations | <N> | user |
-| Train shape | <nodes x GPUs; epochs; batch; LR; LoRA> | user/spec/default |
+| Train shape | <nodes x GPUs; exact GPU model/memory; epochs; batch; LR; LoRA> | user/spec/platform |
 | Mining | <top-K; cosine floor> | user/default |
 | AnomalyGen | <project; num_SDG; asset status> | user/default |
 | Cosmos-RL image | <resolved URI> | versions.yaml |

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/scripts-and-agents.md
@@ -8,8 +8,8 @@ paths before invoking a script.
 | Script | Purpose |
 |---|---|
 | `init_deft_state.py` | Initialize version-3 Cosmos3 state once; freeze Benchmark hash and bare mode. |
-| `audit_deft_run.py` | Read-only state/log/artifact audit and resume oracle. |
-| `commit_stage.py` | Atomically commit one stage and roll back on failed audit. |
+| `audit_deft_run.py` | Read-only state/log/artifact audit and resume oracle, including AMP-allocation sum proof. |
+| `commit_stage.py` | Atomically commit one stage and roll back on failed audit; AnomalyGen records both generated CSV and allocation JSON. |
 | `log_stage.py` | Ordered JSONL writer used by `commit_stage.py`; do not call for normal stage commits. |
 | `metric_contract.py` | Validate/compare the Benchmark KPI contract. |
 | `record_metric_result.py` | Bind `benchmark_metrics/metric_result.json` to an iteration. |
@@ -24,6 +24,14 @@ paths before invoking a script.
 | `assemble_training_json.py` | Monotonic bare training-data merge with dedupe/leakage checks. |
 | `align_token_usage.py` | Backfill stage token accounting after a run when a transcript is available. |
 | `render_report.py` | Deterministically render the self-contained NVIDIA-styled HTML report from canonical state/log and recorded artifacts, including escaped annotation prompt examples; validate required sections/placeholders and replace atomically. |
+
+`init_deft_state.py` requires `--gpu-model` with the exact model string from
+the selected platform's Preflight. `commit_stage.py` requires a positive
+`--duration-sec` on every success, error, skip, and `loop_stop` commit. Use the
+backend's measured elapsed wall time for submitted jobs and a directly measured
+host duration for inline stages; round a measured sub-second stage up to `1`.
+An omitted, zero, or negative duration is rejected rather than recorded as an
+unknown value.
 
 Train, Proxy evaluate, and Benchmark evaluate reuse the current
 `tao-finetune-cosmos-reason` action commands. Mining reuses

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/scripts-and-agents.md
@@ -23,23 +23,31 @@ paths before invoking a script.
 | `emit_mined_sharegpt.py` | Align filtered paths to Mining prompts, golden images, and labels. |
 | `assemble_training_json.py` | Monotonic bare training-data merge with dedupe/leakage checks. |
 | `align_token_usage.py` | Backfill stage token accounting after a run when a transcript is available. |
+| `render_report.py` | Deterministically render the self-contained NVIDIA-styled HTML report from canonical state/log and recorded artifacts, including escaped annotation prompt examples; validate required sections/placeholders and replace atomically. |
 
 Train, Proxy evaluate, and Benchmark evaluate reuse the current
 `tao-finetune-cosmos-reason` action commands. Mining reuses
 `tao-mine-aoi-images`. The application owns only the DEFT-specific state,
 isolation, OK/NG analysis, filtering, and assembly scripts.
 
-## Reporter agent
+## Automatic report hook
 
-Spawn the reporter only after a completed iteration or at loop end. Give it:
+`init_deft_state.py` invokes `render_report.py` after writing canonical state.
+`commit_stage.py` invokes it again after every valid state/log commit,
+including error and `loop_stop` commits. The hook is outside the state
+transaction: it reports `report hook failed` without rolling back a valid
+stage result.
 
-- `results_dir`;
-- absolute `skill_root`;
-- `trigger=iteration-complete|loop-end`.
+Normally do not render separately. After optional loop-end token alignment, or
+to recover from a reported presentation error, run:
 
-The agent must run the audit first, read only canonical state/log plus recorded
-artifacts, and write `${RESULTS_DIR}/DEFT_Loop_Report.html` atomically. It must
-not infer a missing stage from prose or mutate state/log.
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/render_report.py \
+  --results-dir "${RESULTS_DIR}" --require-terminal
+```
+
+The legacy `agents/reporter.md` is a compatibility wrapper around this exact
+command and contains no HTML-generation logic.
 
 ## Path invariants
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/audit_deft_run.py
@@ -190,8 +190,8 @@ def _next_action(
         )
     if status == "COMPLETE":
         return (
-            "render the final report and hand off the best evaluated model",
-            "references/REPORT_RENDERING.md",
+            "hand off the best evaluated model and auto-rendered final report",
+            None,
         )
     if not entries:
         return (
@@ -1049,6 +1049,35 @@ def _print_text(report: dict[str, Any]) -> None:
         print(f"ERROR: {error}")
 
 
+def _completion_report_error(results_dir: pathlib.Path) -> str | None:
+    """Return why the deterministic final HTML is missing/stale/invalid."""
+    results_dir = results_dir.expanduser().resolve()
+    report_path = results_dir / "DEFT_Loop_Report.html"
+    if not report_path.is_file() or report_path.stat().st_size == 0:
+        return f"final HTML report is missing or empty: {report_path}"
+    evidence = [results_dir / "deft_state.json", results_dir / "loop_log.jsonl"]
+    newest_evidence = max(
+        (path.stat().st_mtime_ns for path in evidence if path.exists()),
+        default=0,
+    )
+    if report_path.stat().st_mtime_ns < newest_evidence:
+        return "final HTML report is older than canonical state/log; rerun render_report.py"
+    text = report_path.read_text(encoding="utf-8")
+    required = (
+        "NVIDIA TAO · DEFT AOI",
+        "Dataset Isolation",
+        "Prompt Examples",
+        "Hard Stops / Warnings",
+        "--nvidia-green: #76b900",
+    )
+    missing = [token for token in required if token not in text]
+    if missing:
+        return "final HTML report is missing required content: " + ", ".join(missing)
+    if re.search(r"\{\{\s+[A-Z0-9_]+\s+\}\}", text):
+        return "final HTML report contains unfilled placeholders"
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--results-dir", required=True, type=pathlib.Path)
@@ -1069,8 +1098,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if args.require_terminal and not report["terminal"]:
         return 1
-    if args.require_complete and report["status"] != "COMPLETE":
-        return 1
+    if args.require_complete:
+        if report["status"] != "COMPLETE":
+            return 1
+        report_error = _completion_report_error(args.results_dir)
+        if report_error:
+            print(f"ERROR: {report_error}", file=sys.stderr)
+            return 1
     return 0
 
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/audit_deft_run.py
@@ -50,6 +50,7 @@ PATH_FIELDS = {
     "benchmark_metrics_summary",
     "mining_targets_json",
     "anomalygen_sdg_csv",
+    "anomalygen_allocation_json",
     "anomalygen_sharegpt_json",
     "mining_mined_parquet",
     "mining_summary",
@@ -97,6 +98,12 @@ FIELD_STAGE = {
     for stage, fields in STAGE_REQUIRED_FIELDS.items()
     for field in fields
 }
+FIELD_STAGE.update(
+    {
+        "anomalygen_allocation_json": "anomalygen",
+        "anomalygen_amp_allocated": "anomalygen",
+    }
+)
 
 
 def _driving_label(label: str) -> str | None:
@@ -341,6 +348,38 @@ def _json_list(
         errors.append(f"{field} root must be a list")
         return None
     return payload
+
+
+def _allocation_proof(
+    path: pathlib.Path | None,
+    recorded_count: Any,
+    field: str,
+    errors: list[str],
+) -> None:
+    payload = _json_object(path, field, errors)
+    if payload is None:
+        return
+    if not payload:
+        errors.append(f"{field} must be a non-empty defect-to-count object")
+        return
+    if any(
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value < 0
+        for value in payload.values()
+    ):
+        errors.append(f"{field} contains invalid allocation counts")
+        return
+    allocated = sum(payload.values())
+    if allocated <= 0:
+        errors.append(f"{field} must allocate at least one AMP")
+    if not isinstance(recorded_count, int) or isinstance(recorded_count, bool):
+        errors.append(f"{field} has no integer anomalygen_amp_allocated in state")
+    elif recorded_count != allocated:
+        errors.append(
+            f"{field} total={allocated} disagrees with "
+            f"anomalygen_amp_allocated={recorded_count}"
+        )
 
 
 def _parquet_rows(
@@ -611,6 +650,13 @@ def audit(results_dir: pathlib.Path) -> dict[str, Any]:
                     errors.append(
                         f"{field} must be Proxy-only, non-aggregate RCCA output"
                     )
+            if field == "anomalygen_allocation_json":
+                _allocation_proof(
+                    path,
+                    phase.get("anomalygen_amp_allocated"),
+                    field,
+                    errors,
+                )
             if field in {
                 "proxy_results_json",
                 "benchmark_results_json",
@@ -702,6 +748,15 @@ def audit(results_dir: pathlib.Path) -> dict[str, Any]:
                         "it is the validate_sharegpt.py --summary output, not "
                         "validate_split_contract.py --summary"
                     )
+
+        if (
+            phase.get("anomalygen_amp_allocated") is not None
+            and not phase.get("anomalygen_allocation_json")
+        ):
+            errors.append(
+                f"state.iterations.{label}.anomalygen_amp_allocated is set "
+                "without anomalygen_allocation_json"
+            )
 
         if (label, "data_mining") in log_keys:
             mined_rows = _parquet_rows(

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/commit_stage.py
@@ -109,6 +109,29 @@ def _required_json_file(value: pathlib.Path | None, flag: str) -> str:
     return path
 
 
+def _required_allocation(
+    value: pathlib.Path | None, flag: str
+) -> tuple[str, int]:
+    path = _required_file(value, flag)
+    try:
+        payload = json.loads(pathlib.Path(path).read_text())
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{flag} must be a JSON object: {path} ({exc})") from exc
+    if not isinstance(payload, dict) or not payload:
+        raise ValueError(f"{flag} must be a non-empty defect-to-count JSON object")
+    invalid = {
+        str(defect): count
+        for defect, count in payload.items()
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0
+    }
+    if invalid:
+        raise ValueError(f"{flag} contains invalid allocation counts: {invalid}")
+    allocated = sum(payload.values())
+    if allocated <= 0:
+        raise ValueError(f"{flag} must allocate at least one sample")
+    return path, allocated
+
+
 def _required_checkpoint(value: pathlib.Path | None, flag: str) -> str:
     if value is None:
         raise ValueError(f"{flag} is required")
@@ -244,6 +267,15 @@ def _apply_success(
                 phase_root,
                 "--anomalygen-sdg",
             )
+            allocation, allocated = _required_allocation(
+                args.anomalygen_allocation, "--anomalygen-allocation"
+            )
+            phase["anomalygen_allocation_json"] = _within(
+                allocation,
+                phase_root,
+                "--anomalygen-allocation",
+            )
+            phase["anomalygen_amp_allocated"] = allocated
             phase["anomalygen_sharegpt_json"] = _within(
                 _required_json_file(
                     args.anomalygen_sharegpt, "--anomalygen-sharegpt"
@@ -312,6 +344,14 @@ def _apply_success(
 def commit(args: argparse.Namespace) -> dict[str, Any]:
     if not re.fullmatch(r"baseline|iter[1-9][0-9]*", args.iter_label):
         raise ValueError("--iter-label must be baseline or iterN")
+    if (
+        not isinstance(args.duration_sec, int)
+        or isinstance(args.duration_sec, bool)
+        or args.duration_sec <= 0
+    ):
+        raise ValueError(
+            "--duration-sec is required and must be a positive measured duration"
+        )
     if getattr(args, "skip", False) and args.stage not in SKIPPABLE_STAGES:
         raise ValueError(
             f"--skip is valid only for: {', '.join(SKIPPABLE_STAGES)}"
@@ -417,7 +457,12 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--stage", required=True, choices=STAGES)
     parser.add_argument("--status", choices=("ok", "error"), default="ok")
     parser.add_argument("--summary", required=True)
-    parser.add_argument("--duration-sec", type=int, default=0)
+    parser.add_argument(
+        "--duration-sec",
+        required=True,
+        type=int,
+        help="Measured wall-clock seconds for this stage; must be positive",
+    )
     parser.add_argument("--best-ckpt", type=pathlib.Path)
     parser.add_argument("--training-spec", type=pathlib.Path)
     parser.add_argument("--proxy-results", type=pathlib.Path)
@@ -429,6 +474,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--metric-result", type=pathlib.Path)
     parser.add_argument("--mining-targets", type=pathlib.Path)
     parser.add_argument("--anomalygen-sdg", type=pathlib.Path)
+    parser.add_argument("--anomalygen-allocation", type=pathlib.Path)
     parser.add_argument("--anomalygen-sharegpt", type=pathlib.Path)
     parser.add_argument(
         "--skip",

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/commit_stage.py
@@ -18,6 +18,7 @@ from typing import Any
 from audit_deft_run import _expected_next, audit
 from log_stage import append_stage
 from record_metric_result import commit as commit_metric_result
+from render_report import render as render_html_report
 
 
 STAGES = (
@@ -399,6 +400,13 @@ def commit(args: argparse.Namespace) -> dict[str, Any]:
         else:
             _atomic_text(log_path, original_log)
         raise
+    # Keep reporting outside the state/log transaction: a presentation bug is
+    # surfaced to the caller without invalidating an otherwise valid commit.
+    try:
+        output = render_html_report(results_dir, audit_report=report)
+        report["report_path"] = str(output)
+    except Exception as exc:  # noqa: BLE001 - hook failures are non-transactional
+        report["report_render_error"] = str(exc)
     return report
 
 
@@ -454,6 +462,11 @@ def main(argv: list[str] | None = None) -> int:
         f"committed seq={last['seq']} {last['iter']}/{last['stage']} "
         f"status={last['status']} run={report['status']}"
     )
+    if report.get("report_render_error"):
+        print(
+            f"commit_stage: report hook failed: {report['report_render_error']}",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/emit_sdg_sharegpt.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/emit_sdg_sharegpt.py
@@ -29,7 +29,7 @@ from validate_sharegpt import load_records, prompt_and_label
 
 # AnomalyGen names every output "<texture>+<anomaly>_<index>.<ext>". The paired
 # clean board reuses the stem verbatim under original_image/.
-# paidf-anomalygen:1.0.0 calls the generated-defect column "output_filename".
+# Older paidf-anomalygen releases call the generated-defect column "output_filename".
 RECONSTRUCTED_COLUMNS = (
     "reconstructed_image",
     "reconstructed",

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/init_deft_state.py
@@ -281,6 +281,7 @@ def build_state(args: argparse.Namespace) -> dict[str, Any]:
                 "annotation_source": "generated_from_mining_and_anomalygen",
                 "num_gpus": args.num_gpus,
                 "num_nodes": args.num_nodes,
+                "gpu_model": args.gpu_model,
                 "num_epochs": args.num_epochs,
                 "batch_size": args.batch_size,
                 "learning_rate": args.learning_rate,
@@ -396,6 +397,14 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--mining-annotations", type=pathlib.Path)
     parser.add_argument("--num-gpus", type=int, default=1)
     parser.add_argument("--num-nodes", type=int, default=1)
+    parser.add_argument(
+        "--gpu-model",
+        required=True,
+        help=(
+            "Exact accelerator model recorded by the selected platform's "
+            "Preflight, including memory when available"
+        ),
+    )
     parser.add_argument("--num-epochs", type=int, default=10)
     parser.add_argument("--batch-size", type=int, default=4)
     parser.add_argument("--learning-rate", type=float, default=1e-4)
@@ -439,6 +448,10 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    args.gpu_model = args.gpu_model.strip()
+    if not args.gpu_model:
+        print("init_deft_state: --gpu-model must not be empty", file=sys.stderr)
+        return 2
     positive = {
         "max_iterations": args.max_iterations,
         "num_gpus": args.num_gpus,

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/init_deft_state.py
@@ -17,6 +17,7 @@ import tempfile
 from typing import Any
 
 from metric_contract import render_target, validate_contract
+from render_report import render as render_html_report
 
 
 WORKFLOW = "tao-run-deft-aoi-cosmos3"
@@ -480,6 +481,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"init_deft_state: {exc}", file=sys.stderr)
         return 2
     print(f"init_deft_state: wrote {output}", file=sys.stderr)
+    try:
+        render_html_report(args.results_dir)
+    except Exception as exc:  # noqa: BLE001 - state initialization remains valid
+        print(f"init_deft_state: report hook failed: {exc}", file=sys.stderr)
     return 0
 
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/patch_eval_image_cap.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/patch_eval_image_cap.py
@@ -42,11 +42,18 @@ CAP_PATTERN = re.compile(
 def read_from_image(image: str, container_path: str, *, docker: str) -> str:
     if shutil.which(docker) is None:
         raise ValueError(f"{docker} not found on PATH")
-    proc = subprocess.run(
-        [docker, "run", "--rm", "--entrypoint", "cat", image, container_path],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            [docker, "run", "--rm", "--entrypoint", "cat", image, container_path],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(
+            f"timed out after {exc.timeout}s reading {container_path} from {image}; "
+            "pre-pull the image or fix platform access before launch"
+        ) from exc
     if proc.returncode != 0:
         raise ValueError(
             f"could not read {container_path} from {image}: "

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/render_report.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/render_report.py
@@ -20,7 +20,6 @@ import tempfile
 from typing import Any
 
 from metric_contract import (
-    MINIMIZING_OPERATORS,
     contract_from_state,
     pick_best,
     render_target,
@@ -229,6 +228,220 @@ def _duration(value: Any) -> str:
     return f"{seconds}s"
 
 
+def _metric_summary_html(
+    result: dict[str, Any] | None, contract: dict[str, Any]
+) -> str:
+    if result is None:
+        return "not available"
+    detail = (
+        f"{_escape(contract['display_name'])} = {_fmt(result.get('value'))}"
+        f"{_escape(str(contract.get('unit', '')))}"
+    )
+    values = result.get("constraints", {})
+    if isinstance(values, dict):
+        constraints: list[str] = []
+        for constraint in contract.get("constraints", []):
+            value = values.get(constraint.get("name"))
+            if value is None:
+                continue
+            constraints.append(
+                f"{_escape(constraint.get('display_name', constraint.get('name')))} "
+                f"{_fmt(value)}{_escape(str(constraint.get('unit', '')))}"
+            )
+        if constraints:
+            detail += " @ " + ", ".join(constraints)
+    return detail
+
+
+def _benchmark_summary_html(state: dict[str, Any]) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    annotations = config.get("annotations", {})
+    if not isinstance(annotations, dict):
+        annotations = {}
+    records = _json_records(annotations.get("benchmark"))
+    if not records:
+        return "Benchmark dataset not available"
+    ok, ng = _label_counts(records)
+    return f"Benchmark: {len(records):,} rows: {ok:,} OK / {ng:,} NG"
+
+
+def _recorded_duration_summary(
+    entries: list[dict[str, Any]], completed_iterations: int
+) -> str:
+    timed = [entry for entry in entries if entry.get("stage") != "loop_stop"]
+    durations = [
+        int(entry["duration_sec"])
+        for entry in timed
+        if isinstance(entry.get("duration_sec"), int)
+        and not isinstance(entry.get("duration_sec"), bool)
+        and int(entry["duration_sec"]) > 0
+    ]
+    if not durations:
+        return f"{completed_iterations} iterations · duration not recorded"
+    total = sum(durations)
+    missing = len(timed) - len(durations)
+    if missing:
+        return (
+            f"{completed_iterations} iterations · {_duration(total)} recorded · "
+            f"{missing} stage duration{'s' if missing != 1 else ''} missing"
+        )
+    if completed_iterations <= 0:
+        return f"0 iterations · {_duration(total)} recorded"
+    average = max(1, round(total / completed_iterations))
+    return (
+        f"{completed_iterations} iters × ~{_duration(average)} = "
+        f"{_duration(total)} total time"
+    )
+
+
+def _sdg_summary_html(
+    state: dict[str, Any], entries: list[dict[str, Any]]
+) -> str:
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        return "not available"
+    generated: list[int] = []
+    for label in sorted(iterations, key=_label_key):
+        if label == "baseline" or not isinstance(iterations[label], dict):
+            continue
+        phase = iterations[label]
+        if phase.get("anomalygen_skipped"):
+            generated.append(0)
+        elif phase.get("anomalygen_sdg_csv"):
+            generated.append(len(_csv_rows(phase.get("anomalygen_sdg_csv"))))
+    if not generated:
+        return "not available"
+    total = sum(generated)
+    average = round(total / len(generated))
+    detail = f"{average:,} images/iter · {total:,} total"
+    durations = [
+        int(entry["duration_sec"])
+        for entry in entries
+        if entry.get("stage") == "anomalygen"
+        and isinstance(entry.get("duration_sec"), int)
+        and not isinstance(entry.get("duration_sec"), bool)
+        and int(entry["duration_sec"]) > 0
+    ]
+    if durations:
+        detail += f" · {_duration(round(sum(durations) / len(durations)))} avg SDG time/iter"
+    else:
+        detail += " · SDG duration not recorded"
+    return detail
+
+
+def _assemble_counts(phase: dict[str, Any]) -> tuple[int | None, int | None]:
+    summary = _optional_json(phase.get("assemble_summary"))
+    total = _first_number(summary, ("output_records",))
+    unique = None
+    if isinstance(summary, dict):
+        unique_targets = summary.get("unique_target_images")
+        if isinstance(unique_targets, dict):
+            unique = _first_number(unique_targets, ("new_after_dedup",))
+    if total is None and phase.get("combined_training_json"):
+        total = len(_json_records(phase.get("combined_training_json")))
+    return (
+        int(total) if isinstance(total, (int, float)) else None,
+        int(unique) if isinstance(unique, (int, float)) else None,
+    )
+
+
+def _growth_rows(state: dict[str, Any]) -> str:
+    rows = [
+        '<tr><td><strong>Baseline</strong></td><td class="num">0</td>'
+        '<td class="num">0</td><td class="num">0</td><td class="num">0</td>'
+        '<td class="num">—</td></tr>'
+    ]
+    previous_total = 0
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        return "\n".join(rows)
+    for label in sorted(iterations, key=_label_key):
+        phase = iterations[label]
+        if label == "baseline" or not isinstance(phase, dict):
+            continue
+        mining_summary = _optional_json(phase.get("mining_summary"))
+        raw = _first_number(
+            mining_summary,
+            ("raw_candidates", "candidate_count", "input_rows", "raw_rows"),
+        )
+        if raw is None and phase.get("data_mining_skipped"):
+            raw = 0
+        sdg_generated = (
+            0
+            if phase.get("anomalygen_skipped")
+            else (
+                len(_csv_rows(phase.get("anomalygen_sdg_csv")))
+                if phase.get("anomalygen_sdg_csv")
+                else None
+            )
+        )
+        total, _batch_unique = _assemble_counts(phase)
+        delta = total - previous_total if total is not None else None
+        new_unique = delta if delta is not None and delta >= 0 else None
+        delta_html = (
+            "—"
+            if delta is None
+            else (f"+{delta:,}" if delta > 0 else f"{delta:,}")
+        )
+        rows.append(
+            f'<tr><td><strong>{_escape(label.title())}</strong></td>'
+            f'<td class="num">{_fmt(raw)}</td>'
+            f'<td class="num">{_fmt(sdg_generated)}</td>'
+            f'<td class="num">{_fmt(new_unique)}</td>'
+            f'<td class="num">{_fmt(total)}</td>'
+            f'<td class="num">{delta_html}</td></tr>'
+        )
+        if total is not None:
+            previous_total = total
+    return "\n".join(rows)
+
+
+def _run_summary_rows(
+    state: dict[str, Any],
+    contract: dict[str, Any],
+    candidates: list[tuple[str, dict[str, Any], dict[str, Any]]],
+    entries: list[dict[str, Any]],
+) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    training = config.get("training", {})
+    if not isinstance(training, dict):
+        training = {}
+    baseline = next(
+        (result for label, _, result in candidates if label == "baseline"), None
+    )
+    end_label, end_result = (
+        (candidates[-1][0], candidates[-1][2])
+        if candidates
+        else (None, None)
+    )
+    completed = sum(1 for label, _, _ in candidates if label != "baseline")
+    gpu = f"{_fmt(training.get('num_gpus'))}x {_fmt(training.get('gpu_model'))}"
+    baseline_detail = _metric_summary_html(baseline, contract)
+    if baseline is not None:
+        baseline_detail += f" ({_benchmark_summary_html(state)})"
+    end_detail = _metric_summary_html(end_result, contract)
+    if end_label is not None and end_result is not None:
+        end_detail += f" ({_escape(end_label.title())})"
+    details = (
+        ("Prompt/Goal", f"Run DEFT loop · KPI: {_escape(render_target(contract))}"),
+        ("Model", f"NVIDIA TAO Cosmos Reason 3 · {_fmt(config.get('base_model'))}"),
+        ("GPU", gpu),
+        ("Baseline (pre-DEFT)", baseline_detail),
+        ("Data Routing", "AnomalyGen SDG &amp; k-NN Mining"),
+        ("Iterations × Time", _escape(_recorded_duration_summary(entries, completed))),
+        ("SDG Images", _escape(_sdg_summary_html(state, entries))),
+        ("End Result", end_detail),
+    )
+    return "\n".join(
+        f'<tr><td><strong>{_escape(item)}</strong></td><td>{detail}</td></tr>'
+        for item, detail in details
+    )
+
+
 def _dataset_rows(state: dict[str, Any]) -> str:
     config = state.get("config", {})
     if not isinstance(config, dict):
@@ -372,15 +585,23 @@ def _augmentation_rows(state: dict[str, Any]) -> str:
         kept = phase.get("mining_mined_count")
         if kept is None:
             kept = _first_number(summary, ("kept_rows", "kept_count", "output_rows"))
-        assembled = _json_records(phase.get("combined_training_json"))
-        train_count = len(assembled) if assembled else None
-        new_unique = max(train_count - previous_train, 0) if train_count is not None else None
+        train_count, new_unique = _assemble_counts(phase)
+        if new_unique is None and train_count is not None:
+            new_unique = max(train_count - previous_train, 0)
         if train_count is not None:
             previous_train = train_count
-        allocated = _first_number(
-            _optional_json(phase.get("assemble_summary")),
-            ("amp_allocated", "allocated", "allocated_count"),
-        )
+        allocated = phase.get("anomalygen_amp_allocated")
+        if not isinstance(allocated, int) or isinstance(allocated, bool):
+            allocation = _optional_json(phase.get("anomalygen_allocation_json"))
+            if allocation and all(
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and value >= 0
+                for value in allocation.values()
+            ):
+                allocated = sum(allocation.values())
+            else:
+                allocated = None
         rows.append(
             f'<tr><td><strong>{_escape(label.title())}</strong></td><td class="num">{_fmt(requested)}</td><td class="num">{_fmt(allocated)}</td>'
             f'<td class="num">{_fmt(generated)}</td><td>{_defect_breakdown(sdg_rows)}</td><td class="num">{_fmt(raw)}</td>'
@@ -414,6 +635,7 @@ def _artifact_rows(state: dict[str, Any], contract: dict[str, Any]) -> str:
         ("proxy_gaps_summary", "Proxy RCCA"),
         ("mining_targets_json", "Routing targets"),
         ("anomalygen_sdg_csv", "AnomalyGen SDG_result.csv"),
+        ("anomalygen_allocation_json", "AnomalyGen AMP allocation"),
         ("anomalygen_sharegpt_json", "AnomalyGen ShareGPT"),
         ("mining_mined_parquet", "Mined candidates"),
         ("mining_summary", "Mining filter summary"),
@@ -567,23 +789,22 @@ def render(
         run_status = "IN_PROGRESS"
 
     if run_status == "FAILED":
-        banner_class, banner_icon = "error", "!"
-        kpi_status = "RUN ENDED AT A HARD STOP"
-        kpi_copy = "Review the committed error event and audit findings below."
+        banner = (
+            '<div class="kpi-banner error"><div class="icon">!</div>'
+            '<div class="content"><div class="title">RUN ENDED AT A HARD STOP</div>'
+            '<div class="body">Review the committed error event and audit findings below.</div>'
+            "</div></div>"
+        )
     elif terminal and metric_passed:
-        banner_class, banner_icon = "", "✓"
-        kpi_status = "KPI MET"
-        kpi_copy = f"{best_label.title() if best_label else 'Best result'} satisfies the frozen Benchmark contract."
-    elif terminal and best_result:
-        banner_class, banner_icon = "warn", "i"
-        value = float(best_result["value"])
-        gap = value - contract["target"] if contract["operator"] in MINIMIZING_OPERATORS else contract["target"] - value
-        kpi_status = "BEST RESULT RECORDED"
-        kpi_copy = f"{abs(gap):.4g} from target after the approved iteration budget."
+        label = best_label.title() if best_label else "Best result"
+        banner = (
+            '<div class="kpi-banner"><div class="icon">✓</div>'
+            '<div class="content"><div class="title">KPI MET</div>'
+            f'<div class="body">{_escape(label)} satisfies the frozen Benchmark contract.</div>'
+            "</div></div>"
+        )
     else:
-        banner_class, banner_icon = "warn", "i"
-        kpi_status = "LOOP IN PROGRESS"
-        kpi_copy = "This report refreshes automatically after every committed stage."
+        banner = ""
 
     config = state.get("config", {})
     if not isinstance(config, dict):
@@ -593,7 +814,10 @@ def render(
         training = {}
     num_gpus = training.get("num_gpus")
     num_nodes = training.get("num_nodes")
-    compute_shape = f"{_fmt(num_nodes)} node(s) · {_fmt(num_gpus)} GPU(s)"
+    compute_shape = (
+        f"{_fmt(num_nodes)} node(s) · {_fmt(num_gpus)} GPU(s) · "
+        f"{_fmt(training.get('gpu_model'))}"
+    )
     completed_iterations = sum(1 for label, _, _ in candidates if label != "baseline")
     benchmark_hash = (
         config.get("evaluation", {}).get("benchmark", {}).get("sha256")
@@ -613,10 +837,7 @@ def render(
         "ITERATIONS_RUN": str(completed_iterations),
         "MAX_ITERATIONS": _fmt(state.get("max_iterations")),
         "RUN_STATUS": _escape(run_status),
-        "BANNER_CLASS": banner_class,
-        "BANNER_ICON": banner_icon,
-        "KPI_STATUS": _escape(kpi_status),
-        "KPI_COPY": _escape(kpi_copy),
+        "KPI_BANNER_HTML": banner,
         "PLATFORM": _fmt(config.get("platform")),
         "MODEL": _fmt(config.get("base_model")),
         "ANNOTATION_MODE": _fmt(config.get("annotation_mode", "bare_okng")),
@@ -625,6 +846,10 @@ def render(
         "FINISHED_AT": _fmt(last_ts),
         "BEST_ITERATION": _escape(best_label.title() if best_label else "not available"),
         "BEST_METRIC": best_metric,
+        "RUN_SUMMARY_ROWS_HTML": _run_summary_rows(
+            state, contract, candidates, entries
+        ),
+        "GROWTH_ROWS_HTML": _growth_rows(state),
         "DATASET_ROWS_HTML": _dataset_rows(state),
         "BENCHMARK_HASH": _fmt(benchmark_hash),
         "PROMPT_EXAMPLES_HTML": _prompt_examples(state),
@@ -644,6 +869,8 @@ def render(
     required = (
         "NVIDIA TAO · DEFT AOI",
         "Run Configuration &amp; Outcome",
+        "Training Set Growth",
+        "Benchmark KPI Trend",
         "Dataset Isolation",
         "Prompt Examples",
         "Iteration Metrics",

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/render_report.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/render_report.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render the NVIDIA-styled Cosmos3 DEFT AOI report from disk evidence."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import html as html_lib
+import json
+import math
+import os
+import pathlib
+import re
+import sys
+import tempfile
+from typing import Any
+
+from metric_contract import (
+    MINIMIZING_OPERATORS,
+    contract_from_state,
+    pick_best,
+    render_target,
+    result_from_iteration,
+    result_passes,
+)
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TEMPLATE_PATH = SKILL_ROOT / "references" / "DEFT_Loop_Report.html"
+REPORT_NAME = "DEFT_Loop_Report.html"
+
+
+def _escape(value: Any) -> str:
+    return html_lib.escape(str(value), quote=True)
+
+
+def _fmt(value: Any, digits: int = 4) -> str:
+    if value is None:
+        return "not available"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        number = float(value)
+        if not math.isfinite(number):
+            return "not available"
+        if number.is_integer():
+            return f"{int(number):,}"
+        return f"{number:.{digits}g}"
+    text = str(value)
+    return _escape(text) if text else "not available"
+
+
+def _label_key(label: str) -> tuple[int, int]:
+    if label == "baseline":
+        return (0, 0)
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    return (1, int(match.group(1))) if match else (2, 0)
+
+
+def _read_json(path: pathlib.Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _optional_json(path_value: Any) -> Any:
+    if not isinstance(path_value, str) or not path_value:
+        return None
+    path = pathlib.Path(path_value)
+    if not path.is_file():
+        return None
+    try:
+        return _read_json(path)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _read_log(path: pathlib.Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid loop_log.jsonl line {line_number}: {exc}") from exc
+        if not isinstance(entry, dict):
+            raise ValueError(f"loop_log.jsonl line {line_number} must be an object")
+        entries.append(entry)
+    return entries
+
+
+def _json_records(path_value: Any) -> list[dict[str, Any]]:
+    payload = _optional_json(path_value)
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _label_counts(records: list[dict[str, Any]]) -> tuple[int, int]:
+    ok = ng = 0
+    for record in records:
+        conversations = record.get("conversations")
+        if not isinstance(conversations, list) or not conversations:
+            continue
+        final = conversations[-1]
+        if not isinstance(final, dict):
+            continue
+        value = str(final.get("value", "")).strip()
+        if value == "OK":
+            ok += 1
+        elif value == "NG":
+            ng += 1
+    return ok, ng
+
+
+def _human_prompt(record: dict[str, Any]) -> str | None:
+    conversations = record.get("conversations")
+    if not isinstance(conversations, list):
+        return None
+    for turn in conversations:
+        if not isinstance(turn, dict):
+            continue
+        if str(turn.get("from", "")).strip().lower() not in {"human", "user"}:
+            continue
+        value = turn.get("value")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _prompt_examples(state: dict[str, Any], *, limit: int = 3) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    annotations = config.get("annotations", {})
+    if not isinstance(annotations, dict):
+        annotations = {}
+
+    examples: dict[str, dict[str, Any]] = {}
+    for role in ("proxy", "benchmark", "mining"):
+        for record in _json_records(annotations.get(role)):
+            prompt = _human_prompt(record)
+            if prompt is None:
+                continue
+            example = examples.setdefault(prompt, {"roles": [], "records": 0})
+            if role not in example["roles"]:
+                example["roles"].append(role)
+            example["records"] += 1
+
+    if not examples:
+        return (
+            '<div class="notice warn"><strong>Prompt examples are not available yet.</strong> '
+            "They appear after the recorded annotation files are staged.</div>"
+        )
+
+    rows: list[str] = []
+    for prompt, metadata in list(examples.items())[:limit]:
+        roles = " · ".join(str(role).title() for role in metadata["roles"])
+        record_count = int(metadata["records"])
+        preview = prompt if len(prompt) <= 600 else prompt[:599] + "…"
+        truncation = (
+            '<span class="prompt-truncated">Preview truncated at 600 characters</span>'
+            if len(prompt) > 600
+            else ""
+        )
+        rows.append(
+            '<div class="prompt-example">'
+            '<div class="prompt-meta">'
+            f'<span class="prompt-role">{_escape(roles)}</span>'
+            f'<span class="badge muted">{record_count:,} RECORDS</span>'
+            "</div>"
+            f'<div class="prompt-text">{_escape(preview)}</div>'
+            f"{truncation}"
+            '<div class="prompt-response"><span>Exact assistant output</span>'
+            '<code>OK</code><span>or</span><code>NG</code></div>'
+            "</div>"
+        )
+    return "\n".join(rows)
+
+
+def _csv_rows(path_value: Any) -> list[dict[str, str]]:
+    if not isinstance(path_value, str) or not path_value:
+        return []
+    path = pathlib.Path(path_value)
+    if not path.is_file():
+        return []
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+    except (OSError, UnicodeDecodeError, csv.Error):
+        return []
+
+
+def _metric_candidates(
+    state: dict[str, Any], contract: dict[str, Any]
+) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        raise ValueError("state.iterations must be an object")
+    result: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    for label in sorted(iterations, key=_label_key):
+        phase = iterations[label]
+        if not isinstance(phase, dict):
+            continue
+        metric = result_from_iteration(phase, contract)
+        if metric is not None:
+            result.append((label, phase, metric))
+    return result
+
+
+def _duration(value: Any) -> str:
+    try:
+        total = int(value)
+    except (TypeError, ValueError):
+        return "not recorded"
+    if total <= 0:
+        return "not recorded"
+    hours, remainder = divmod(total, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
+def _dataset_rows(state: dict[str, Any]) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    annotations = config.get("annotations", {})
+    if not isinstance(annotations, dict):
+        annotations = {}
+    purposes = {
+        "proxy": "RCCA and routing only; never gates the loop",
+        "benchmark": "Frozen stop-gate evaluation only",
+        "mining": "Candidate source for mined training pairs",
+    }
+    rows: list[str] = []
+    for role in ("proxy", "benchmark", "mining"):
+        path = annotations.get(role)
+        records = _json_records(path)
+        ok, ng = _label_counts(records)
+        rows.append(
+            f'<tr><td><strong>{_escape(role.title())}</strong></td><td>{_escape(purposes[role])}</td>'
+            f'<td class="num">{len(records):,}</td><td class="num">{ok:,} / {ng:,}</td><td class="path">{_fmt(path)}</td></tr>'
+        )
+    iterations = state.get("iterations", {})
+    if isinstance(iterations, dict):
+        for label in sorted(iterations, key=_label_key):
+            if label == "baseline" or not isinstance(iterations[label], dict):
+                continue
+            phase = iterations[label]
+            producers = (
+                ("Mined real pairs", phase.get("mined_sharegpt_json")),
+                ("AnomalyGen synthetic pairs", phase.get("anomalygen_sharegpt_json")),
+            )
+            for producer, path in producers:
+                if not path and producer.startswith("AnomalyGen") and phase.get("anomalygen_skipped"):
+                    rows.append(
+                        f'<tr><td><strong>{_escape(label.title())} · AnomalyGen</strong></td><td>Documented skip</td><td class="num">0</td><td class="num">0 / 0</td><td>skipped by committed stage</td></tr>'
+                    )
+                    continue
+                if not path:
+                    continue
+                records = _json_records(path)
+                ok, ng = _label_counts(records)
+                rows.append(
+                    f'<tr><td><strong>{_escape(label.title())} · {_escape(producer)}</strong></td><td>Generated Train producer</td>'
+                    f'<td class="num">{len(records):,}</td><td class="num">{ok:,} / {ng:,}</td><td class="path">{_fmt(path)}</td></tr>'
+                )
+    return "\n".join(rows)
+
+
+def _metric_rows(
+    candidates: list[tuple[str, dict[str, Any], dict[str, Any]]],
+    contract: dict[str, Any],
+    best_label: str | None,
+) -> str:
+    rows: list[str] = []
+    for label, _, result in candidates:
+        metrics = result.get("metrics", {})
+        confusion = result.get("confusion", {})
+        constraints = result.get("constraints", {})
+        if not isinstance(metrics, dict):
+            metrics = {}
+        if not isinstance(confusion, dict):
+            confusion = {}
+        if not isinstance(constraints, dict):
+            constraints = {}
+        passed, failures = result_passes(contract, result)
+        verdict = (
+            '<span class="badge good">MET</span>'
+            if passed
+            else f'<span class="badge warn">GAP · {_escape(", ".join(failures))}</span>'
+        )
+        rows.append(
+            f'<tr class="{"best" if label == best_label else ""}"><td><strong>{_escape(label.title())}</strong></td><td>Frozen Benchmark</td>'
+            f'<td class="num">{_fmt(metrics.get("accuracy"))}</td><td class="num">{_fmt(metrics.get("recall_ng", result.get("value") if contract["name"] == "recall_ng" else None))}</td>'
+            f'<td class="num">{_fmt(metrics.get("precision_ng"))}</td><td class="num">{_fmt(metrics.get("f1_ng"))}</td>'
+            f'<td class="num">{_fmt(confusion.get("fn_ng_to_ok_false_accept"))}</td><td class="num">{_fmt(confusion.get("fp_ok_to_ng_false_reject"))}</td>'
+            f'<td class="num">{_fmt(constraints.get("unknown_predictions"))}</td><td>{verdict}</td></tr>'
+        )
+    return "\n".join(rows) or '<tr><td colspan="10">No frozen Benchmark metric has been committed yet.</td></tr>'
+
+
+def _stage_rows(entries: list[dict[str, Any]]) -> str:
+    rows: list[str] = []
+    for entry in entries:
+        status = str(entry.get("status", "unknown"))
+        badge = "good" if status == "ok" else "error"
+        rows.append(
+            f'<tr><td class="num">{_fmt(entry.get("seq"))}</td><td>{_fmt(entry.get("iter"))}</td><td>{_fmt(entry.get("stage"))}</td>'
+            f'<td><span class="badge {badge}">{_escape(status.upper())}</span></td><td class="num">{_escape(_duration(entry.get("duration_sec")))}</td>'
+            f'<td>{_fmt(entry.get("summary"))}</td></tr>'
+        )
+    return "\n".join(rows) or '<tr><td colspan="6">No stage has been committed yet.</td></tr>'
+
+
+def _first_number(payload: Any, names: tuple[str, ...]) -> Any:
+    if not isinstance(payload, dict):
+        return None
+    for name in names:
+        value = payload.get(name)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return value
+    for value in payload.values():
+        if isinstance(value, dict):
+            found = _first_number(value, names)
+            if found is not None:
+                return found
+    return None
+
+
+def _defect_breakdown(rows: list[dict[str, str]]) -> str:
+    counts: dict[str, int] = {}
+    for row in rows:
+        raw = row.get("defect_type") or row.get("anomaly_type") or row.get("reconstructed_image") or "unknown"
+        name = pathlib.Path(raw).stem.split("_")[0].split("+")[-1] or "unknown"
+        counts[name] = counts.get(name, 0) + 1
+    if not counts:
+        return "not available"
+    return ", ".join(f"{_escape(name)}: {count}" for name, count in sorted(counts.items()))
+
+
+def _augmentation_rows(state: dict[str, Any]) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    anomalygen = config.get("anomalygen", {})
+    if not isinstance(anomalygen, dict):
+        anomalygen = {}
+    requested = anomalygen.get("num_SDG")
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        return '<tr><td colspan="9">No augmentation has been committed yet.</td></tr>'
+    rows: list[str] = []
+    previous_train = 0
+    for label in sorted(iterations, key=_label_key):
+        if label == "baseline" or not isinstance(iterations[label], dict):
+            continue
+        phase = iterations[label]
+        sdg_rows = _csv_rows(phase.get("anomalygen_sdg_csv"))
+        generated = 0 if phase.get("anomalygen_skipped") else (len(sdg_rows) if sdg_rows else None)
+        summary = _optional_json(phase.get("mining_summary"))
+        raw = _first_number(summary, ("raw_candidates", "candidate_count", "input_rows", "raw_rows"))
+        kept = phase.get("mining_mined_count")
+        if kept is None:
+            kept = _first_number(summary, ("kept_rows", "kept_count", "output_rows"))
+        assembled = _json_records(phase.get("combined_training_json"))
+        train_count = len(assembled) if assembled else None
+        new_unique = max(train_count - previous_train, 0) if train_count is not None else None
+        if train_count is not None:
+            previous_train = train_count
+        allocated = _first_number(
+            _optional_json(phase.get("assemble_summary")),
+            ("amp_allocated", "allocated", "allocated_count"),
+        )
+        rows.append(
+            f'<tr><td><strong>{_escape(label.title())}</strong></td><td class="num">{_fmt(requested)}</td><td class="num">{_fmt(allocated)}</td>'
+            f'<td class="num">{_fmt(generated)}</td><td>{_defect_breakdown(sdg_rows)}</td><td class="num">{_fmt(raw)}</td>'
+            f'<td class="num">{_fmt(kept)}</td><td class="num">{_fmt(new_unique)}</td><td class="num">{_fmt(train_count)}</td></tr>'
+        )
+    return "\n".join(rows) or '<tr><td colspan="9">No augmentation has been committed yet.</td></tr>'
+
+
+def _terminal_iteration(label: str, phase: dict[str, Any], state: dict[str, Any], contract: dict[str, Any]) -> bool:
+    result = result_from_iteration(phase, contract)
+    if result is None:
+        return False
+    passed = result_passes(contract, result)[0]
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    reached_max = bool(match and int(match.group(1)) >= int(state.get("max_iterations", 0)))
+    return passed or reached_max
+
+
+def _artifact_rows(state: dict[str, Any], contract: dict[str, Any]) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    rows = [
+        f'<tr><td>Baseline</td><td>Base model reference</td><td><span class="badge good">RECORDED</span></td><td class="path">{_fmt(config.get("base_model"))}</td></tr>'
+    ]
+    fields = (
+        ("best_ckpt_path", "Checkpoint"),
+        ("benchmark_results_json", "Benchmark results"),
+        ("benchmark_metrics_summary", "Benchmark metrics"),
+        ("proxy_results_json", "Proxy results"),
+        ("proxy_gaps_summary", "Proxy RCCA"),
+        ("mining_targets_json", "Routing targets"),
+        ("anomalygen_sdg_csv", "AnomalyGen SDG_result.csv"),
+        ("anomalygen_sharegpt_json", "AnomalyGen ShareGPT"),
+        ("mining_mined_parquet", "Mined candidates"),
+        ("mining_summary", "Mining filter summary"),
+        ("combined_training_json", "Assembled Train JSON"),
+        ("validation_report", "Validation report"),
+    )
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        return "\n".join(rows)
+    for label in sorted(iterations, key=_label_key):
+        phase = iterations[label]
+        if not isinstance(phase, dict):
+            continue
+        terminal = _terminal_iteration(label, phase, state, contract)
+        for field, display in fields:
+            value = phase.get(field)
+            if value:
+                path = pathlib.Path(str(value))
+                badge = "good" if path.exists() else "warn"
+                state_text = "AVAILABLE" if path.exists() else "RECORDED"
+                rows.append(
+                    f'<tr><td>{_escape(label.title())}</td><td>{_escape(display)}</td><td><span class="badge {badge}">{state_text}</span></td><td class="path">{_fmt(value)}</td></tr>'
+                )
+            elif field in {"proxy_results_json", "proxy_gaps_summary"} and terminal:
+                rows.append(
+                    f'<tr><td>{_escape(label.title())}</td><td>{_escape(display)}</td><td><span class="badge muted">NOT RUN</span></td><td>not run (terminal iteration)</td></tr>'
+                )
+        if phase.get("anomalygen_skipped"):
+            rows.append(
+                f'<tr><td>{_escape(label.title())}</td><td>AnomalyGen</td><td><span class="badge muted">SKIPPED</span></td><td>documented skip: driving Proxy RCCA recorded zero false accepts</td></tr>'
+            )
+    return "\n".join(rows)
+
+
+def _warnings(
+    entries: list[dict[str, Any]], audit_report: dict[str, Any] | None
+) -> str:
+    messages: list[tuple[str, str]] = []
+    if audit_report:
+        for message in audit_report.get("errors", []):
+            messages.append(("error", str(message)))
+        for message in audit_report.get("warnings", []):
+            messages.append(("warn", str(message)))
+    for entry in entries:
+        if entry.get("status") == "error":
+            messages.append(
+                ("error", f"{entry.get('iter')}/{entry.get('stage')}: {entry.get('summary')}")
+            )
+    if not messages:
+        return '<div class="notice"><strong>No hard stops or audit warnings.</strong> Canonical state is internally consistent at render time.</div>'
+    return "\n".join(
+        f'<div class="notice {kind}"><strong>{"Hard stop" if kind == "error" else "Warning"}:</strong> {_escape(message)}</div>'
+        for kind, message in messages
+    )
+
+
+def _metric_chart(
+    candidates: list[tuple[str, dict[str, Any], dict[str, Any]]],
+    contract: dict[str, Any],
+) -> str:
+    if not candidates:
+        return '<div class="notice">Trend appears after the first frozen Benchmark metric is committed.</div>'
+    width, height = 720, 240
+    left, right, top, bottom = 54, 18, 18, 44
+    values = [float(result["value"]) for _, _, result in candidates]
+    target = float(contract["target"])
+    low, high = min([target, *values]), max([target, *values])
+    padding = max((high - low) * 0.15, abs(high or 1) * 0.06, 0.02)
+    low -= padding
+    high += padding
+    chart_w, chart_h = width - left - right, height - top - bottom
+
+    def x(index: int) -> float:
+        return left + chart_w * index / max(len(values) - 1, 1)
+
+    def y(value: float) -> float:
+        return top + (high - value) / (high - low) * chart_h
+
+    grid: list[str] = []
+    for index in range(5):
+        value = low + (high - low) * index / 4
+        ypos = y(value)
+        grid.append(f'<line x1="{left}" y1="{ypos:.1f}" x2="{width-right}" y2="{ypos:.1f}" stroke="rgba(255,255,255,.08)"/>')
+        grid.append(f'<text x="{left-8}" y="{ypos+4:.1f}" fill="#858585" font-size="11" text-anchor="end">{_escape(f"{value:.3g}")}</text>')
+    target_y = y(target)
+    points = " ".join(f"{x(index):.1f},{y(value):.1f}" for index, value in enumerate(values))
+    marks: list[str] = []
+    for index, ((label, _, result), value) in enumerate(zip(candidates, values)):
+        xpos, ypos = x(index), y(value)
+        passed = result_passes(contract, result)[0]
+        color = "#76b900" if passed else "#ffbc01"
+        marks.append(f'<circle cx="{xpos:.1f}" cy="{ypos:.1f}" r="6" fill="{color}" stroke="#232323" stroke-width="3"/>')
+        marks.append(f'<text x="{xpos:.1f}" y="{ypos-13:.1f}" fill="{color}" font-size="12" font-weight="700" text-anchor="middle">{_escape(f"{value:.4g}")}</text>')
+        marks.append(f'<text x="{xpos:.1f}" y="{height-12}" fill="#c2c2c2" font-size="12" text-anchor="middle">{_escape(label.title())}</text>')
+    return (
+        f'<svg viewBox="0 0 {width} {height}" role="img" aria-label="Benchmark KPI trend">'
+        + "".join(grid)
+        + f'<line x1="{left}" y1="{target_y:.1f}" x2="{width-right}" y2="{target_y:.1f}" stroke="#c2262d" stroke-width="1.5" stroke-dasharray="6 5"/>'
+        + f'<text x="{width-right}" y="{target_y-7:.1f}" fill="#ef8085" font-size="11" text-anchor="end">Target {_escape(f"{target:.4g}")}</text>'
+        + (f'<polyline points="{points}" fill="none" stroke="#76b900" stroke-width="2.5"/>' if len(values) > 1 else "")
+        + "".join(marks)
+        + "</svg>"
+    )
+
+
+def _atomic_write(path: pathlib.Path, text: str) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def render(
+    results_dir: pathlib.Path,
+    *,
+    audit_report: dict[str, Any] | None = None,
+) -> pathlib.Path:
+    results_dir = results_dir.expanduser().resolve()
+    state_path = results_dir / "deft_state.json"
+    if not state_path.is_file():
+        raise ValueError(f"state file not found: {state_path}")
+    state = _read_json(state_path)
+    if not isinstance(state, dict):
+        raise ValueError("deft_state.json root must be an object")
+    contract = contract_from_state(state)
+    entries = _read_log(results_dir / "loop_log.jsonl")
+    candidates = _metric_candidates(state, contract)
+    best_label: str | None = None
+    best_result: dict[str, Any] | None = None
+    if candidates:
+        best_label, _, best_result = pick_best(candidates, contract)
+    metric_passed = bool(best_result and result_passes(contract, best_result)[0])
+    terminal = bool(entries and entries[-1].get("stage") == "loop_stop")
+    has_error = any(entry.get("status") == "error" for entry in entries)
+    if audit_report:
+        run_status = str(audit_report.get("status", "IN_PROGRESS"))
+    elif terminal and has_error:
+        run_status = "FAILED"
+    elif terminal:
+        run_status = "COMPLETE"
+    else:
+        run_status = "IN_PROGRESS"
+
+    if run_status == "FAILED":
+        banner_class, banner_icon = "error", "!"
+        kpi_status = "RUN ENDED AT A HARD STOP"
+        kpi_copy = "Review the committed error event and audit findings below."
+    elif terminal and metric_passed:
+        banner_class, banner_icon = "", "✓"
+        kpi_status = "KPI MET"
+        kpi_copy = f"{best_label.title() if best_label else 'Best result'} satisfies the frozen Benchmark contract."
+    elif terminal and best_result:
+        banner_class, banner_icon = "warn", "i"
+        value = float(best_result["value"])
+        gap = value - contract["target"] if contract["operator"] in MINIMIZING_OPERATORS else contract["target"] - value
+        kpi_status = "BEST RESULT RECORDED"
+        kpi_copy = f"{abs(gap):.4g} from target after the approved iteration budget."
+    else:
+        banner_class, banner_icon = "warn", "i"
+        kpi_status = "LOOP IN PROGRESS"
+        kpi_copy = "This report refreshes automatically after every committed stage."
+
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    training = config.get("training", {})
+    if not isinstance(training, dict):
+        training = {}
+    num_gpus = training.get("num_gpus")
+    num_nodes = training.get("num_nodes")
+    compute_shape = f"{_fmt(num_nodes)} node(s) · {_fmt(num_gpus)} GPU(s)"
+    completed_iterations = sum(1 for label, _, _ in candidates if label != "baseline")
+    benchmark_hash = (
+        config.get("evaluation", {}).get("benchmark", {}).get("sha256")
+        if isinstance(config.get("evaluation"), dict)
+        and isinstance(config.get("evaluation", {}).get("benchmark"), dict)
+        else None
+    )
+    last_ts = entries[-1].get("ts") if entries else "not available"
+    best_metric = (
+        f"{_fmt(best_result['value'])} ({_escape(contract['display_name'])})"
+        if best_result
+        else "not available"
+    )
+    values = {
+        "GENERATED_DATE": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        "KPI_TARGET": _escape(render_target(contract)),
+        "ITERATIONS_RUN": str(completed_iterations),
+        "MAX_ITERATIONS": _fmt(state.get("max_iterations")),
+        "RUN_STATUS": _escape(run_status),
+        "BANNER_CLASS": banner_class,
+        "BANNER_ICON": banner_icon,
+        "KPI_STATUS": _escape(kpi_status),
+        "KPI_COPY": _escape(kpi_copy),
+        "PLATFORM": _fmt(config.get("platform")),
+        "MODEL": _fmt(config.get("base_model")),
+        "ANNOTATION_MODE": _fmt(config.get("annotation_mode", "bare_okng")),
+        "COMPUTE_SHAPE": compute_shape,
+        "STARTED_AT": _fmt(state.get("started_at")),
+        "FINISHED_AT": _fmt(last_ts),
+        "BEST_ITERATION": _escape(best_label.title() if best_label else "not available"),
+        "BEST_METRIC": best_metric,
+        "DATASET_ROWS_HTML": _dataset_rows(state),
+        "BENCHMARK_HASH": _fmt(benchmark_hash),
+        "PROMPT_EXAMPLES_HTML": _prompt_examples(state),
+        "METRIC_CHART_HTML": _metric_chart(candidates, contract),
+        "AUGMENTATION_ROWS_HTML": _augmentation_rows(state),
+        "METRIC_ROWS_HTML": _metric_rows(candidates, contract, best_label),
+        "STAGE_ROWS_HTML": _stage_rows(entries),
+        "ARTIFACT_ROWS_HTML": _artifact_rows(state, contract),
+        "WARNING_ROWS_HTML": _warnings(entries, audit_report),
+    }
+    rendered = TEMPLATE_PATH.read_text(encoding="utf-8")
+    for name, value in values.items():
+        rendered = rendered.replace("{{ " + name + " }}", str(value))
+    remaining = sorted(set(re.findall(r"\{\{\s+[A-Z0-9_]+\s+\}\}", rendered)))
+    if remaining:
+        raise ValueError("unfilled report placeholders: " + ", ".join(remaining))
+    required = (
+        "NVIDIA TAO · DEFT AOI",
+        "Run Configuration &amp; Outcome",
+        "Dataset Isolation",
+        "Prompt Examples",
+        "Iteration Metrics",
+        "Pipeline Execution",
+        "Augmentation Volume",
+        "Artifacts",
+        "Hard Stops / Warnings",
+        "--nvidia-green: #76b900",
+    )
+    missing = [token for token in required if token not in rendered]
+    if missing:
+        raise ValueError("rendered report is missing required content: " + ", ".join(missing))
+    output = results_dir / REPORT_NAME
+    _atomic_write(output, rendered)
+    return output
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--require-terminal", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        from audit_deft_run import audit
+
+        report = audit(args.results_dir.expanduser().resolve())
+        if report["status"] == "INVALID":
+            raise ValueError("audit failed: " + "; ".join(report["errors"]))
+        if args.require_terminal and not report["terminal"]:
+            raise ValueError("--require-terminal requested but loop_stop is not committed")
+        output = render(args.results_dir, audit_report=report)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"render_report: {exc}", file=sys.stderr)
+        return 2
+    print(f"render_report: wrote {output} ({output.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_bare.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_bare.py
@@ -629,6 +629,18 @@ class StateMachineTests(unittest.TestCase):
             report = audit_deft_run.audit(results)
             self.assertEqual(report["status"], "COMPLETE")
             self.assertEqual(report["best_iteration"], "baseline")
+            html_report = results / "DEFT_Loop_Report.html"
+            self.assertTrue(html_report.is_file())
+            self.assertIn("KPI MET", html_report.read_text())
+            self.assertIsNone(
+                audit_deft_run._completion_report_error(results)
+            )
+            self.assertEqual(
+                audit_deft_run.main(
+                    ["--results-dir", str(results), "--require-complete"]
+                ),
+                0,
+            )
             phase = json.loads(
                 (results / "deft_state.json").read_text()
             )["iterations"]["baseline"]

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_bare.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_bare.py
@@ -503,6 +503,21 @@ class IsolationAndMetricTests(unittest.TestCase):
 
 
 class StateMachineTests(unittest.TestCase):
+    def test_stage_commit_requires_positive_measured_duration(self) -> None:
+        base = [
+            "--results-dir",
+            "/tmp/cosmos3-duration-contract",
+            "--iter-label",
+            "baseline",
+            "--stage",
+            "loop_stop",
+            "--summary",
+            "done",
+        ]
+        with self.assertRaises(SystemExit):
+            commit_stage._parser().parse_args(base)
+        self.assertEqual(commit_stage.main([*base, "--duration-sec", "0"]), 2)
+
     def test_baseline_commit_to_completion(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)
@@ -530,6 +545,8 @@ class StateMachineTests(unittest.TestCase):
                     str(workspace),
                     "--platform",
                     "docker",
+                    "--gpu-model",
+                    "NVIDIA H100 80GB HBM3",
                     "--max-iterations",
                     "1",
                     "--cosmos-container",
@@ -571,6 +588,8 @@ class StateMachineTests(unittest.TestCase):
                         "evaluate_benchmark",
                         "--benchmark-results",
                         str(benchmark_results),
+                        "--duration-sec",
+                        "1",
                         "--summary",
                         "Benchmark evaluation complete",
                     ]
@@ -604,6 +623,8 @@ class StateMachineTests(unittest.TestCase):
                         str(benchmark_dir / "metrics_summary.json"),
                         "--metric-result",
                         str(benchmark_dir / "metric_result.json"),
+                        "--duration-sec",
+                        "1",
                         "--summary",
                         "Benchmark KPI met",
                     ]
@@ -620,6 +641,8 @@ class StateMachineTests(unittest.TestCase):
                         "baseline",
                         "--stage",
                         "loop_stop",
+                        "--duration-sec",
+                        "1",
                         "--summary",
                         "Benchmark KPI met",
                     ]
@@ -673,6 +696,8 @@ class StateMachineTests(unittest.TestCase):
                         str(workspace),
                         "--platform",
                         "docker",
+                        "--gpu-model",
+                        "NVIDIA H100 80GB HBM3",
                         "--max-iterations",
                         "2",
                         "--cosmos-container",
@@ -693,6 +718,8 @@ class StateMachineTests(unittest.TestCase):
                         "baseline",
                         "--stage",
                         stage,
+                        "--duration-sec",
+                        "1",
                         "--summary",
                         f"baseline {stage}",
                         *extra,
@@ -779,6 +806,8 @@ class StateMachineTests(unittest.TestCase):
                 str(workspace),
                 "--platform",
                 "docker",
+                "--gpu-model",
+                "NVIDIA H100 80GB HBM3",
                 "--max-iterations",
                 "1",
                 "--cosmos-container",
@@ -822,6 +851,8 @@ class StateMachineTests(unittest.TestCase):
                             str(workspace),
                             "--platform",
                             "docker",
+                            "--gpu-model",
+                            "NVIDIA H100 80GB HBM3",
                             "--max-iterations",
                             "1",
                             "--cosmos-container",
@@ -890,6 +921,8 @@ class StateMachineTests(unittest.TestCase):
                         str(workspace),
                         "--platform",
                         "docker",
+                        "--gpu-model",
+                        "NVIDIA H100 80GB HBM3",
                         "--max-iterations",
                         "1",
                         "--cosmos-container",
@@ -913,6 +946,8 @@ class StateMachineTests(unittest.TestCase):
                         "evaluate_benchmark",
                         "--status",
                         "error",
+                        "--duration-sec",
+                        "1",
                         "--summary",
                         "cosmos-rl-evaluate exited 1 before writing results",
                     ]
@@ -955,6 +990,8 @@ class StateMachineTests(unittest.TestCase):
                         str(workspace),
                         "--platform",
                         "docker",
+                        "--gpu-model",
+                        "NVIDIA H100 80GB HBM3",
                         "--max-iterations",
                         "2",
                         "--cosmos-container",
@@ -975,6 +1012,8 @@ class StateMachineTests(unittest.TestCase):
                         label,
                         "--stage",
                         stage,
+                        "--duration-sec",
+                        "1",
                         "--summary",
                         f"{label} {stage}",
                         *extra,
@@ -1103,6 +1142,8 @@ class StateMachineTests(unittest.TestCase):
                         str(workspace),
                         "--platform",
                         "docker",
+                        "--gpu-model",
+                        "NVIDIA H100 80GB HBM3",
                         "--max-iterations",
                         "1",
                         "--cosmos-container",
@@ -1124,6 +1165,8 @@ class StateMachineTests(unittest.TestCase):
                             label,
                             "--stage",
                             stage,
+                            "--duration-sec",
+                            "1",
                             "--summary",
                             f"{label} {stage}",
                             *extra,
@@ -1243,6 +1286,8 @@ class StateMachineTests(unittest.TestCase):
                         "--stage",
                         "anomalygen",
                         "--skip",
+                        "--duration-sec",
+                        "1",
                         "--summary",
                         "attempted unjustified skip",
                     ]
@@ -1252,6 +1297,9 @@ class StateMachineTests(unittest.TestCase):
 
             sdg_csv = write_sdg_output(
                 results / "iter1/anomalygen/sdg", ["PCB+bridge_00000"]
+            )
+            allocation = write_json(
+                results / "iter1/anomalygen/sdg/allocation.json", {"bridge": 1}
             )
             synthetic_json = results / "iter1/anomalygen/sdg_sharegpt.json"
             self.assertEqual(
@@ -1279,8 +1327,18 @@ class StateMachineTests(unittest.TestCase):
                 "anomalygen",
                 "--anomalygen-sdg",
                 str(sdg_csv),
+                "--anomalygen-allocation",
+                str(allocation),
                 "--anomalygen-sharegpt",
                 str(synthetic_json),
+            )
+            state = json.loads((results / "deft_state.json").read_text())
+            self.assertEqual(
+                state["iterations"]["iter1"]["anomalygen_amp_allocated"], 1
+            )
+            self.assertEqual(
+                state["iterations"]["iter1"]["anomalygen_allocation_json"],
+                str(allocation.resolve()),
             )
 
             mining_dir = results / "iter1/mining"

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_bare.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_bare.py
@@ -12,6 +12,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 import yaml
 
@@ -199,6 +200,26 @@ class BareAnnotationTests(unittest.TestCase):
             patch_eval_image_cap.apply_cap("engine = LLM(model=ckpt)\n", 2)
         with self.assertRaisesRegex(ValueError, "exactly one image cap"):
             patch_eval_image_cap.apply_cap(source + source, 2)
+
+    def test_eval_image_cap_probe_times_out(self) -> None:
+        timeout = patch_eval_image_cap.subprocess.TimeoutExpired(
+            cmd=["docker", "run"], timeout=120
+        )
+        with mock.patch.object(
+            patch_eval_image_cap.shutil, "which", return_value="/usr/bin/docker"
+        ), mock.patch.object(
+            patch_eval_image_cap.subprocess, "run", side_effect=timeout
+        ) as run:
+            with self.assertRaisesRegex(
+                ValueError,
+                "timed out after 120s.*pre-pull the image",
+            ):
+                patch_eval_image_cap.read_from_image(
+                    "example/cosmos:1",
+                    patch_eval_image_cap.CONTAINER_PATH,
+                    docker="docker",
+                )
+        self.assertEqual(run.call_args.kwargs["timeout"], 120)
 
     def test_media_root_one_level_too_deep_is_diagnosed(self) -> None:
         """Annotations resolve from the workspace root, not workspace/images."""

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_report_rendering.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+import tempfile
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+for module_name in ("audit_deft_run", "metric_contract", "render_report"):
+    sys.modules.pop(module_name, None)
+sys.path.insert(0, str(SCRIPTS))
+
+import audit_deft_run  # noqa: E402
+import render_report  # noqa: E402
+
+
+CHANGE_TEMPLATE = (
+    SKILL_ROOT.parent
+    / "tao-run-deft-aoi"
+    / "references"
+    / "DEFT_Loop_Report.html"
+)
+COSMOS_TEMPLATE = SKILL_ROOT / "references" / "DEFT_Loop_Report.html"
+
+
+def css_rules(template: pathlib.Path) -> dict[str, dict[str, str]]:
+    text = template.read_text(encoding="utf-8")
+    css = text.split("<style>", 1)[1].split("</style>", 1)[0]
+    css = css.split("@media", 1)[0]
+    css = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+    rules: dict[str, dict[str, str]] = {}
+    for selector_group, body in re.findall(r"([^{}]+)\{([^{}]*)\}", css):
+        for selector in selector_group.split(","):
+            selector = selector.strip()
+            if selector.startswith("/*") or selector.startswith("@"):
+                continue
+            declarations = rules.setdefault(selector, {})
+            for declaration in body.split(";"):
+                if ":" not in declaration:
+                    continue
+                name, value = declaration.split(":", 1)
+                declarations[name.strip()] = " ".join(value.split())
+    return rules
+
+
+def record(label: str, prompt: str = "Inspect.") -> dict:
+    return {
+        "images": ["target.png", "golden.png"],
+        "conversations": [
+            {"from": "human", "value": prompt},
+            {"from": "gpt", "value": label},
+        ],
+    }
+
+
+class CosmosReportRenderingTests(unittest.TestCase):
+    def test_matches_changenet_visual_contract_and_single_column_skeleton(self) -> None:
+        change = css_rules(CHANGE_TEMPLATE)
+        cosmos = css_rules(COSMOS_TEMPLATE)
+        contract = {
+            ":root": (
+                "--nvidia-green",
+                "--nvidia-green-light",
+                "--nvidia-yellow",
+                "--nvidia-red",
+                "--bg-dark",
+                "--bg-card",
+                "--bg-panel",
+                "--text-primary",
+                "--text-secondary",
+                "--text-muted",
+                "--border-soft",
+            ),
+            "body": (
+                "font-family",
+                "background",
+                "color",
+                "display",
+                "flex-direction",
+                "align-items",
+                "gap",
+                "padding",
+                "font-size",
+            ),
+            ".card": (
+                "width",
+                "background",
+                "border-radius",
+                "padding",
+                "box-shadow",
+                "position",
+                "overflow",
+            ),
+            ".card::before": ("height", "background"),
+            ".header": (
+                "display",
+                "justify-content",
+                "align-items",
+                "margin-bottom",
+            ),
+            ".chart-title": (
+                "font-size",
+                "font-weight",
+                "letter-spacing",
+                "color",
+                "line-height",
+            ),
+            ".chart-subtitle": (
+                "font-size",
+                "font-weight",
+                "color",
+                "margin-top",
+            ),
+            ".hero": (
+                "width",
+                "background",
+                "border-radius",
+                "padding",
+                "box-shadow",
+                "position",
+                "overflow",
+            ),
+            ".hero::before": ("height", "background"),
+            ".hero h1": (
+                "font-size",
+                "font-weight",
+                "letter-spacing",
+                "color",
+            ),
+            ".hero .meta": (
+                "display",
+                "gap",
+                "font-size",
+                "color",
+                "margin-top",
+                "flex-wrap",
+            ),
+            ".hero .meta-item strong": ("color", "font-weight"),
+            ".hero .meta-item .value": ("color", "font-weight"),
+            ".data-table": (
+                "width",
+                "border-collapse",
+                "margin-top",
+                "font-size",
+            ),
+            ".data-table th": (
+                "text-align",
+                "padding",
+                "font-size",
+                "font-weight",
+                "letter-spacing",
+                "text-transform",
+                "color",
+                "background",
+                "border-bottom",
+            ),
+            ".data-table td": (
+                "padding",
+                "color",
+                "border-bottom",
+                "vertical-align",
+            ),
+        }
+        for selector, properties in contract.items():
+            with self.subTest(selector=selector):
+                self.assertIn(selector, change)
+                self.assertIn(selector, cosmos)
+                self.assertEqual(
+                    {name: change[selector][name] for name in properties},
+                    {name: cosmos[selector][name] for name in properties},
+                )
+
+        cosmos_html = COSMOS_TEMPLATE.read_text(encoding="utf-8")
+        self.assertIn(".page, .grid { display: contents; }", cosmos_html)
+        self.assertNotIn('class="card half"', cosmos_html)
+        self.assertEqual(cosmos_html.count('class="card"'), 9)
+        self.assertEqual(cosmos_html.count('class="header"'), 9)
+
+    def test_nvidia_sections_terminal_proxy_semantics_and_escaping(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            results = pathlib.Path(temporary) / "results"
+            workspace = pathlib.Path(temporary) / "workspace"
+            results.mkdir()
+            annotations: dict[str, str] = {}
+            inspection_prompt = "Compare <script>alert('prompt')</script> with golden."
+            for role, label in (("proxy", "NG"), ("benchmark", "NG"), ("mining", "OK")):
+                path = workspace / "annotations" / f"{role}.json"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    json.dumps([record(label, inspection_prompt)]), encoding="utf-8"
+                )
+                annotations[role] = str(path)
+            contract = {
+                "name": "recall_ng",
+                "display_name": "NG recall",
+                "operator": ">=",
+                "target": 1.0,
+                "unit": "",
+                "evaluator": {
+                    "type": "artifact",
+                    "producer": "scripts/analyze_gaps.py",
+                    "path_template": str(
+                        results / "{iter_label}/benchmark_metrics/metric_result.json"
+                    ),
+                },
+                "constraints": [
+                    {
+                        "name": "unknown_predictions",
+                        "display_name": "Unknown predictions",
+                        "operator": "<=",
+                        "target": 0,
+                        "unit": "",
+                    }
+                ],
+            }
+            state = {
+                "version": 3,
+                "workflow": "tao-run-deft-aoi-cosmos3",
+                "started_at": "2026-08-04T00:00:00+00:00",
+                "kpi_target": "NG recall >= 1",
+                "metric_contract": contract,
+                "results_dir": str(results),
+                "max_iterations": 1,
+                "current_iteration": 1,
+                "config": {
+                    "platform": "docker",
+                    "base_model": "nvidia/Cosmos3-Nano",
+                    "annotation_mode": "bare_okng",
+                    "annotations": annotations,
+                    "evaluation": {"benchmark": {"sha256": "abc123"}},
+                    "training": {"num_nodes": 1, "num_gpus": 2},
+                    "anomalygen": {"num_SDG": 20},
+                },
+                "iterations": {
+                    "iter1": {
+                        "status": "complete",
+                        "stage_completed": "benchmark_metrics",
+                        "benchmark_results_json": str(results / "iter1/benchmark/results.json"),
+                        "metric_result": {
+                            "name": "recall_ng",
+                            "value": 0.75,
+                            "unit": "",
+                            "constraints": {"unknown_predictions": 0},
+                            "metrics": {
+                                "accuracy": 0.8,
+                                "recall_ng": 0.75,
+                                "precision_ng": 1.0,
+                                "f1_ng": 0.857,
+                            },
+                            "confusion": {
+                                "fn_ng_to_ok_false_accept": 1,
+                                "fp_ok_to_ng_false_reject": 0,
+                            },
+                        },
+                    }
+                },
+                "_completed_step_values": [],
+                "_status_values": [],
+            }
+            (results / "deft_state.json").write_text(json.dumps(state), encoding="utf-8")
+            entries = [
+                {
+                    "seq": 1,
+                    "ts": "2026-08-04T00:01:00Z",
+                    "iter": "iter1",
+                    "stage": "benchmark_metrics",
+                    "status": "ok",
+                    "summary": "<img src=x onerror=alert(1)>",
+                    "duration_sec": 12,
+                },
+                {
+                    "seq": 2,
+                    "ts": "2026-08-04T00:02:00Z",
+                    "iter": "iter1",
+                    "stage": "loop_stop",
+                    "status": "ok",
+                    "summary": "max iterations",
+                    "duration_sec": 0,
+                },
+            ]
+            (results / "loop_log.jsonl").write_text(
+                "".join(json.dumps(entry) + "\n" for entry in entries),
+                encoding="utf-8",
+            )
+            output = render_report.render(results)
+            text = output.read_text(encoding="utf-8")
+            for heading in (
+                "NVIDIA TAO · DEFT AOI",
+                "Run Configuration &amp; Outcome",
+                "Dataset Isolation",
+                "Prompt Examples",
+                "Iteration Metrics",
+                "Pipeline Execution",
+                "Augmentation Volume",
+                "Artifacts",
+                "Hard Stops / Warnings",
+            ):
+                self.assertIn(heading, text)
+            self.assertIn("not run (terminal iteration)", text)
+            self.assertIn("Proxy · Benchmark · Mining", text)
+            self.assertIn("3 RECORDS", text)
+            self.assertIn("Compare &lt;script&gt;alert(&#x27;prompt&#x27;)&lt;/script&gt; with golden.", text)
+            self.assertNotIn(inspection_prompt, text)
+            self.assertIn("Exact assistant output", text)
+            self.assertIn("&lt;img src=x onerror=alert(1)&gt;", text)
+            self.assertNotIn("<img src=x onerror=alert(1)>", text)
+            self.assertNotRegex(text, r"\{\{\s+[A-Z0-9_]+\s+\}\}")
+            self.assertIsNone(audit_deft_run._completion_report_error(results))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_report_rendering.py
@@ -235,7 +235,11 @@ class CosmosReportRenderingTests(unittest.TestCase):
                     "annotation_mode": "bare_okng",
                     "annotations": annotations,
                     "evaluation": {"benchmark": {"sha256": "abc123"}},
-                    "training": {"num_nodes": 1, "num_gpus": 2},
+                    "training": {
+                        "num_nodes": 1,
+                        "num_gpus": 2,
+                        "gpu_model": "NVIDIA H100 80GB HBM3",
+                    },
                     "anomalygen": {"num_SDG": 20},
                 },
                 "iterations": {
@@ -264,6 +268,37 @@ class CosmosReportRenderingTests(unittest.TestCase):
                 "_completed_step_values": [],
                 "_status_values": [],
             }
+            mining_summary = results / "iter1/mining/mining_summary.json"
+            mining_summary.parent.mkdir(parents=True, exist_ok=True)
+            mining_summary.write_text(
+                json.dumps({"candidate_count": 170, "kept_count": 170}),
+                encoding="utf-8",
+            )
+            assemble_summary = results / "iter1/assemble/assemble_summary.json"
+            assemble_summary.parent.mkdir(parents=True, exist_ok=True)
+            assemble_summary.write_text(
+                json.dumps(
+                    {
+                        "output_records": 170,
+                        "unique_target_images": {"new_after_dedup": 170},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            sdg_csv = results / "iter1/anomalygen/sdg/SDG_result.csv"
+            sdg_csv.parent.mkdir(parents=True, exist_ok=True)
+            sdg_csv.write_text("image,label\na.png,NG\nb.png,NG\n", encoding="utf-8")
+            allocation = results / "iter1/anomalygen/sdg/allocation.json"
+            allocation.write_text(json.dumps({"bridge": 20}), encoding="utf-8")
+            state["iterations"]["iter1"].update(
+                {
+                    "mining_summary": str(mining_summary),
+                    "assemble_summary": str(assemble_summary),
+                    "anomalygen_sdg_csv": str(sdg_csv),
+                    "anomalygen_allocation_json": str(allocation),
+                    "anomalygen_amp_allocated": 20,
+                }
+            )
             (results / "deft_state.json").write_text(json.dumps(state), encoding="utf-8")
             entries = [
                 {
@@ -294,6 +329,7 @@ class CosmosReportRenderingTests(unittest.TestCase):
             for heading in (
                 "NVIDIA TAO · DEFT AOI",
                 "Run Configuration &amp; Outcome",
+                "Benchmark KPI Trend",
                 "Dataset Isolation",
                 "Prompt Examples",
                 "Iteration Metrics",
@@ -304,15 +340,84 @@ class CosmosReportRenderingTests(unittest.TestCase):
             ):
                 self.assertIn(heading, text)
             self.assertIn("not run (terminal iteration)", text)
+            self.assertIn("1 node(s) · 2 GPU(s) · NVIDIA H100 80GB HBM3", text)
+            self.assertIn("1 iters × ~12s = 12s total time", text)
+            self.assertIn("KNN Raw Mined", text)
+            self.assertIn("SDG Generated", text)
+            self.assertIn("New Unique Images (After Dedup)", text)
+            self.assertIn(">170</td>", text)
+            self.assertIn(">+170</td>", text)
+            self.assertIn(">20</td><td class=\"num\">2</td>", text)
+            self.assertLess(
+                text.index("Run Configuration &amp; Outcome"),
+                text.index("Benchmark KPI Trend"),
+            )
+            self.assertLess(
+                text.index("Benchmark KPI Trend"), text.index("Dataset Isolation")
+            )
             self.assertIn("Proxy · Benchmark · Mining", text)
             self.assertIn("3 RECORDS", text)
             self.assertIn("Compare &lt;script&gt;alert(&#x27;prompt&#x27;)&lt;/script&gt; with golden.", text)
             self.assertNotIn(inspection_prompt, text)
             self.assertIn("Exact assistant output", text)
+            self.assertNotIn("BEST RESULT RECORDED", text)
+            self.assertNotIn("after the approved iteration budget", text)
+            self.assertNotIn('<div class="icon">i</div>', text)
+            self.assertNotIn("kpi-banner warn", text)
             self.assertIn("&lt;img src=x onerror=alert(1)&gt;", text)
             self.assertNotIn("<img src=x onerror=alert(1)>", text)
             self.assertNotRegex(text, r"\{\{\s+[A-Z0-9_]+\s+\}\}")
             self.assertIsNone(audit_deft_run._completion_report_error(results))
+
+    def test_growth_uses_cumulative_delta_not_batch_unique_diagnostic(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            results = pathlib.Path(temporary)
+            iterations: dict[str, dict[str, str]] = {}
+            for number, raw, generated, total, batch_unique in (
+                (1, 13, 20, 33, 33),
+                (2, 10, 20, 36, 23),
+            ):
+                root = results / f"iter{number}"
+                mining = root / "mining_summary.json"
+                mining.parent.mkdir(parents=True)
+                mining.write_text(json.dumps({"input_rows": raw}), encoding="utf-8")
+                sdg = root / "SDG_result.csv"
+                sdg.write_text(
+                    "image,label\n"
+                    + "".join(f"sdg-{index}.png,NG\n" for index in range(generated)),
+                    encoding="utf-8",
+                )
+                assemble = root / "assemble_summary.json"
+                assemble.write_text(
+                    json.dumps(
+                        {
+                            "output_records": total,
+                            "unique_target_images": {
+                                "new_after_dedup": batch_unique
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                iterations[f"iter{number}"] = {
+                    "mining_summary": str(mining),
+                    "anomalygen_sdg_csv": str(sdg),
+                    "assemble_summary": str(assemble),
+                }
+
+            rows = render_report._growth_rows({"iterations": iterations})
+            self.assertIn(
+                '<strong>Iter1</strong></td><td class="num">13</td>'
+                '<td class="num">20</td><td class="num">33</td>'
+                '<td class="num">33</td><td class="num">+33</td>',
+                rows,
+            )
+            self.assertIn(
+                '<strong>Iter2</strong></td><td class="num">10</td>'
+                '<td class="num">20</td><td class="num">3</td>'
+                '<td class="num">36</td><td class="num">+3</td>',
+                rows,
+            )
 
 
 if __name__ == "__main__":

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_report_rendering.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/skills/applications/tao-run-deft-aoi/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi/SKILL.md
@@ -207,9 +207,16 @@ Execute the loop in this order (full detail in `references/pipeline-and-state.md
 2. **Baseline.** If `deft_state.json` already has `iterations.baseline.stage_completed == "train"` and a `best_ckpt_path` pointing at an existing file (the upstream `automl-deft-pipeline` pre-seeds these from its Phase 1 AutoML winner — see its Phase 1 → Phase 2 handoff), **skip the train sub-step** and resume at `inference -> evaluate` against the pre-seeded checkpoint. Otherwise run `train -> inference -> evaluate` by invoking the `tao-skill-bank:tao-train-visual-changenet` skill. Evaluate with the approved contract and evaluator in `references/metric-contract.md`. Either way, then `rca` by invoking `tao-skill-bank:tao-analyze-gaps-visual-changenet`. Read `references/visual-changenet.md`, `references/metric-contract.md`, and `references/tao-analyze-gaps-visual-changenet.md` first for DEFT-loop-specific args.
 3. **Iterate.** For each iteration up to `max_iterations`, execute Pipeline steps 1-7. Between steps run the audit and follow its one-line disk-backed next action; do not print full state or logs.
 4. **Stop** when the KPI target is met, `max_iterations` is reached, or a hard-stop gate fires (silent-drop, AMP allocation mismatch, train/val leakage). Never auto-retry hard stops.
-5. **Render** `results/DEFT_Loop_Report.html` after each completed iteration (and once more at loop end) by spawning the `reporter` subagent (`agents/reporter.md`). Per-stage renders are not done — every stage already appends one line to `loop_log.jsonl`, which is enough for a tail-watching user; the HTML render carries an iteration's worth of state and one render per iteration keeps the per-loop token cost roughly linear in iteration count, not in stage count. Do not render inline.
+5. **Render automatically.** `scripts/init_deft_state.py` writes the initial
+   `results/DEFT_Loop_Report.html`; every successful `commit_stage.py` call
+   then refreshes it through the deterministic `scripts/render_report.py`
+   post-commit hook. The `loop_stop` commit therefore produces the final
+   report even when the parent context is saturated. If a hook reports an
+   error, run `scripts/render_report.py --results-dir "${RESULTS_DIR}"`
+   directly after repairing the named presentation input; never hand-author
+   report HTML.
 
-All pipeline stages run inline in the parent context. Prefer invoking the underlying `tao-skill-bank:*` skills directly via the Skill tool, layering DEFT-loop conventions on top via the matching `references/*.md` file. If the mapped Skill tool is unavailable but Docker, the skill source tree, and the stage reference modules are present, use the documented direct-container fallback in `references/scripts-and-agents.md`; before the first fallback stage, write `execution_path=direct-container` to the transcript, and for each fallback stage record the mapped underlying skill name plus the exact direct command used. Preserve the same `deft_state.json`, `loop_log.jsonl`, artifact, and audit contracts. The **only** delegated work in the Skill-tool path is HTML report rendering, handled by the `reporter` subagent in a fresh context so an end-of-loop render is never silently dropped when the parent's context is saturated.
+All pipeline stages run inline in the parent context. Prefer invoking the underlying `tao-skill-bank:*` skills directly via the Skill tool, layering DEFT-loop conventions on top via the matching `references/*.md` file. If the mapped Skill tool is unavailable but Docker, the skill source tree, and the stage reference modules are present, use the documented direct-container fallback in `references/scripts-and-agents.md`; before the first fallback stage, write `execution_path=direct-container` to the transcript, and for each fallback stage record the mapped underlying skill name plus the exact direct command used. Preserve the same `deft_state.json`, `loop_log.jsonl`, artifact, audit, and script-backed report contracts. HTML rendering is not delegated.
 
 ### Using Bundled Scripts
 
@@ -217,8 +224,8 @@ Run bundled scripts through `<skill_root>/scripts/deft_python.sh`; do not rely
 on harness-specific helpers or a shell export surviving the next tool call.
 Resolve every path argument to an absolute host path first. Use
 `commit_stage.py` for all state/log writes. See
-`references/scripts-and-agents.md` for script invocations, the reporter spawn
-contract, stage mapping, direct-container fallback, and path invariants.
+`references/scripts-and-agents.md` for script invocations, the automatic
+report hook, stage mapping, direct-container fallback, and path invariants.
 
 ## Stage Reference Modules
 
@@ -240,7 +247,7 @@ directory to `/results/iterN`.
 | Customer metric contract and evaluator adapter | `references/metric-contract.md` | Primary metric schema, comparison direction, evaluator JSON, constraints, evaluate commit, and compatibility behavior |
 | Pre-Flight checks, defaults, Pre-Flight Summary template, runtime estimate | `references/preflight.md` | The 10 ordered Pre-Flight checks, required input `max_iterations`, all defaults, the full Pre-Flight Summary table + populate commands, and the per-iteration runtime estimate |
 | Pipeline steps, state/logging, stage execution, reports, runtime behavior | `references/pipeline-and-state.md` | Baseline pre-seed/skip-train logic, the 7 iteration Pipeline steps, `deft_state.json` + `loop_log.jsonl` schema and `seq` cadence, post-stage check, per-iteration HTML render, and the loop-end sequence |
-| Bundled scripts, reporter agent, stage modules, AutoML pitfall | `references/scripts-and-agents.md` | Available Scripts table, `agents/reporter.md` spawn contract, Stage Reference Modules table, path-rule invariant, AutoML-policy spec trap |
+| Bundled scripts, report hook, stage modules, AutoML pitfall | `references/scripts-and-agents.md` | Available Scripts table, deterministic report renderer and post-commit hook, Stage Reference Modules table, path-rule invariant, AutoML-policy spec trap |
 
 **Required input — `max_iterations`.** No default; ask the user if not supplied and do not proceed past Pre-Flight without it. If the user gives a time limit instead, convert it to an estimated `max_iterations` using the per-iteration runtime figure in `references/preflight.md` and surface the estimate for confirmation. All other run parameters have defaults — never ask about a parameter with a default. The full defaults list and the Pre-Flight Summary the user approves at the single gate are in `references/preflight.md`.
 

--- a/skills/applications/tao-run-deft-aoi/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi/SKILL.md
@@ -38,7 +38,8 @@ Treat this as a disk-backed state machine, not as a prose recipe.
    constraints. The approved `metric_contract` is the source of truth for
    evaluation, checkpoint selection, completion, and reporting.
 2. After the user approves the Summary, initialize `deft_state.json` once with
-   `scripts/init_deft_state.py`. Never hand-author or reinitialize it on resume.
+   `scripts/init_deft_state.py`, passing Preflight's exact GPU model/memory as
+   `--gpu-model`. Never hand-author or reinitialize it on resume.
 3. Run every bundled or inline host-Python command through
    `scripts/deft_python.sh`; it selects an already-provisioned interpreter on
    every shell invocation, so tool calls do not depend on a prior `export`.
@@ -65,6 +66,8 @@ Treat this as a disk-backed state machine, not as a prose recipe.
    fresh run; a later successful audit cannot legitimize fabricated history.
    For evaluate, pass the metric result,
    checkpoint, inference CSV, and threshold directly to `commit_stage.py`.
+   Pass positive measured `--duration-sec` from backend elapsed time or a host
+   timer; missing/zero durations are rejected.
 6. Claim the loop complete only when this exits zero:
 
    ```bash

--- a/skills/applications/tao-run-deft-aoi/agents/reporter.md
+++ b/skills/applications/tao-run-deft-aoi/agents/reporter.md
@@ -1,152 +1,25 @@
-# DEFT Loop Reporter Agent
+# DEFT Loop Reporter Compatibility Wrapper
 
-Render `${RESULTS_DIR}/DEFT_Loop_Report.html` from the canonical disk state, following the protocol in `references/REPORT_RENDERING.md` and the template at `references/DEFT_Loop_Report.html`.
+Use this wrapper only when a runtime explicitly invokes the legacy reporter
+agent. Normal workflow execution does not spawn a reporting agent:
+`init_deft_state.py` and `commit_stage.py` already invoke the deterministic
+renderer.
 
-## Role
+Inputs:
 
-The main skill (`tao-run-deft-aoi`) re-renders `DEFT_Loop_Report.html` after each completed iteration and once more at loop end. (Earlier revisions rendered after every stage; the cost dominated for short stages and the per-iteration cadence captures the same information.) By the time the loop finishes, the parent's context window is often saturated and the final render gets silently dropped. This agent owns rendering as a fresh, isolated task: every invocation starts with no inherited context and reads disk as the single source of truth, so a missed end-of-loop render is impossible.
+- `results_dir`: absolute DEFT run directory;
+- `skill_root`: absolute `tao-run-deft-aoi` skill directory;
+- `trigger`: optional legacy value; use it only to decide whether the run must
+  already be terminal.
 
-You are spawned by the parent via the Task tool. You return one line of status and exit; the parent does not depend on your in-memory state.
-
-## Inputs
-
-You receive these parameters in your prompt:
-
-- **results_dir**: absolute path to `${RESULTS_DIR}` — contains `deft_state.json`, `loop_log.jsonl`, `baseline/`, `iter*/`, `iter*_summary.md`
-- **skill_root**: absolute path to the `tao-run-deft-aoi` skill directory — `references/DEFT_Loop_Report.html` and `references/REPORT_RENDERING.md` live here
-- **trigger** (optional, default `"after-iteration"`): one of `"after-iteration"` (mid-loop render — most common), `"loop-end"` (final render after `loop_stop`), or the legacy `"after-stage"` (deprecated; behaved identically to `after-iteration` for placeholder logic but ran much more often). Controls in-progress stub behavior per `references/REPORT_RENDERING.md` § *In-progress rendering rules* — anything other than `"loop-end"` applies the in-progress rules.
-
-Before reading report inputs, run:
+Run exactly one command:
 
 ```bash
-${skill_root}/scripts/deft_python.sh ${skill_root}/scripts/audit_deft_run.py --results-dir ${results_dir}
+"${skill_root}/scripts/deft_python.sh" \
+  "${skill_root}/scripts/render_report.py" \
+  --results-dir "${results_dir}"
 ```
 
-For `trigger="loop-end"`, also pass `--require-terminal`. If the audit exits
-non-zero, hard-stop and print its errors; never render a completion report from
-inconsistent or non-terminal state.
-
-## Process
-
-### Step 1 — Load canonical disk state
-
-1. Read `${results_dir}/deft_state.json` (metric contract, max_iterations, per-iteration metric results, best checkpoint, optional threshold). Read `references/metric-contract.md` and use its configured primary metric.
-2. Read every line of `${results_dir}/loop_log.jsonl` (stage events, timings, statuses; the `tokens` field from `align_token_usage.py` if present).
-3. Read every `${results_dir}/iter*_summary.md` that exists.
-4. Read RCA artifacts when present: `${results_dir}/baseline/rca_results/` and `${results_dir}/iter*/rca_results/` (score distribution, evaluator diagnostics, per-defect breakdown).
-5. Read mining outputs when present for the augmentation table: `${results_dir}/iter*/mining_filter/knn_summary.csv` and `mining_pool.csv`.
-
-Trust the disk over any value the parent prompt provides except `results_dir`, `skill_root`, `trigger`. If a state file is malformed or missing while the loop appears to have progressed past its stage, hard-stop (see *Hard stops* below).
-
-### Step 2 — Load template + rendering protocol
-
-1. Read `${skill_root}/references/DEFT_Loop_Report.html` — the **source** template. Always re-read on each invocation; never read the output file for a second pass.
-2. Read `${skill_root}/references/REPORT_RENDERING.md` — the placeholder map, in-progress rules, doc-comment stripping recipe, image-embedding spec, chart-data field names, and table column counts.
-
-### Step 3 — Strip the template's doc-comment header
-
-Per `REPORT_RENDERING.md` § *Strip the doc-comment header*. Use exact boundary detection (`template.index('-->\n<html')` and `template.index('<!--\n====')`); do **not** use a `<!--.*?-->` regex — it stops at the first `-->` inside the block and leaves the rest as visible text.
-
-### Step 4 — Compute every placeholder value
-
-Build a single Python dict of all `{{ ... }}` substitutions from disk state.
-
-- **Simple tokens** (`{{ GENERATED_DATE }}`, `{{ KPI_TARGET }}`, `{{ PRIMARY_METRIC_LABEL }}`, `{{ PRIMARY_METRIC_UNIT }}`, `{{ METRIC_DIRECTION_LABEL }}`, `{{ BEST_METRIC_VALUE }}`, …): scalar strings derived from the metric contract/result. Use the generic metric placeholders declared by the template; evaluator-specific values belong in diagnostics, not headline tokens.
-- **`*_HTML` blocks**: assemble HTML in Python (`"\n".join(...)`); no template engine.
-- **`*_JSON` blocks**: dump compact JSON whose field names match the template's JavaScript exactly. See `REPORT_RENDERING.md` § *Chart data field names* and § *Table row schemas*. A trend point must use the generic `value` field or the chart renders blank.
-- **Global context blocks** (`{{ PROBLEM_STATEMENT_HTML }}`, `{{ KPI_DATASET_HTML }}`, `{{ APPROACH_HTML }}`): build these on **every** render (including the very first, before any iteration completes) so the user always sees the run's framing. Bake the configured metric name, predicate, evaluator, constraints, max iterations, cosine threshold, and dataset totals directly into the HTML. Render evaluator diagnostics separately from the primary goal. These blocks are substituted with `.replace()` once, so nested placeholders will not re-substitute.
-
-Apply the in-progress rules from `REPORT_RENDERING.md` when `trigger != "loop-end"`:
-- `{{ FINAL_KPI_STATUS }}` → `"IN PROGRESS"`, class → `""`
-- `{{ ITERATIONS_RUN }}` → count of iterations with `status == "complete"` only
-- Iteration table and `{{ ITER_CARDS_HTML }}` → completed iterations only
-- KPI banner → empty string
-- Chart data → only completed-iteration points
-
-For the final render (`trigger == "loop-end"`), recompute success with the
-contract operator and every constraint. Be neutral, never say `NOT MET`. For a
-miss, render the absolute direction-aware gap plus unit (use `pp` only for a
-percentage-point metric), for example `0.004 cost/board from target` or
-`1.2pp from target`. Use the neutral yellow banner treatment, never a red
-failure banner.
-
-### Step 5 — Embed one representative sample pair as base64 thumbnails
-
-Before the sample pair, emit a literal status line in `{{ DATA_SAMPLES_HTML }}`:
-`AnomalyGen: enabled · num_SDG: <generated_count>`. Derive the count from the
-completed iteration's generated outputs; do not infer enabled status only from
-the presence of thumbnails.
-
-Emit **exactly one** `.sample-iter-block` containing **one** AnomalyGen input/output pair — not one per iteration. Pick the first existing pair (sorted by filename) from the best iteration; if the best iteration has no AnomalyGen output, fall back to the most recent iteration that does; if no iteration has output, emit two `<div class="sample-img-placeholder">No image</div>` cells.
-
-Column direction follows AnomalyGen-model semantics — **left column = AnomalyGen Input (OK / normal reference)** loaded from `synthetic_iter${N}_ok/`, **right column = AnomalyGen Output (synthetic NG)** loaded from `synthetic_iter${N}_ng/`. Do not swap these; reversing them makes the report read as "loop reconstructs OK from a defect", the opposite of the actual data flow. See `REPORT_RENDERING.md` § *Image embedding* for the canonical table.
-
-Resolve source paths per `REPORT_RENDERING.md` § *Image embedding*. Resize each image to **256×256** with `PIL.Image.thumbnail` and encode as `data:image/jpeg;base64,...`. When a source image does not exist for a column, emit `<div class="sample-img-placeholder">No image</div>` instead of `<img>`.
-
-The earlier `Normal`, `OV SDG Defect`, and `Mask` columns were removed, and the per-iteration loop was collapsed to a single pair. Do not emit them and do not gather their source images. Rationale: every extra sample shown is one more crop the reader can pick apart — one clean representative pair is the deliverable.
-
-### Step 6 — Render in a single pass
-
-Apply every replacement on the template string in **one chained `.replace()` block**. Never read the output file and run a second round of replacements on it.
-
-Quoting `REPORT_RENDERING.md` § *CRITICAL: Always render in a single pass from the source template*: a second pass can split partially-rendered HTML on an unfilled placeholder, duplicate every subsequent section, and produce two `<script>` blocks; it can also overwrite already-correct values with stale data.
-
-```python
-html = (
-    template
-    .replace("{{ GENERATED_DATE }}", generated_date)
-    .replace("{{ KPI_TARGET }}",     kpi_target)
-    .replace("{{ PRIMARY_METRIC_LABEL }}", primary_metric_label)
-    .replace("{{ PRIMARY_METRIC_UNIT }}", primary_metric_unit)
-    .replace("{{ METRIC_DIRECTION_LABEL }}", metric_direction_label)
-    # ... ALL remaining tokens in one chain ...
-    .replace("{{ RECOMMENDATIONS_HTML }}", recommendations_html)
-)
-```
-
-### Step 7 — Verify
-
-Before writing:
-
-- `assert "{{ " not in html`, `"{{ " in html` means a placeholder was missed; hard-stop with the first offending token quoted.
-- Count `<div class="sample-img-placeholder">` occurrences (not the bare class string, which appears in CSS too) and compare against expected = `sum(missing_columns_per_iter)`.
-
-### Step 8 — Atomic write
-
-Write to `${results_dir}/DEFT_Loop_Report.html.tmp`, then `os.replace` it onto `${results_dir}/DEFT_Loop_Report.html`. This keeps the previous HTML readable until the new one is fully on disk; partial writes never leak through.
-
-## Output
-
-Print exactly one line to stdout, then exit:
-
-```
-reporter: wrote DEFT_Loop_Report.html (<bytes>B, <N>/<M> iterations complete, status=<IN PROGRESS|MET|<gap><unit> from target>)
-```
-
-Examples:
-- `status=IN PROGRESS` — loop still running
-- `status=MET` — the primary metric and constraints pass
-- `status=0.004 cost/board from target` — a minimizing cost metric is 0.004 above its ceiling
-
-Never print `status=NOT MET`.
-
-Return a non-zero exit code only on hard failure (see below). Do not return long prose or repeat the file contents to the parent.
-
-## Hard stops
-
-Exit non-zero with a single-line error if any of the following:
-
-- `${skill_root}/references/DEFT_Loop_Report.html` is missing or unreadable.
-- `${results_dir}/deft_state.json` is missing or invalid JSON.
-- The doc-comment boundary tokens (`<!--\n====` / `-->\n<html`) cannot be located in the template (template tampered).
-- Any `{{ ... }}` placeholder remains after Step 6.
-- Atomic rename fails.
-
-Do not silently emit a half-rendered file. The parent will surface the error to the user.
-
-## Guidelines
-
-- **Never short-circuit.** Even mid-loop with most data stubbed, render the full template — the user refreshes the HTML to see live progress.
-- **Disk is the only source of truth.** The parent's prompt carries paths, not values.
-- **Template is read-only.** Never edit `references/DEFT_Loop_Report.html`; only the output file is written.
-- **Be terse.** One status line on success; one error line on failure. The parent's context is already saturated — that's why this agent exists.
+When `trigger` is `loop-end`, append `--require-terminal`. Return the script's
+single status line and exit with the same status. Do not read state, assemble
+HTML, edit the template, or write the output yourself.

--- a/skills/applications/tao-run-deft-aoi/references/DEFT_Loop_Report.html
+++ b/skills/applications/tao-run-deft-aoi/references/DEFT_Loop_Report.html
@@ -45,21 +45,10 @@
 
   ── PRE-RENDERED HTML BLOCK REFERENCE ─────────────────────────────────────────
   {{ KPI_BANNER_HTML }}
-      Conditional banner. Use neutral phrasing when the target is not yet reached
-      (we are the product team — describe the gap, never say "NOT MET"). Example
-      for a run still short of target:
-        <div class="kpi-banner" style="background:rgba(255,188,1,0.10);border-color:rgba(255,188,1,0.35);">
-          <div class="icon" style="background:var(--nvidia-yellow);color:#000">i</div>
-          <div class="content">
-            <div class="title" style="color:var(--nvidia-yellow)">Best result so far</div>
-            <div class="body">After N iterations, best is
-              <strong>Iter X — Weighted escape cost = Y cost/board</strong>
-              (<strong>Z cost/board from target</strong>).
-              <strong>Next lever:</strong> one-liner.
-            </div>
-          </div>
-        </div>
-      KPI MET example (green):
+      Conditional banner. Emit only for KPI MET or a committed hard stop. Use
+      an empty string while the loop is running or when the iteration budget
+      ends short of target; never emit an informational `i` / gap banner. KPI
+      MET example (green):
         <div class="kpi-banner" style="background:rgba(118,185,0,0.12);border-color:rgba(118,185,0,0.4);">
           <div class="icon" style="background:var(--nvidia-green);color:#000">✓</div>
           <div class="content">
@@ -934,6 +923,36 @@
   </div>
 
   {{ KPI_BANNER_HTML }}
+</div>
+
+<!-- ════════════ RUN CONFIGURATION & OUTCOME ════════════ -->
+<div class="card">
+  <div class="header">
+    <div>
+      <div class="chart-title">Run Configuration &amp; Outcome</div>
+      <div class="chart-subtitle">Approved configuration, measured wall time, and the current canonical outcome</div>
+    </div>
+  </div>
+  <table class="data-table">
+    <thead><tr><th>Item</th><th>Details</th></tr></thead>
+    <tbody>{{ RUN_SUMMARY_ROWS_HTML }}</tbody>
+  </table>
+
+  <h3 class="sub-title" style="margin-top:28px">Training Set Growth</h3>
+  <div class="chart-subtitle">Raw k-NN candidates and generated SDG rows compared with net unique rows retained after the committed deduplicating merge</div>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Iteration</th>
+        <th>KNN Raw Mined</th>
+        <th>SDG Generated</th>
+        <th>New Unique Images (After Dedup)</th>
+        <th>Training Set Total</th>
+        <th>Δ</th>
+      </tr>
+    </thead>
+    <tbody>{{ GROWTH_ROWS_HTML }}</tbody>
+  </table>
 </div>
 
 <!-- ════════════ PROBLEM STATEMENT ════════════ -->

--- a/skills/applications/tao-run-deft-aoi/references/DEFT_Loop_Report.html
+++ b/skills/applications/tao-run-deft-aoi/references/DEFT_Loop_Report.html
@@ -317,8 +317,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>DEFT Loop Final Report — PCB AOI ChangeNet</title>
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
-
   :root {
     --nvidia-green: #76b900;
     --nvidia-green-light: #8ed100;
@@ -340,7 +338,7 @@
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   body {
-    font-family: 'Inter', 'NVIDIA Sans', Arial, sans-serif;
+    font-family: 'NVIDIA Sans', Inter, Arial, sans-serif;
     background: var(--bg-dark);
     color: var(--text-primary);
     display: flex;

--- a/skills/applications/tao-run-deft-aoi/references/REPORT_RENDERING.md
+++ b/skills/applications/tao-run-deft-aoi/references/REPORT_RENDERING.md
@@ -10,14 +10,24 @@ file opens offline.
 
 | Stage trigger | New data available |
 |---|---|
-| Loop start (config loaded) | `{{ PROBLEM_STATEMENT_HTML }}`, `{{ APPROACH_HTML }}` — both populated immediately from `metric_contract`, max_iterations, and mining cos floor. The initialization hook writes these cards in the first report. |
+| Loop start (config loaded) | `{{ RUN_SUMMARY_ROWS_HTML }}`, baseline `{{ GROWTH_ROWS_HTML }}`, `{{ PROBLEM_STATEMENT_HTML }}`, and `{{ APPROACH_HTML }}`. The summary records the approved KPI, Visual ChangeNet identity, GPU count/model, routing, and available outcome evidence. |
 | Baseline evaluate done | baseline primary `metric_result`, optional threshold, and evaluator diagnostics; `{{ KPI_DATASET_HTML }}` populated from the evaluation manifest scanned during baseline. |
 | Baseline RCA done | RCA insight, score distribution, evaluator diagnostics, and defect type rows; also refines `{{ KPI_DATASET_HTML }}`'s per-defect-type breakdown using `${results_dir}/baseline/rca_results/defect_type_rows.csv`. |
 | Iter N evaluate done | iter N primary metric, constraints, optional threshold, diagnostics, checkpoint |
 | Iter N RCA done | updated RCA insight and tables |
 | Iter N AnomalyGen done | an explicit `AnomalyGen: enabled` status line, the `num_SDG` generated count, and sample images (base64 thumbnails) for iter N |
-| Iter N k-NN filtering done | knn_summary (`candidate_count`, `kept_count`, `rejected_count`), training row counts |
+| Iter N k-NN filtering / data merge done | `knn_summary.csv` supplies `KNN Raw Mined`; the committed combined training CSV supplies cumulative rows and the monotonic difference from the preceding total supplies `New Unique Images (After Dedup)` and `Δ`. |
 | Loop stop (KPI met or max_iterations) | final status, `best_iter`, recommendations |
+
+The **Run Configuration & Outcome** card always contains the two-column DEFT
+experiment summary followed by **Training Set Growth** with the exact columns
+`Iteration`, `KNN Raw Mined`, `SDG Generated`,
+`New Unique Images (After Dedup)`, `Training Set Total`, and `Δ`. `SDG
+Generated` is the row count of the committed `SDG_result.csv`; the two final
+growth columns come from the cumulative combined training CSV, so `New Unique
+Images (After Dedup)` always equals `Δ`. Runtime totals are sums of positive measured
+`duration_sec` values from `loop_log.jsonl`; identify partial historical logs
+as missing data rather than treating zero as elapsed time.
 
 Stub values for data not yet available:
 - future iter metric/rows → render `—`
@@ -31,14 +41,15 @@ While the loop has not stopped:
 - `{{ ITERATIONS_RUN }}` → count of iterations with `status == "complete"` at render time.
 - Iteration table rows → only completed iterations; omit rows for unstarted iterations.
 - `{{ ITER_CARDS_HTML }}` → only emit cards for completed iterations.
-- KPI banner → empty string while running; inject it only on loop stop.
+- KPI banner → empty string while running or when a terminal run misses the
+  target; inject it only for KPI MET or a committed hard stop.
 - `{{ METRIC_DATA_JSON }}` → primary-metric points from completed iterations.
 
 ## KPI status phrasing — be neutral, never say "NOT MET"
 
 We are the product team. When the target is not yet reached, describe the **gap**
-instead of stamping a failure label. Phrasing rules for `{{ FINAL_KPI_STATUS }}`
-and any KPI banner copy:
+in the final status panel instead of stamping a failure label. Phrasing rules
+for `{{ FINAL_KPI_STATUS }}`:
 
 | Condition | `FINAL_KPI_STATUS` | `FINAL_KPI_STATUS_CLASS` |
 |---|---|---|
@@ -53,10 +64,10 @@ When substituting `{{ PRIMARY_METRIC_UNIT }}`, use `%` directly and prepend one
 space for non-percent units (for example ` cost/board`) so value labels remain
 readable without encoding presentation whitespace in `metric_contract.unit`.
 
-Do **not** emit `"NOT MET"`, `"FAILED"`, the `red` CSS class, or red banner styling
-even when the target is missed. The KPI banner in this case should use the neutral
-yellow "Best result so far" treatment shown in the template doc-comment, not the
-red "KPI NOT MET" treatment. Reporting the gap factually is the entire ask.
+Do **not** emit `"NOT MET"`, `"FAILED"`, the `red` CSS class, or a KPI banner
+when the target is missed. In particular, never emit the yellow informational
+`i` / "Best result" banner. The final status panel and metric tables already
+report the gap factually.
 
 ## Renderer entry point
 

--- a/skills/applications/tao-run-deft-aoi/references/REPORT_RENDERING.md
+++ b/skills/applications/tao-run-deft-aoi/references/REPORT_RENDERING.md
@@ -1,14 +1,16 @@
 # DEFT Loop Report Rendering Protocol
 
 Template: `references/DEFT_Loop_Report.html`. Output: `results/DEFT_Loop_Report.html`.
-Re-render after each completed iteration and at loop end. Embed all images as base64 data URIs so
-the file opens offline.
+`scripts/render_report.py` is the only renderer. `init_deft_state.py` invokes it
+once at loop start, and `commit_stage.py` invokes it as a post-commit hook after
+every stage, including `loop_stop`. Embed all images as base64 data URIs so the
+file opens offline.
 
 ## When to update which data
 
 | Stage trigger | New data available |
 |---|---|
-| Loop start (config loaded) | `{{ PROBLEM_STATEMENT_HTML }}`, `{{ APPROACH_HTML }}` — both populated immediately from `metric_contract`, max_iterations, and mining cos floor. Re-render every iteration so the cards are present from the first render. |
+| Loop start (config loaded) | `{{ PROBLEM_STATEMENT_HTML }}`, `{{ APPROACH_HTML }}` — both populated immediately from `metric_contract`, max_iterations, and mining cos floor. The initialization hook writes these cards in the first report. |
 | Baseline evaluate done | baseline primary `metric_result`, optional threshold, and evaluator diagnostics; `{{ KPI_DATASET_HTML }}` populated from the evaluation manifest scanned during baseline. |
 | Baseline RCA done | RCA insight, score distribution, evaluator diagnostics, and defect type rows; also refines `{{ KPI_DATASET_HTML }}`'s per-defect-type breakdown using `${results_dir}/baseline/rca_results/defect_type_rows.csv`. |
 | Iter N evaluate done | iter N primary metric, constraints, optional threshold, diagnostics, checkpoint |
@@ -56,21 +58,16 @@ even when the target is missed. The KPI banner in this case should use the neutr
 yellow "Best result so far" treatment shown in the template doc-comment, not the
 red "KPI NOT MET" treatment. Reporting the gap factually is the entire ask.
 
-## Minimal render pattern
+## Renderer entry point
 
-```python
-import datetime, json, pathlib
-
-template = pathlib.Path("references/DEFT_Loop_Report.html").read_text()
-html = (
-    template
-    .replace("{{ GENERATED_DATE }}", datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"))
-    # ... fill remaining placeholders from deft_state.json + latest stage outputs ...
-)
-pathlib.Path(f"{RESULTS_DIR}/DEFT_Loop_Report.html").write_text(html)
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/render_report.py \
+  --results-dir "${RESULTS_DIR}"
 ```
 
-Never defer to a single end-of-loop render — write after each completed iteration so the user can refresh and see progress without paying a render cost for every short stage.
+Do not copy this protocol into inline Python. The bundled script owns
+placeholder construction, escaping, validation, and atomic replacement. Use
+`--require-terminal` for a final manual verification/rebuild.
 
 ### CRITICAL: Always render in a single pass from the source template
 
@@ -186,8 +183,9 @@ attempt to render the old chart.
 
 These three pre-rendered HTML blocks sit between the hero and Progress Overview
 and provide the run's global context — mirroring the gap-analysis report
-sections "Problem Statement", "KPI Dataset Statistics", and "DEFT". The agent
-builds each as a Python string and substitutes it once per render. Schemas:
+sections "Problem Statement", "KPI Dataset Statistics", and "DEFT". The
+renderer builds each as a Python string and substitutes it once per render.
+Schemas:
 
 | Placeholder | Required pieces | Source on disk |
 |---|---|---|

--- a/skills/applications/tao-run-deft-aoi/references/data-layout.md
+++ b/skills/applications/tao-run-deft-aoi/references/data-layout.md
@@ -44,7 +44,7 @@ creates (paths under `<workspace>` unless absolute):
 
 ```text
 <workspace>/
-├── .env                                     # NGC_KEY (nvcr.io/* pulls for all pinned images), HF_TOKEN (HuggingFace pre-flight pulls)
+├── .env                                     # NGC_KEY (nvcr.io/* pulls for all manifest-resolved images), HF_TOKEN (HuggingFace pre-flight pulls)
 ├── specs/baseline_spec.yaml                 # ChangeNet train/eval spec
 ├── train/base/
 │   ├── training_set.csv                     # seed training rows; four mandatory ChangeNet columns

--- a/skills/applications/tao-run-deft-aoi/references/data-layout.md
+++ b/skills/applications/tao-run-deft-aoi/references/data-layout.md
@@ -102,7 +102,7 @@ Relative to `<workspace>`:
 results/run_<YYYYMMDD_HHMMSS>/               # = ${RESULTS_DIR}
 ├── deft_state.json                          # current resume snapshot (schema: references/deft_state.json)
 ├── loop_log.jsonl                           # append-only stage log; single source of truth
-├── DEFT_Loop_Report.html                    # re-rendered after every stage by agents/reporter.md
+├── DEFT_Loop_Report.html                    # atomically refreshed by the commit_stage.py report hook
 ├── best_model.json                          # inference handoff metadata (see references/prepare-for-inference.md)
 ├── best_model_inference_spec.yaml           # ready-to-run TAO inference spec built from training config
 ├── iter${ITER}_summary.md                   # ≤300-word per-iteration summary

--- a/skills/applications/tao-run-deft-aoi/references/deft_state.json
+++ b/skills/applications/tao-run-deft-aoi/references/deft_state.json
@@ -29,6 +29,7 @@
     "backbone_weight_dir": "/home/user/workspace/augmentation/backbone",
     "train_container": "<resolved from versions.yaml::images.tao_toolkit.pyt at init time>",
     "num_gpus": 4,
+    "gpu_model": "NVIDIA RTX PRO 6000 Blackwell (96 GB)",
     "batch_size": 16,
     "num_epochs": 10,
     "anomalygen": {

--- a/skills/applications/tao-run-deft-aoi/references/metric-contract.md
+++ b/skills/applications/tao-run-deft-aoi/references/metric-contract.md
@@ -109,6 +109,7 @@ as one audited transaction:
   --inference-csv "${INFERENCE_CSV}" \
   --training-spec "${ITER_TRAINING_SPEC}" \
   --threshold "${THRESHOLD}" \
+  --duration-sec "${STAGE_DURATION_SEC}" \
   --summary "Evaluate: ${METRIC_NAME}=${METRIC_VALUE}"
 ```
 

--- a/skills/applications/tao-run-deft-aoi/references/paidf-anomalygen.md
+++ b/skills/applications/tao-run-deft-aoi/references/paidf-anomalygen.md
@@ -155,7 +155,7 @@ CKPT=$(find -L "$WS/augmentation/anomalygen/checkpoints/<project>" -path '*/ag_c
 : "${CKPT:?no AnomalyGen checkpoint directory with ag_config.yaml found under checkpoints/<project>}"
 COSMOS=$WS/augmentation/anomalygen/base_checkpoints
 RUN_DIR=$WS/results/run_<TS>/iter${N}/anomalygen
-: "${AG_IMAGE:=nvcr.io/nvidia/paidf-anomalygen:1.0.1}"  # versions-key: images.metropolis_sdg.paidf_anomalygen — reuses Pre-Flight export if set
+: "${AG_IMAGE:?AG_IMAGE unset — resolve images.metropolis_sdg.paidf_anomalygen from versions.yaml in Pre-Flight step 5}"
 mkdir -p $COSMOS $DS $(dirname $CKPT) $RUN_DIR/amp $RUN_DIR/sdg
 for p in "$COSMOS" "$DS" "$(dirname "$CKPT")"; do
   chmod 777 "$p" 2>/dev/null || echo "warning: could not chmod $p; continuing if it is readable"

--- a/skills/applications/tao-run-deft-aoi/references/paidf-anomalygen.md
+++ b/skills/applications/tao-run-deft-aoi/references/paidf-anomalygen.md
@@ -295,6 +295,7 @@ Required mounts (per-iteration): `<workspace>:<workspace>` (same path) +
 
 ```
 <output_dir>/
+├── allocation.json                         # Phase 2 defect -> AMP count proof
 ├── SDG_result.csv                          # one row per generated sample (image, mask, params, PSNR)
 ├── reconstructed_image/<T>+<A>_<idx>.png   # synthetic NG — ChangeNet input_path
 ├── original_image/<T>+<A>_<idx>.png        # paired OK — ChangeNet golden_path
@@ -303,11 +304,14 @@ Required mounts (per-iteration): `<workspace>:<workspace>` (same path) +
 ```
 
 After verifying `SDG_result.csv`, `reconstructed_image/`, and
-`original_image/`, commit:
+`original_image/`, keep Phase 2's `allocation.json` beside those outputs and
+commit:
 
 ```python
 phase = state["iterations"][f"iter{N}"]
 phase["anomalygen_sdg_csv"] = "<abs_path>/SDG_result.csv"
+phase["anomalygen_allocation_json"] = "<abs_path>/allocation.json"
+phase["anomalygen_amp_allocated"] = <sum of allocation.json counts>
 phase["stage_completed"] = "anomalygen"
 ```
 
@@ -321,9 +325,13 @@ This snippet documents the schema only; never execute it as inline Python.
     --iter-label iter${N} \
     --stage anomalygen \
     --anomalygen-sdg <absolute path to SDG_result.csv> \
+    --anomalygen-allocation <absolute path to allocation.json> \
+    --duration-sec "${STAGE_DURATION_SEC}" \
     --summary "SDG: requested=N, AMP-allocated=M, generated=K by type"
 ```
 
-When `M < N` (AMP yield gap), include both requested and allocated counts
+`commit_stage.py` derives `M` by summing the committed defect-to-count
+`allocation.json` and audits that disk proof on resume. When `M < N` (AMP
+yield gap), include both requested and allocated counts
 — that's the signal a reviewer needs to spot allocation-vs-generation
 bottlenecks.

--- a/skills/applications/tao-run-deft-aoi/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-aoi/references/pipeline-and-state.md
@@ -135,7 +135,8 @@ Three stage types:
 
 - **SKILL** — read `references/<stage>.md` first, then invoke the matching `tao-skill-bank:*` skill via the Skill tool or its documented direct-container fallback. Stage→skill mapping and fallback contract are in `references/scripts-and-agents.md`.
 - **INLINE** — parent does the work directly (pre-flight, CSV assembly, leakage check).
-- **AGENT** — parent spawns a subagent. The only AGENT stage is `agents/reporter.md` for HTML rendering.
+- **HOOK** — `commit_stage.py` invokes `scripts/render_report.py` after each
+  valid commit. Report generation is deterministic and never delegated.
 
 For `tao-skill-bank:tao-train-visual-changenet`, pass a separate task name (`train`, `inference`, or `evaluate`); the `stage` value in `loop_log.jsonl` is still only `train` or `evaluate`.
 
@@ -149,19 +150,28 @@ After every stage finishes, before advancing:
 2. Invoke `commit_stage.py` once with the documented artifact flags. For an error use `--status error`; it sets the iteration failed. Never repair a rejected commit by editing JSON.
 3. Run `scripts/audit_deft_run.py --results-dir ${RESULTS_DIR}`. If it reports `INVALID`, halt and repair; do not advance on in-memory success.
 4. If the committed log status is `error` — halt, surface the disk evidence verbatim, **do not auto-retry**.
-5. If the committed log status is `ok` — print one status line in the standard format `[iter <N>/<max> · <stage>] <primary metric> · <duration> · next: <stage>` (e.g. `[iter 2/3 · evaluate] weighted escape cost 0.024 → 0.018 (target <=0.02) · 2m · next: loop_stop`). Use the contract's display name, direction, target, and unit. Then advance. Render `DEFT_Loop_Report.html` only at iteration end (`trigger="after-iteration"`) and at loop end (`trigger="loop-end"`); never inline.
+5. If the committed log status is `ok` — confirm that `commit_stage.py` did
+   not print `report hook failed`, then print one status line in the standard
+   format `[iter <N>/<max> · <stage>] <primary metric> · <duration> · next:
+   <stage>` (e.g. `[iter 2/3 · evaluate] weighted escape cost 0.024 → 0.018
+   (target <=0.02) · 2m · next: loop_stop`). Use the contract's display name,
+   direction, target, and unit. The post-commit hook has already refreshed
+   `DEFT_Loop_Report.html`; do not spawn a reporting agent.
 
 ## Reports
 
 - `results/iter${ITER}_summary.md` — ≤300 words; readable after context compaction.
 - `results/iter${ITER}/report.html` — RCA targets, branch outputs, filter decision, metric delta.
-- `results/DEFT_Loop_Report.html` — re-rendered after each completed iteration and at loop end by the `reporter` subagent (`agents/reporter.md`). The agent owns the entire render: it reads the template, the rendering protocol (`references/REPORT_RENDERING.md`), and disk state, then writes atomically. The parent's only responsibility is to spawn the agent — never render inline.
+- `results/DEFT_Loop_Report.html` — initialized by `init_deft_state.py` and
+  re-rendered after every committed stage by `commit_stage.py` through
+  `scripts/render_report.py`. The script reads the source template and disk
+  evidence, validates the full output, and writes atomically.
 
 ## Runtime Behavior
 
 Run without pausing. Between stages, run the audit and print only its one-line
-status/next action. Spawn the `reporter` only after a full iteration and at
-loop end. `commit_stage.py` appends exactly one event per stage. For background
+status/next action. `commit_stage.py` appends exactly one event per stage and
+refreshes the report through its post-commit hook. For background
 Docker work, redirect both streams, save its PID, poll one line or `tail -40`
 at intervals no longer than 30s, and always `wait`; never poll a Skill-tool call.
 
@@ -177,7 +187,18 @@ at intervals no longer than 30s, and always `wait`; never poll a Skill-tool call
    ```
 
    This rewrites every entry's `context_tokens` field with the real context size at stage end and adds a `tokens` object (`input`, `output`, `cache_read`, `cache_create`, `n_messages`, `models`). The next step's report includes the numbers.
-3. Spawn `reporter` with `trigger="loop-end"` to re-render `DEFT_Loop_Report.html` against the now-aligned log.
+3. Run the renderer once after token alignment so the final report includes
+   the backfilled usage fields:
+
+   ```bash
+   <this-skill-dir>/scripts/deft_python.sh \
+     <this-skill-dir>/scripts/render_report.py \
+     --results-dir "${RESULTS_DIR}" --require-terminal
+   ```
+
+   This is an explicit deterministic script call, not delegated work; the
+   preceding `loop_stop` commit already produced a valid report before token
+   alignment.
 4. Run `scripts/prepare_inference_spec.py` (see below).
 
 Before telling the user the loop is complete, run:

--- a/skills/applications/tao-run-deft-aoi/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-aoi/references/pipeline-and-state.md
@@ -21,7 +21,7 @@ iteration executes:
 
 2. **[SKILL — `tao-skill-bank:tao-route-visual-changenet-samples`] Route weak samples.** Split the prior phase's `rca_gaps_parquet` into `routing_mining_parquet` and `routing_anomalygen_parquet` under the current `iterN` object. Downstream mining and AnomalyGen stages read those paths from disk. See `references/tao-route-visual-changenet-samples.md`.
 
-3. **[SKILL — `tao-skill-bank:paidf-anomalygen`] Run AMP + SDG.** Pass `dataset_dir` verbatim — no pool-staging, no parallel cache. Pre-create only `${RESULTS_DIR}/iter${N}/anomalygen/sdg/`. The four invariants that actually gate the run (cad_mask RGB preserved, `text` entries have prompts, clean+cad pairs by stem, `semantic_segmentation_labels.json` present) and the full parameter mapping live in `references/paidf-anomalygen.md`. Read it before invoking. Set `num_search_run=0` and `nn_threshold=0` to skip the SDG-quality phases (4–7) — the DEFT loop only needs the NG/OK pairs from Phase 3.
+3. **[SKILL — `tao-skill-bank:paidf-anomalygen`] Run AMP + SDG.** Pass `dataset_dir` verbatim — no pool-staging, no parallel cache. Pre-create only `${RESULTS_DIR}/iter${N}/anomalygen/sdg/`. Commit both `SDG_result.csv` and Phase 2's defect-to-count `allocation.json`; the latter is the canonical proof for AMP allocated. The four invariants that actually gate the run (cad_mask RGB preserved, `text` entries have prompts, clean+cad pairs by stem, `semantic_segmentation_labels.json` present) and the full parameter mapping live in `references/paidf-anomalygen.md`. Read it before invoking. Set `num_search_run=0` and `nn_threshold=0` to skip the SDG-quality phases (4–7) — the DEFT loop only needs the NG/OK pairs from Phase 3.
 
    If the committed `routing_anomalygen_parquet` has zero rows, do not launch
    the GPU generator. Set `anomalygen_skipped=true`, advance
@@ -79,6 +79,7 @@ iteration executes:
      --combined-csv "${RESULTS_DIR}/iter${ITER}/dataset/train_combined_iter${ITER}.csv" \
      --provenance-csv "${RESULTS_DIR}/iter${ITER}/dataset/train_combined_iter${ITER}_provenance.csv" \
      --merge-validation-report "${RESULTS_DIR}/iter${ITER}/dataset/merge_validation.json" \
+     --duration-sec "${STAGE_DURATION_SEC}" \
      --summary "validated combined training CSV"
    ```
 

--- a/skills/applications/tao-run-deft-aoi/references/preflight.md
+++ b/skills/applications/tao-run-deft-aoi/references/preflight.md
@@ -74,7 +74,29 @@ Resolve everything possible before asking the user. In order:
    **GPU-arch runnability probe.** Matching CPU arch isn't sufficient — the image's CUDA build must also support the host GPU's compute capability (e.g. DGX Spark `sm_121` vs a `cu128` build passes the manifest check but fails at the first CUDA call). Probe it directly: `docker run --rm --gpus all "$TAO_PYT_IMAGE" python3 -c "import torch; torch.zeros(1).cuda()"` — a non-zero exit or `no kernel image is available` means the build can't target this GPU; hard stop.
 
 7. Apply the path rule: pre-create iter dirs under `${RESULTS_DIR}/iter${ITER}/` and mount `<workspace>` into containers at the same absolute path. Workflows enforce their own container-level invariants (entrypoints, env vars); the loop just supplies the workspace mount and the resolved image URI.
-8. Verify GPU count. Probe the three AnomalyGen override slots under `augmentation/anomalygen/` (`checkpoints/<project>/`, `base_checkpoints/`, `datasets/<project>/`) and report their status in the Summary. **Empty slots are not missing — auto-fetch from HuggingFace is the default and requires no user action.** NVIDIA publishes the PCB fine-tuned checkpoint (`nvidia/Cosmos-AnomalyGen-PCB-2B`) and the PCB reference dataset (`nvidia/Cosmos-AnomalyGen-PCB-Dataset`) publicly on HuggingFace; paidf-anomalygen downloads them automatically on first use. Users who want to provide their own fine-tuned checkpoint or custom dataset can pre-stage the directory to override. Do not ask the user about missing AnomalyGen assets — treat empty slots as `will auto-fetch from HF (default)` and proceed. If `base_checkpoints/` is pre-staged, export its host path as `COSMOS_MODELS_DIR` for downstream mounts. Stage the ChangeNet pretrained backbone by running `scripts/stage_backbone.py --workspace <workspace>`, then set `specs/baseline_spec.yaml::model.backbone.pretrained_backbone_path` to the staged file and bind-mount it per `references/visual-changenet.md` → *Pre-Flight responsibility*. Staging is mandatory — hard-stop if the script exits non-zero; there is no URL fallback. See `references/paidf-anomalygen.md` for invocation and mount layout.
+8. Verify GPU count and record the exact GPU model plus memory reported by the
+   selected platform (for local Docker:
+   `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader`). Preserve
+   that string for `init_deft_state.py --gpu-model`; never substitute a local
+   GPU when the selected backend is remote. Probe the three AnomalyGen override
+   slots under `augmentation/anomalygen/` (`checkpoints/<project>/`,
+   `base_checkpoints/`, `datasets/<project>/`) and report their status in the
+   Summary. **Empty slots are not missing — auto-fetch from HuggingFace is the
+   default and requires no user action.** NVIDIA publishes the PCB fine-tuned
+   checkpoint (`nvidia/Cosmos-AnomalyGen-PCB-2B`) and the PCB reference dataset
+   (`nvidia/Cosmos-AnomalyGen-PCB-Dataset`) publicly on HuggingFace;
+   paidf-anomalygen downloads them automatically on first use. Users who want
+   to provide their own fine-tuned checkpoint or custom dataset can pre-stage
+   the directory to override. Do not ask the user about missing AnomalyGen
+   assets — treat empty slots as `will auto-fetch from HF (default)` and
+   proceed. If `base_checkpoints/` is pre-staged, export its host path as
+   `COSMOS_MODELS_DIR` for downstream mounts. Stage the ChangeNet pretrained
+   backbone by running `scripts/stage_backbone.py --workspace <workspace>`,
+   then set `specs/baseline_spec.yaml::model.backbone.pretrained_backbone_path`
+   to the staged file and bind-mount it per `references/visual-changenet.md` →
+   *Pre-Flight responsibility*. Staging is mandatory — hard-stop if the script
+   exits non-zero; there is no URL fallback. See
+   `references/paidf-anomalygen.md` for invocation and mount layout.
 9. **GPU memory sanity check.** ChangeNet classify with C-RADIOv2-B (ViT-B) at the spec defaults (`batch_size: 64`, `image_width/height: 224`, `cls_weight: [1.0, 10.0]`, learnable difference modules) OOMs on a single 48GB-class GPU. Inspect `nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits` and warn if the assembled spec's `dataset.classify.batch_size` is too large for the available memory: as a rule of thumb, **≤ 16 on 48GB GPUs, ≤ 8 on 24GB GPUs**. Surface the recommendation in the Pre-Flight Summary's `GPUs` row — let the user accept or override before launch rather than failing 30 seconds into training.
 10. Run train/validation leakage check before resuming any prior run.
 
@@ -109,7 +131,7 @@ Once all checks pass, print this summary and **STOP — wait for explicit user a
 | Training Epochs                | N per iteration                                                                |
 | Num SDG                        | N synthetic samples per iteration                                              |
 | Mining cutoff                  | cosine ≥ <min_similarity> (default 0.9)                                        |
-| GPUs                           | N                                                                              |
+| Compute / GPUs                 | N GPU(s) · <exact model> (<memory>)                                             |
 | Resuming                       | yes — iter N complete / no                                                     |
 | Est. runtime                   | ~max_iterations × 33 min on RTX 6000 Ada — estimate only (+~Yh downloads if MISSING) |
 

--- a/skills/applications/tao-run-deft-aoi/references/preflight.md
+++ b/skills/applications/tao-run-deft-aoi/references/preflight.md
@@ -17,18 +17,38 @@ Resolve everything possible before asking the user. In order:
 
    | Variable | Required for | Image prefix it gates |
    |---|---|---|
-   | `NGC_KEY` | All nvcr.io image pulls — TAO toolkit (train/infer/deploy/data services) and the paidf-anomalygen SDG container | the registry orgs of the pinned image URIs in step 5 |
+   | `NGC_KEY` | All nvcr.io image pulls — TAO toolkit (train/infer/deploy/data services) and the paidf-anomalygen SDG container | the registry orgs of the manifest-resolved image URIs in step 5 |
    | `HF_TOKEN` | Pre-Flight HuggingFace model downloads (ChangeNet backbone, Cosmos diffusion, T5, C-RADIO-V3, DINOv2, SAM2, Qwen-VL, SigLIP) — cached under `augmentation/anomalygen/base_checkpoints/`. Also gates the PCB reference dataset auto-fetch. | huggingface.co |
 
-   Both variables must be non-empty. The single `NGC_KEY` must have read access to every registry org referenced by the pinned image URIs in step 5 (TAO Toolkit and paidf-anomalygen images). If either is missing, show the user `.env.example` (next to this skill), ask them to copy it to `<workspace>/.env` and fill in values, and do not proceed until set.
+   Both variables must be non-empty. The single `NGC_KEY` must have read access to every registry org referenced by the image URIs resolved in step 5 (TAO Toolkit and Metropolis SDG). If either is missing, show the user `.env.example` (next to this skill), ask them to copy it to `<workspace>/.env` and fill in values, and do not proceed until set.
 4. `docker login nvcr.io` once with `NGC_KEY` (username `$oauthtoken`, password = the key). nvcr.io stores one credential per host. Do not fall back to host-side TAO wrappers.
-5. **Export the pinned container image env vars.** The rest of this skill — including the Pre-Flight Summary's `docker image inspect` line, every stage launch, and the `references/*.md` files — references three env vars. They are **not** defined elsewhere; the pinned URIs below are stamped from the release manifest. `export` them so all downstream commands see them:
+5. **Resolve and export the version-managed container image env vars.** The rest of this skill — including the Pre-Flight Summary's `docker image inspect` line, every stage launch, and the `references/*.md` files — references three env vars. Resolve every value from the installed skill bank's `versions.yaml`; never copy a tag into this document or preserve a tag from an earlier run:
 
    ```bash
-   export TAO_PYT_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
-   export TAO_DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
-   export AG_IMAGE=nvcr.io/nvidia/paidf-anomalygen:1.0.1  # versions-key: images.metropolis_sdg.paidf_anomalygen
+   TAO_PYT_IMAGE=$(
+     <skill_root>/scripts/deft_python.sh \
+       "$TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" \
+       images.tao_toolkit.pyt --skill-bank "$TAO_SKILL_BANK_PATH"
+   )
+   TAO_DS_IMAGE=$(
+     <skill_root>/scripts/deft_python.sh \
+       "$TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" \
+       images.tao_toolkit.data_services --skill-bank "$TAO_SKILL_BANK_PATH"
+   )
+   AG_IMAGE=$(
+     <skill_root>/scripts/deft_python.sh \
+       "$TAO_SKILL_BANK_PATH/scripts/resolve_versions_key.py" \
+       images.metropolis_sdg.paidf_anomalygen --skill-bank "$TAO_SKILL_BANK_PATH"
+   )
+   : "${TAO_PYT_IMAGE:?versions key images.tao_toolkit.pyt did not resolve}"
+   : "${TAO_DS_IMAGE:?versions key images.tao_toolkit.data_services did not resolve}"
+   : "${AG_IMAGE:?versions key images.metropolis_sdg.paidf_anomalygen did not resolve}"
+   export TAO_PYT_IMAGE TAO_DS_IMAGE AG_IMAGE
    ```
+
+   Hard-stop on any resolver error. `versions.yaml` is authoritative even when
+   a reference, cached transcript, or previously installed plugin mentions a
+   different tag.
 
    | Env var | versions-key | Used by |
    |---|---|---|
@@ -118,7 +138,7 @@ Fill the `Image` column with the actual URI resolved in Pre-Flight step 5
 (i.e. the value of the env var), not the literal `${VAR}` placeholder.
 Print one row per env var so the audit trail shows exactly which tag will run.
 
-| Env var          | Image (pinned in Pre-Flight step 5)                                            | Status     |
+| Env var          | Image (resolved in Pre-Flight step 5)                                          | Status     |
 | ---------------- | ------------------------------------------------------------------------------ | ---------- |
 | `TAO_PYT_IMAGE`  | `<$TAO_PYT_IMAGE>` (key: `images.tao_toolkit.pyt`)                             | OK/MISSING |
 | `AG_IMAGE`       | `<$AG_IMAGE>` (key: `images.metropolis_sdg.paidf_anomalygen`)                 | OK/MISSING |
@@ -133,7 +153,7 @@ cat <workspace>/augmentation/anomalygen/checkpoints/<project>/checkpoints/latest
 cat <workspace>/augmentation/anomalygen/datasets/<project>/defect_spec.jsonl | python3 -c "import sys,json; [print(json.loads(l)['defect_type']) for l in sys.stdin]"
 nvidia-smi --list-gpus | wc -l
 # ${TAO_PYT_IMAGE}, ${AG_IMAGE}, ${TAO_DS_IMAGE} are exported by Pre-Flight step 5
-# (pinned URIs stamped from the release manifest). Loop per-image so the
+# (URIs resolved from the installed versions.yaml). Loop per-image so the
 # output maps 1:1 to the Docker Images table rows above (you can't fill a
 # per-row Status column from a single aggregate "grep -c sha256" count).
 for var in TAO_PYT_IMAGE AG_IMAGE TAO_DS_IMAGE; do

--- a/skills/applications/tao-run-deft-aoi/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-aoi/references/scripts-and-agents.md
@@ -1,4 +1,4 @@
-# Bundled Scripts and Agents
+# Bundled Scripts and Report Hook
 
 ## Using Bundled Scripts
 
@@ -21,7 +21,8 @@ editor, echo, or jq.
 | `scripts/audit_deft_run.py` | Read-only cross-check of `deft_state.json`, `loop_log.jsonl`, recorded artifact paths, mining parquet schemas/counts/TAO PASS logs, iteration checkpoint ownership, stage commits, and terminal status. Prints the safe next action/reference. Run on startup/resume, before every stage, after every stage commit, and before completion claims. `--require-terminal` accepts a finalized failed run for reporting; `--require-complete` requires metric/max-iteration proof. | `--results-dir PATH [--json] [--require-terminal] [--require-complete]` |
 | `scripts/metric_contract.py` | Shared stdlib parser/comparator for primary metrics, direction-aware best selection, constraints, and bundled-evaluator normalization. Import from sibling scripts; no CLI. | — |
 | `scripts/record_metric_result.py` | Internal evaluate helper: validate standard evaluator JSON, enforce a configured artifact path, recompute `passed`, and write evaluate evidence. `commit_stage.py` calls it transactionally. | Internal; standalone CLI retained for compatibility |
-| `scripts/commit_stage.py` | The only supported normal stage writer. Validate the ordered transition and artifact proofs, update state, append the log event, audit, and roll back both files on failure. Train requires an iteration-owned checkpoint plus the exact spec; mining requires both embedding parquets, all three TAO logs, filtered parquet/count, and summary. | `--results-dir PATH --iter-label STR --stage STAGE --summary STR [stage artifact flags] [--status ok|error] [--duration-sec INT]` |
+| `scripts/commit_stage.py` | The only supported normal stage writer. Validate the ordered transition and artifact proofs, update state, append the log event, audit, and roll back both files on failure; then invoke the non-transactional report hook. Train requires an iteration-owned checkpoint plus the exact spec; mining requires both embedding parquets, all three TAO logs, filtered parquet/count, and summary. | `--results-dir PATH --iter-label STR --stage STAGE --summary STR [stage artifact flags] [--status ok|error] [--duration-sec INT]` |
+| `scripts/render_report.py` | Deterministically render the NVIDIA-styled, self-contained `DEFT_Loop_Report.html` from canonical state/log and recorded artifacts. Read the source template fresh, escape file-derived text, embed optional thumbnails, validate every placeholder/section, and replace atomically. Called automatically after initialization and every successful stage commit. | `--results-dir PATH [--require-terminal]` |
 | `scripts/log_stage.py` | Low-level log writer used by `commit_stage.py`. Do not call it directly during normal orchestration because it cannot update state transactionally. | Internal/legacy |
 | `scripts/align_token_usage.py` | Backfill per-stage LLM token usage into `results/loop_log.jsonl` by parsing the Claude Code transcript JSONL. Run after the loop (or any time). Adds a `tokens` field per entry and refreshes `context_tokens`. | `--log-path PATH [--cwd PATH \| --project-dir PATH \| --transcript PATH ...] [--dry-run]` |
 | `scripts/analyze_kpi.py` | Bundled threshold-sweep evaluator: emit standard `metric_result.json` plus diagnostic CSV/plots. Other customer metrics use the adapter contract in `references/metric-contract.md`. | `csv_path` (positional) `[--output-dir PATH]` `[--label-column NAME=label]` `[--score-column NAME=siamese_score]` `[--pass-label NAME=PASS]` `[--bins INT=40]` |
@@ -60,29 +61,26 @@ Do not invent a duration. Stage references list the required artifact flags.
 
 The script reads `~/.claude/projects/<slug>/*.jsonl` (slug derived from `--cwd`), attributes each assistant message's `usage` to the stage whose `(prev.ts, this.ts]` window contains it, and rewrites `loop_log.jsonl` atomically with a per-entry `tokens` field plus a refreshed `context_tokens`. The `tokens` field exposes `input`, `output`, `cache_read`, `cache_create` (and its `5m`/`1h` breakdown), `context_size_end`, and the list of `models` seen. Pass `--transcript PATH` (repeatable) or `--project-dir PATH` to override the auto-discovered location; `--dry-run` inspects output without rewriting the log.
 
-## Agents
+## Automatic report hook
 
-| Agent | Purpose | Invoke when |
-|---|---|---|
-| `agents/reporter.md` | Render `results/DEFT_Loop_Report.html` from disk state (`deft_state.json` + `loop_log.jsonl` + iter summaries + RCA artifacts) following `references/REPORT_RENDERING.md`. Atomic write; verifies all placeholders filled. | After each iteration completes (with `trigger="after-iteration"`) and once more at loop end (with `trigger="loop-end"`). Note: a per-stage trigger existed in earlier revisions and is no longer recommended — the spawn cost dominated for short stages. |
+`init_deft_state.py` writes the first report immediately after canonical state
+is initialized. `commit_stage.py` then calls `render_report.py` after every
+valid state/log commit, including failed-stage and `loop_stop` commits. The
+hook is deliberately outside the state transaction: a presentation error is
+printed as `report hook failed` but never rolls back a valid GPU-stage result.
 
-Spawn via the Task tool. Pass paths only, never values — the agent reads disk as the single source of truth:
+Normally do not invoke the renderer separately. If a hook reports an error,
+repair the named presentation input and run:
 
-```
-Task(
-  description="Render DEFT report",
-  subagent_type="general-purpose",
-  prompt=(
-    f"Read {skill_root}/agents/reporter.md and follow its instructions exactly.\n"
-    f"Inputs:\n"
-    f"  results_dir = {RESULTS_DIR}\n"
-    f"  skill_root  = {skill_root}\n"
-    f"  trigger     = after-iteration   # or 'loop-end' at the very end\n"
-  ),
-)
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/render_report.py \
+  --results-dir "${RESULTS_DIR}"
 ```
 
-The agent prints one status line and exits. Never render `DEFT_Loop_Report.html` inline in the parent — the whole point of this agent is to keep rendering alive when the parent's context is saturated.
+At loop end, add `--require-terminal` when verifying or manually rebuilding
+the final artifact. `agents/reporter.md` remains only as a compatibility
+wrapper for runtimes that explicitly invoke that legacy agent; it calls the
+same script and contains no rendering logic.
 
 ## Stage Reference Modules
 

--- a/skills/applications/tao-run-deft-aoi/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-aoi/references/scripts-and-agents.md
@@ -21,13 +21,13 @@ editor, echo, or jq.
 | `scripts/audit_deft_run.py` | Read-only cross-check of `deft_state.json`, `loop_log.jsonl`, recorded artifact paths, mining parquet schemas/counts/TAO PASS logs, iteration checkpoint ownership, stage commits, and terminal status. Prints the safe next action/reference. Run on startup/resume, before every stage, after every stage commit, and before completion claims. `--require-terminal` accepts a finalized failed run for reporting; `--require-complete` requires metric/max-iteration proof. | `--results-dir PATH [--json] [--require-terminal] [--require-complete]` |
 | `scripts/metric_contract.py` | Shared stdlib parser/comparator for primary metrics, direction-aware best selection, constraints, and bundled-evaluator normalization. Import from sibling scripts; no CLI. | — |
 | `scripts/record_metric_result.py` | Internal evaluate helper: validate standard evaluator JSON, enforce a configured artifact path, recompute `passed`, and write evaluate evidence. `commit_stage.py` calls it transactionally. | Internal; standalone CLI retained for compatibility |
-| `scripts/commit_stage.py` | The only supported normal stage writer. Validate the ordered transition and artifact proofs, update state, append the log event, audit, and roll back both files on failure; then invoke the non-transactional report hook. Train requires an iteration-owned checkpoint plus the exact spec; mining requires both embedding parquets, all three TAO logs, filtered parquet/count, and summary. | `--results-dir PATH --iter-label STR --stage STAGE --summary STR [stage artifact flags] [--status ok|error] [--duration-sec INT]` |
+| `scripts/commit_stage.py` | The only supported normal stage writer. Validate the ordered transition and artifact proofs, update state, append the log event, audit, and roll back both files on failure; then invoke the non-transactional report hook. Train requires an iteration-owned checkpoint plus the exact spec; mining requires both embedding parquets, all three TAO logs, filtered parquet/count, and summary. | `--results-dir PATH --iter-label STR --stage STAGE --summary STR --duration-sec POSITIVE_INT [stage artifact flags] [--status ok|error]` |
 | `scripts/render_report.py` | Deterministically render the NVIDIA-styled, self-contained `DEFT_Loop_Report.html` from canonical state/log and recorded artifacts. Read the source template fresh, escape file-derived text, embed optional thumbnails, validate every placeholder/section, and replace atomically. Called automatically after initialization and every successful stage commit. | `--results-dir PATH [--require-terminal]` |
 | `scripts/log_stage.py` | Low-level log writer used by `commit_stage.py`. Do not call it directly during normal orchestration because it cannot update state transactionally. | Internal/legacy |
 | `scripts/align_token_usage.py` | Backfill per-stage LLM token usage into `results/loop_log.jsonl` by parsing the Claude Code transcript JSONL. Run after the loop (or any time). Adds a `tokens` field per entry and refreshes `context_tokens`. | `--log-path PATH [--cwd PATH \| --project-dir PATH \| --transcript PATH ...] [--dry-run]` |
 | `scripts/analyze_kpi.py` | Bundled threshold-sweep evaluator: emit standard `metric_result.json` plus diagnostic CSV/plots. Other customer metrics use the adapter contract in `references/metric-contract.md`. | `csv_path` (positional) `[--output-dir PATH]` `[--label-column NAME=label]` `[--score-column NAME=siamese_score]` `[--pass-label NAME=PASS]` `[--bins INT=40]` |
 | `scripts/validate_training_csv.py` | Validate an assembled ChangeNet training CSV before launching training. Checks required columns, every reconstructed `input_path` / `golden_path`, filename-shape mistakes, duplicates, and optional validation leakage; `--report-json` writes the required merge-validation proof. Stdlib only — no pandas required. | `--csv PATH --workspace-root PATH [--validation-csv PATH] [--report-json PATH] [--light NAME] [--image-ext EXT]` |
-| `scripts/init_deft_state.py` | Write a fresh `${RESULTS_DIR}/deft_state.json` from CLI args. Guarantees unique top-level keys. Atomic write; refuses to overwrite without `--force`. Use only on fresh runs; never on resume. | `--results-dir PATH --workspace PATH --kpi-target STR --max-iterations INT --num-gpus INT --num-epochs INT --num-sdg INT --project STR --step INT [--batch-size INT] [--top-k-per-target INT] [--knn-metric STR] [--min-similarity FLOAT] [--train-container STR] [--ag-container STR] [--force]` |
+| `scripts/init_deft_state.py` | Write a fresh `${RESULTS_DIR}/deft_state.json` from CLI args. Guarantees unique top-level keys. Atomic write; refuses to overwrite without `--force`. Use only on fresh runs; never on resume. | `--results-dir PATH --workspace PATH --kpi-target STR --max-iterations INT --num-gpus INT --gpu-model STR --num-epochs INT --num-sdg INT --project STR --step INT [--batch-size INT] [--top-k-per-target INT] [--knn-metric STR] [--min-similarity FLOAT] [--train-container STR] [--ag-container STR] [--force]` |
 | `scripts/changenet_data_pair_prepare.py` | Build the ChangeNet `(input, golden, label, object_name)` CSV from `_ng/` + `_ok/` image directories. NV_PCB_Siamese mode (`--images-dir`) emits the 14-column siamese CSV and copies images into the staged tree. | `--input-dir PATH --golden-dir PATH` `[--output PATH=dataset.csv]` `[--label STR]` `[--images-dir PATH]` `[--subdir NAME=sdg]` `[--light NAME=SolderLight]` `[--image-ext EXT=.jpg]` |
 | `scripts/prepare_inference_spec.py` | Write `best_model.json` + `best_model_inference_spec.yaml` from `deft_state.json` + the training spec. Run once at loop end. See `references/prepare-for-inference.md`. | `--results-dir PATH` |
 | `scripts/stage_backbone.py` | Stage the ChangeNet pretrained backbone locally (download from HF, copy into the workspace). Idempotent; reuses an existing staged file. Hard-fails (non-zero exit) if it cannot produce a staged file. Prints the staged absolute path as the last stdout line. | `(--workspace PATH \| --dest PATH) [--repo-id STR=nvidia/C-RADIOv2-B] [--filename STR=model.safetensors] [--stage-name STR=c_radio_v2_b.safetensors] [--force]` |
@@ -43,11 +43,17 @@ Use one portable form in every harness:
   --iter-label iter1 \
   --stage anomalygen \
   --anomalygen-sdg /abs/path/iter1/anomalygen/sdg/SDG_result.csv \
+  --anomalygen-allocation /abs/path/iter1/anomalygen/sdg/allocation.json \
+  --duration-sec "${STAGE_DURATION_SEC}" \
   --summary "generated 10 pairs"
 ```
 
-If no reliable start time was captured, omit `--duration-sec`; it records `0`.
-Do not invent a duration. Stage references list the required artifact flags.
+Set `STAGE_DURATION_SEC` from measured wall-clock evidence before committing:
+use the selected backend's elapsed time for submitted jobs, or time an inline
+host stage directly. Round a measured sub-second stage up to `1`; never invent
+a duration. `commit_stage.py` rejects an omitted, zero, or negative value so the
+report can always calculate per-stage and total runtime. Stage references list
+the required artifact flags.
 
 ### Aligning Per-Stage Token Usage (Post-Loop)
 

--- a/skills/applications/tao-run-deft-aoi/references/tao-analyze-gaps-visual-changenet.md
+++ b/skills/applications/tao-run-deft-aoi/references/tao-analyze-gaps-visual-changenet.md
@@ -56,5 +56,6 @@ the path and threshold with the command below.
     --rca-gaps <absolute path to kpi_gaps.parquet> \
     --rca-threshold <float> \
     --rca-target-defect <label> ... \
+    --duration-sec "${STAGE_DURATION_SEC}" \
     --summary "RCA (VCN): threshold=X recall=Y; gaps=K rows across N labels"
 ```

--- a/skills/applications/tao-run-deft-aoi/references/tao-mine-aoi-images.md
+++ b/skills/applications/tao-run-deft-aoi/references/tao-mine-aoi-images.md
@@ -158,5 +158,6 @@ This snippet documents the schema only; use `commit_stage.py` for the write.
     --mining-source-log <absolute path to source_embeddings.log> \
     --mining-knn-log <absolute path to nearest_neighbors.log> \
     --mining-count <int> \
+    --duration-sec "${STAGE_DURATION_SEC}" \
     --summary "Mining (VCN): mined=N_mined source images for N_targets targets"
 ```

--- a/skills/applications/tao-run-deft-aoi/references/tao-route-visual-changenet-samples.md
+++ b/skills/applications/tao-run-deft-aoi/references/tao-route-visual-changenet-samples.md
@@ -52,5 +52,6 @@ The snippet documents the schema only; use `commit_stage.py` for the write.
     --stage routing \
     --routing-mining <absolute path to mining_gaps.parquet> \
     --routing-anomalygen <absolute path to anomalygen_gaps.parquet> \
+    --duration-sec "${STAGE_DURATION_SEC}" \
     --summary "Routing: mining=N_mn rows, anomalygen=N_ag rows; N_drop labels dropped"
 ```

--- a/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
+++ b/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
@@ -258,6 +258,7 @@ row["label"] = row["label"] if row["label"] == "PASS" else row["label"].lower().
     --best-ckpt-kind <best_val|latest> \
     --training-spec <absolute exact training spec> \
     --val-loss <float> \
+    --duration-sec "${STAGE_DURATION_SEC}" \
     --summary "Train: val_loss=Z best_ckpt=<kind>:<absolute path>"
 
 # Commit the evaluator result and ordered evaluate event together.
@@ -270,5 +271,6 @@ row["label"] = row["label"] if row["label"] == "PASS" else row["label"].lower().
     --inference-csv <absolute inference CSV> \
     --training-spec <absolute exact training spec> \
     --threshold <float; include when required by the evaluator contract> \
+    --duration-sec "${STAGE_DURATION_SEC}" \
     --summary "Evaluate: <metric>=X <operator> target; threshold=Y|n/a"
 ```

--- a/skills/applications/tao-run-deft-aoi/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/audit_deft_run.py
@@ -1023,6 +1023,29 @@ def _print_text(report: dict[str, Any]) -> None:
         print(f"ERROR: {error}")
 
 
+def _completion_report_error(results_dir: pathlib.Path) -> str | None:
+    """Return why the deterministic final HTML is missing/stale/invalid."""
+    results_dir = results_dir.expanduser().resolve()
+    report_path = results_dir / "DEFT_Loop_Report.html"
+    if not report_path.is_file() or report_path.stat().st_size == 0:
+        return f"final HTML report is missing or empty: {report_path}"
+    evidence = [results_dir / "deft_state.json", results_dir / "loop_log.jsonl"]
+    newest_evidence = max(
+        (path.stat().st_mtime_ns for path in evidence if path.exists()),
+        default=0,
+    )
+    if report_path.stat().st_mtime_ns < newest_evidence:
+        return "final HTML report is older than canonical state/log; rerun render_report.py"
+    text = report_path.read_text(encoding="utf-8")
+    required = ("DEFT Loop Final Report", "Final Status", "--nvidia-green: #76b900")
+    missing = [token for token in required if token not in text]
+    if missing:
+        return "final HTML report is missing required content: " + ", ".join(missing)
+    if re.search(r"\{\{\s+[A-Z0-9_]+\s+\}\}", text):
+        return "final HTML report contains unfilled placeholders"
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--results-dir", required=True, type=pathlib.Path)
@@ -1051,8 +1074,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if args.require_terminal and not report["terminal"]:
         return 1
-    if args.require_complete and report["status"] != "COMPLETE":
-        return 1
+    if args.require_complete:
+        if report["status"] != "COMPLETE":
+            return 1
+        report_error = _completion_report_error(args.results_dir)
+        if report_error:
+            print(f"ERROR: {report_error}", file=sys.stderr)
+            return 1
     return 0
 
 

--- a/skills/applications/tao-run-deft-aoi/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/audit_deft_run.py
@@ -58,6 +58,7 @@ PATH_FIELDS = {
     "routing_mining_parquet",
     "routing_anomalygen_parquet",
     "anomalygen_sdg_csv",
+    "anomalygen_allocation_json",
     "mining_mined_parquet",
     "mining_parquet",  # legacy field: accepted but still checked
     "mining_summary",
@@ -84,6 +85,8 @@ FIELD_STAGE = {
     "routing_mining_parquet": "routing",
     "routing_anomalygen_parquet": "routing",
     "anomalygen_sdg_csv": "anomalygen",
+    "anomalygen_allocation_json": "anomalygen",
+    "anomalygen_amp_allocated": "anomalygen",
     "mining_mined_parquet": "data_mining",
     "mining_parquet": "data_mining",
     "mining_summary": "data_mining",
@@ -267,6 +270,40 @@ def _mining_summary_proof(
     if mined_rows is not None and kept != mined_rows:
         errors.append(
             f"{field}.kept_count={kept} disagrees with mined parquet rows={mined_rows}"
+        )
+
+
+def _allocation_proof(
+    path: pathlib.Path,
+    recorded_count: Any,
+    field: str,
+    errors: list[str],
+) -> None:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"{field} is invalid JSON: {exc}")
+        return
+    if not isinstance(payload, dict) or not payload:
+        errors.append(f"{field} must be a non-empty defect-to-count object")
+        return
+    if any(
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value < 0
+        for value in payload.values()
+    ):
+        errors.append(f"{field} contains invalid allocation counts")
+        return
+    allocated = sum(payload.values())
+    if allocated <= 0:
+        errors.append(f"{field} must allocate at least one AMP")
+    if not isinstance(recorded_count, int) or isinstance(recorded_count, bool):
+        errors.append(f"{field} has no integer anomalygen_amp_allocated in state")
+    elif recorded_count != allocated:
+        errors.append(
+            f"{field} total={allocated} disagrees with "
+            f"anomalygen_amp_allocated={recorded_count}"
         )
 
 
@@ -615,6 +652,22 @@ def audit(results_dir: pathlib.Path) -> dict[str, Any]:
                 errors.append(
                     f"state.iterations.{label}.{field} is set but loop_log lacks {label}/{stage}"
                 )
+
+        allocation_value = info.get("anomalygen_allocation_json")
+        if allocation_value:
+            allocation_path = pathlib.Path(str(allocation_value)).expanduser()
+            if allocation_path.is_file() and allocation_path.stat().st_size > 0:
+                _allocation_proof(
+                    allocation_path,
+                    info.get("anomalygen_amp_allocated"),
+                    f"state.iterations.{label}.anomalygen_allocation_json",
+                    errors,
+                )
+        elif info.get("anomalygen_amp_allocated") is not None:
+            errors.append(
+                f"state.iterations.{label}.anomalygen_amp_allocated is set "
+                "without anomalygen_allocation_json"
+            )
 
         merge_report_value = info.get("merge_validation_report")
         if merge_report_value:

--- a/skills/applications/tao-run-deft-aoi/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/commit_stage.py
@@ -69,6 +69,29 @@ def _required_file(path: pathlib.Path | None, name: str) -> str:
     return str(expanded.resolve())
 
 
+def _required_allocation(
+    path: pathlib.Path | None, name: str
+) -> tuple[str, int]:
+    resolved = _required_file(path, name)
+    try:
+        payload = json.loads(pathlib.Path(resolved).read_text())
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{name} must be a JSON object: {resolved} ({exc})") from exc
+    if not isinstance(payload, dict) or not payload:
+        raise ValueError(f"{name} must be a non-empty defect-to-count JSON object")
+    invalid = {
+        str(defect): count
+        for defect, count in payload.items()
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0
+    }
+    if invalid:
+        raise ValueError(f"{name} contains invalid allocation counts: {invalid}")
+    allocated = sum(payload.values())
+    if allocated <= 0:
+        raise ValueError(f"{name} must allocate at least one sample")
+    return resolved, allocated
+
+
 def _require_within(path: str, root: pathlib.Path, name: str) -> str:
     resolved = pathlib.Path(path).resolve()
     try:
@@ -165,6 +188,11 @@ def _apply_success(
             phase["anomalygen_sdg_csv"] = _required_file(
                 args.anomalygen_sdg, "--anomalygen-sdg"
             )
+            allocation, allocated = _required_allocation(
+                args.anomalygen_allocation, "--anomalygen-allocation"
+            )
+            phase["anomalygen_allocation_json"] = allocation
+            phase["anomalygen_amp_allocated"] = allocated
     elif stage == "data_mining":
         if args.skip:
             phase["data_mining_skipped"] = True
@@ -223,6 +251,14 @@ def _apply_success(
 def commit(args: argparse.Namespace) -> dict[str, Any]:
     if not re.fullmatch(r"baseline|iter[1-9][0-9]*", args.iter_label):
         raise ValueError("--iter-label must be baseline or iterN (N >= 1)")
+    if (
+        not isinstance(args.duration_sec, int)
+        or isinstance(args.duration_sec, bool)
+        or args.duration_sec <= 0
+    ):
+        raise ValueError(
+            "--duration-sec is required and must be a positive measured duration"
+        )
     if args.skip and args.stage not in {"anomalygen", "data_mining"}:
         raise ValueError("--skip is valid only for anomalygen or data_mining")
 
@@ -334,7 +370,12 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--status", choices=("ok", "error"), default="ok")
     parser.add_argument("--summary", required=True)
-    parser.add_argument("--duration-sec", type=int, default=0)
+    parser.add_argument(
+        "--duration-sec",
+        required=True,
+        type=int,
+        help="Measured wall-clock seconds for this stage; must be positive",
+    )
     parser.add_argument("--skip", action="store_true")
     parser.add_argument("--best-ckpt", type=pathlib.Path)
     parser.add_argument("--best-ckpt-kind", choices=("best_val", "latest"))
@@ -349,6 +390,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--routing-mining", type=pathlib.Path)
     parser.add_argument("--routing-anomalygen", type=pathlib.Path)
     parser.add_argument("--anomalygen-sdg", type=pathlib.Path)
+    parser.add_argument("--anomalygen-allocation", type=pathlib.Path)
     parser.add_argument("--mining-parquet", type=pathlib.Path)
     parser.add_argument("--mining-summary", type=pathlib.Path)
     parser.add_argument("--mining-target-embeddings", type=pathlib.Path)

--- a/skills/applications/tao-run-deft-aoi/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/commit_stage.py
@@ -22,6 +22,7 @@ from typing import Any
 from audit_deft_run import _expected_next, audit
 from log_stage import append_stage
 from record_metric_result import commit as commit_metric_result
+from render_report import render as render_html_report
 
 
 def _atomic_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
@@ -301,6 +302,14 @@ def commit(args: argparse.Namespace) -> dict[str, Any]:
         else:
             _atomic_text(log_path, original_log)
         raise
+    # Report rendering is a deterministic post-commit hook.  A presentation
+    # failure must be visible, but it must not roll back a valid GPU-stage
+    # commit and leave callers unable to advance the state machine.
+    try:
+        output = render_html_report(results_dir, audit_report=report)
+        report["report_path"] = str(output)
+    except Exception as exc:  # noqa: BLE001 - hook failures are non-transactional
+        report["report_render_error"] = str(exc)
     return report
 
 
@@ -366,6 +375,11 @@ def main(argv: list[str] | None = None) -> int:
         f"committed seq={last['seq']} {last['iter']}/{last['stage']} "
         f"status={last['status']} run={report['status']}"
     )
+    if report.get("report_render_error"):
+        print(
+            f"commit_stage: report hook failed: {report['report_render_error']}",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/skills/applications/tao-run-deft-aoi/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/init_deft_state.py
@@ -21,6 +21,7 @@ CLI:
         --metric-evaluator ~/workspace/metrics/evaluate_quality.py \
         --max-iterations 2 \
         --num-gpus 4 \
+        --gpu-model "NVIDIA RTX PRO 6000 Blackwell (96 GB)" \
         --num-epochs 20 \
         --num-sdg 20 \
         --project nvpcb \
@@ -149,6 +150,7 @@ def build_state(args: argparse.Namespace) -> dict:
             "backbone_weight_dir": str(ws / "augmentation" / "backbone"),
             "train_container": args.train_container,
             "num_gpus": args.num_gpus,
+            "gpu_model": args.gpu_model,
             "batch_size": args.batch_size,
             "num_epochs": args.num_epochs,
             "anomalygen": {
@@ -281,6 +283,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--max-iterations", required=True, type=int)
     parser.add_argument("--num-gpus", required=True, type=int)
+    parser.add_argument(
+        "--gpu-model",
+        required=True,
+        help=(
+            "Exact accelerator model recorded by the selected platform's "
+            "Preflight, including memory when available"
+        ),
+    )
     parser.add_argument("--num-epochs", required=True, type=int)
     parser.add_argument("--num-sdg", required=True, type=int)
     parser.add_argument("--project", required=True, help="AnomalyGen project name (e.g. nvpcb)")
@@ -438,6 +448,10 @@ def _build_metric_contract(args: argparse.Namespace) -> tuple[dict, str]:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
+    args.gpu_model = args.gpu_model.strip()
+    if not args.gpu_model:
+        print("init_deft_state: --gpu-model must not be empty", file=sys.stderr)
+        return 2
     try:
         args.metric_contract, args.kpi_target_text = _build_metric_contract(args)
     except ValueError as exc:

--- a/skills/applications/tao-run-deft-aoi/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/init_deft_state.py
@@ -40,6 +40,7 @@ import sys
 import tempfile
 
 from metric_contract import parse_target_expression, render_target, validate_contract
+from render_report import render as render_html_report
 
 
 _COMPLETED_STEP_VALUES = [
@@ -484,6 +485,10 @@ def main(argv: list[str] | None = None) -> int:
     state = build_state(args)
     write_atomic(out, state)
     print(f"init_deft_state: wrote {out}", file=sys.stderr)
+    try:
+        render_html_report(args.results_dir)
+    except Exception as exc:  # noqa: BLE001 - state initialization remains valid
+        print(f"init_deft_state: report hook failed: {exc}", file=sys.stderr)
     return 0
 
 

--- a/skills/applications/tao-run-deft-aoi/scripts/render_report.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/render_report.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render the NVIDIA-styled DEFT AOI HTML report from canonical disk state.
+
+The renderer is intentionally deterministic and stdlib-first.  It is called by
+``commit_stage.py`` after every successful commit, so report freshness no
+longer depends on an agent remembering an end-of-loop rendering task.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import datetime as dt
+import html as html_lib
+import io
+import json
+import math
+import os
+import pathlib
+import re
+import sys
+import tempfile
+from typing import Any, Iterable
+
+from metric_contract import (
+    MINIMIZING_OPERATORS,
+    contract_from_state,
+    pick_best,
+    render_target,
+    result_from_iteration,
+    result_passes,
+)
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TEMPLATE_PATH = SKILL_ROOT / "references" / "DEFT_Loop_Report.html"
+REPORT_NAME = "DEFT_Loop_Report.html"
+
+
+def _escape(value: Any) -> str:
+    return html_lib.escape(str(value), quote=True)
+
+
+def _fmt(value: Any, digits: int = 4) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        number = float(value)
+        if not math.isfinite(number):
+            return "—"
+        if number.is_integer():
+            return f"{int(number):,}"
+        return f"{number:.{digits}g}"
+    return _escape(value)
+
+
+def _display_unit(unit: str) -> str:
+    if not unit:
+        return ""
+    return unit if unit == "%" else f" {unit}"
+
+
+def _json_for_html(value: Any) -> str:
+    """Serialize JSON safely for an inline script element."""
+    return (
+        json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def _label_key(label: str) -> tuple[int, int]:
+    if label == "baseline":
+        return (0, 0)
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    return (1, int(match.group(1))) if match else (2, 0)
+
+
+def _read_json(path: pathlib.Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_optional_json(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value:
+        return None
+    path = pathlib.Path(value)
+    if not path.is_file():
+        return None
+    try:
+        payload = _read_json(path)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _read_log(path: pathlib.Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid loop_log.jsonl line {line_number}: {exc}") from exc
+        if not isinstance(entry, dict):
+            raise ValueError(f"loop_log.jsonl line {line_number} must be an object")
+        entries.append(entry)
+    return entries
+
+
+def _csv_row_count(path_value: Any) -> int | None:
+    if not isinstance(path_value, str) or not path_value:
+        return None
+    path = pathlib.Path(path_value)
+    if not path.is_file():
+        return None
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            return sum(1 for _ in csv.DictReader(handle))
+    except (OSError, UnicodeDecodeError, csv.Error):
+        return None
+
+
+def _csv_rows(path: pathlib.Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        return []
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+    except (OSError, UnicodeDecodeError, csv.Error):
+        return []
+
+
+def _metric_candidates(
+    state: dict[str, Any], contract: dict[str, Any]
+) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        raise ValueError("state.iterations must be an object")
+    candidates: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    for label in sorted(iterations, key=_label_key):
+        phase = iterations[label]
+        if not isinstance(phase, dict):
+            continue
+        result = result_from_iteration(phase, contract)
+        if result is not None:
+            candidates.append((label, phase, result))
+    return candidates
+
+
+def _chart_extent(values: Iterable[float], target: float) -> tuple[float, float, list[float]]:
+    points = [float(target), *(float(value) for value in values)]
+    low, high = min(points), max(points)
+    if math.isclose(low, high):
+        padding = max(abs(low) * 0.1, 0.1)
+    else:
+        padding = (high - low) * 0.15
+    low -= padding
+    high += padding
+    steps = [low + (high - low) * index / 4 for index in range(5)]
+    return low, high, [round(value, 6) for value in steps]
+
+
+def _format_duration(seconds: Any) -> str:
+    try:
+        total = int(seconds)
+    except (TypeError, ValueError):
+        return "—"
+    if total <= 0:
+        return "not recorded"
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def _iteration_rows(
+    state: dict[str, Any],
+    contract: dict[str, Any],
+    candidates: list[tuple[str, dict[str, Any], dict[str, Any]]],
+    best_label: str | None,
+) -> tuple[str, str, str]:
+    baseline_value = candidates[0][2]["value"] if candidates else None
+    minimizes = contract["operator"] in MINIMIZING_OPERATORS
+    table_rows: list[str] = []
+    cards: list[str] = []
+    pool_rows: list[str] = []
+    for label, phase, result in candidates:
+        value = float(result["value"])
+        delta = None if baseline_value is None or label == "baseline" else value - float(baseline_value)
+        delta_class = ""
+        if delta is not None:
+            improved = delta < 0 if minimizes else delta > 0
+            delta_class = "pos" if improved else ("neg" if delta != 0 else "")
+        training_rows = _csv_row_count(
+            phase.get("combined_training_csv")
+            or (state.get("config", {}) if isinstance(state.get("config"), dict) else {}).get("training_csv")
+        )
+        synthetic_rows = _csv_row_count(phase.get("anomalygen_sdg_csv")) or 0
+        mined_rows = phase.get("mining_mined_count")
+        if not isinstance(mined_rows, int):
+            mined_rows = 0
+        ratio = (
+            synthetic_rows / training_rows * 100
+            if isinstance(training_rows, int) and training_rows > 0
+            else None
+        )
+        passed, failures = result_passes(contract, result)
+        row_class = "best" if label == best_label else ("regress" if delta_class == "neg" else "")
+        badge = '<span class="badge best">★ BEST</span>' if label == best_label else ""
+        threshold = phase.get("threshold", result.get("threshold"))
+        ratio_html = _fmt(ratio)
+        if ratio is not None:
+            ratio_html += "%"
+            if ratio > 50:
+                ratio_html = f'<span class="badge warn">{ratio_html} ⚠</span>'
+        note = "KPI met" if passed else ("Constraints: " + ", ".join(failures) if failures else "Evaluated")
+        table_rows.append(
+            f'<tr class="{row_class}">'
+            f'<td><strong>{_escape(label.title())}</strong> {badge}</td>'
+            f'<td class="num {"pos" if label == best_label else ""}">{_fmt(value)}{_escape(_display_unit(contract["unit"]))}</td>'
+            f'<td class="num {delta_class}">{"—" if delta is None else _fmt(delta)}</td>'
+            f'<td class="num">{_fmt(threshold)}</td>'
+            f'<td class="num">{_fmt(training_rows)}</td>'
+            f'<td class="num">{_fmt(synthetic_rows)}</td>'
+            f'<td>{ratio_html}</td>'
+            f'<td>{_escape(note)}</td></tr>'
+        )
+        card_class = "best" if label == best_label else ("regress" if delta_class == "neg" else "")
+        tag = "★ Best" if label == best_label else ("Regression" if delta_class == "neg" else "Evaluated")
+        cards.append(
+            f'<div class="iter-card {card_class}"><span class="iter-tag">{_escape(tag)}</span>'
+            f'<div class="iter-title">{_escape(label.title())}</div>'
+            f'<div class="iter-metric">{_fmt(value)}{_escape(_display_unit(contract["unit"]))}</div>'
+            '<ul>'
+            f'<li>Stage: {_escape(phase.get("stage_completed", "evaluate"))}</li>'
+            f'<li>Training rows: {_fmt(training_rows)}</li>'
+            f'<li>Synthetic / mined: {_fmt(synthetic_rows)} / {_fmt(mined_rows)}</li>'
+            f'<li class="{"" if passed else "warn"}">{_escape(note)}</li>'
+            '</ul></div>'
+        )
+        if label != "baseline":
+            pool_rows.append(
+                f'<tr><td><strong>{_escape(label.title())}</strong></td>'
+                f'<td class="num">{_fmt(synthetic_rows)}</td>'
+                f'<td class="num">{_fmt(mined_rows)}</td>'
+                f'<td class="num pos">{_fmt(synthetic_rows + mined_rows)}</td></tr>'
+            )
+    if not table_rows:
+        table_rows.append('<tr><td colspan="8">No completed evaluation yet.</td></tr>')
+    if not cards:
+        cards.append('<div class="iter-card"><span class="iter-tag">Pending</span><div class="iter-title">No completed iteration</div><div class="iter-metric">—</div></div>')
+    if not pool_rows:
+        pool_rows.append('<tr><td colspan="4">No augmentation has been committed yet.</td></tr>')
+    return "\n".join(table_rows), "\n".join(cards), "\n".join(pool_rows)
+
+
+def _dataset_card(state: dict[str, Any]) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    path = pathlib.Path(str(config.get("kpi_test_csv", "")))
+    rows = _csv_rows(path)
+    counts: dict[str, int] = {}
+    for row in rows:
+        label = str(row.get("label", row.get("object_name", "Unlabeled"))).strip() or "Unlabeled"
+        counts[label] = counts.get(label, 0) + 1
+    if not rows:
+        return '<p class="info-text">KPI dataset details are not available yet. The report will refresh automatically after evaluation artifacts are committed.</p>'
+    body = [
+        f'<p class="info-text"><strong>{len(rows):,}</strong> evaluation rows from <code>{_escape(path.name)}</code>. Counts are read directly from the frozen KPI CSV.</p>',
+        '<table class="data-table"><thead><tr><th>Category</th><th>Rows</th><th>Share</th></tr></thead><tbody>',
+    ]
+    for label, count in sorted(counts.items()):
+        body.append(f'<tr><td>{_escape(label)}</td><td class="num">{count:,}</td><td class="num">{count / len(rows) * 100:.1f}%</td></tr>')
+    body.append('</tbody></table>')
+    return "\n".join(body)
+
+
+def _context_cards(state: dict[str, Any], contract: dict[str, Any]) -> tuple[str, str]:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    evaluator = contract.get("evaluator", {})
+    evaluator_name = evaluator.get("id") or evaluator.get("producer") or evaluator.get("path") or evaluator.get("type", "configured evaluator")
+    constraints = contract.get("constraints", [])
+    constraint_text = ", ".join(
+        f"{item.get('display_name', item.get('name'))} {item.get('operator')} {item.get('target'):g}{_display_unit(str(item.get('unit', '')))}"
+        for item in constraints
+    ) or "none"
+    problem = (
+        '<p class="info-text">Improve NVIDIA TAO Visual ChangeNet PCB inspection against the approved customer KPI without changing the evaluation contract.</p>'
+        '<ul class="context-list">'
+        f'<li><strong>Primary gate:</strong> {_escape(render_target(contract))}</li>'
+        f'<li><strong>Evaluator:</strong> {_escape(evaluator_name)}</li>'
+        f'<li><strong>Secondary constraints:</strong> {_escape(constraint_text)}</li>'
+        f'<li><strong>Iteration budget:</strong> {_fmt(state.get("max_iterations"))}</li>'
+        '</ul>'
+    )
+    mining = config.get("mining_filter", {})
+    if not isinstance(mining, dict):
+        mining = {}
+    approach = (
+        '<p class="info-text">The DEFT loop evaluates the current checkpoint, identifies root causes, routes weak samples, expands the training set with mined real images and AnomalyGen defects, then fine-tunes and re-evaluates.</p>'
+        '<div class="insight">'
+        f'<strong>Run policy:</strong> up to {_fmt(state.get("max_iterations"))} iterations; '
+        f'k-NN metric <code>{_escape(mining.get("metric", "cosine"))}</code> with minimum similarity <code>{_fmt(mining.get("min_similarity"))}</code>. '
+        'Every number shown here is rebuilt from canonical state and committed artifacts.'
+        '</div>'
+    )
+    return problem, approach
+
+
+def _diagnostic_rows(
+    contract: dict[str, Any], best_result: dict[str, Any] | None
+) -> str:
+    rows: list[str] = []
+    if best_result is not None:
+        passed, _ = result_passes(contract, best_result)
+        rows.append(
+            f'<tr><td>{_escape(contract["display_name"])}</td><td class="num">{_fmt(best_result["value"])}{_escape(_display_unit(contract["unit"]))}</td>'
+            f'<td class="num">{_escape(contract["operator"])} {_fmt(contract["target"])}</td>'
+            f'<td><span class="{"check" if passed else "warn"}">{"✓" if passed else "△"}</span></td></tr>'
+        )
+        values = best_result.get("constraints", {})
+        if isinstance(values, dict):
+            for constraint in contract.get("constraints", []):
+                value = values.get(constraint["name"])
+                rows.append(
+                    f'<tr><td>{_escape(constraint["display_name"])}</td><td class="num">{_fmt(value)}{_escape(_display_unit(constraint["unit"]))}</td>'
+                    f'<td class="num">{_escape(constraint["operator"])} {_fmt(constraint["target"])}</td>'
+                    f'<td>{"recorded" if value is not None else "not available"}</td></tr>'
+                )
+    return "\n".join(rows) or '<tr><td colspan="4">Evaluator diagnostics are not available yet.</td></tr>'
+
+
+def _rca_rows(results_dir: pathlib.Path, best_label: str | None) -> tuple[str, str]:
+    if best_label is None:
+        empty = '<tr><td colspan="4">RCA artifacts are not available yet.</td></tr>'
+        return empty, empty
+    base = results_dir / best_label
+    score_candidates = [
+        base / "rca_results" / "score_distribution.csv",
+        base / "inference" / "threshold_metrics.csv",
+    ]
+    score_rows = next((_csv_rows(path) for path in score_candidates if path.is_file()), [])
+    rendered_score: list[str] = []
+    for row in score_rows[:8]:
+        values = list(row.values())
+        values += ["—"] * (4 - len(values))
+        rendered_score.append('<tr>' + ''.join(f'<td>{_escape(value)}</td>' for value in values[:4]) + '</tr>')
+    defect_rows = _csv_rows(base / "rca_results" / "defect_type_rows.csv")
+    rendered_defect: list[str] = []
+    for row in defect_rows[:20]:
+        values = list(row.values())
+        values += ["—"] * (4 - len(values))
+        rendered_defect.append('<tr>' + ''.join(f'<td>{_escape(value)}</td>' for value in values[:4]) + '</tr>')
+    empty_score = '<tr><td colspan="4">Score-distribution artifact is not available.</td></tr>'
+    empty_defect = '<tr><td colspan="4">Per-defect RCA artifact is not available.</td></tr>'
+    return "\n".join(rendered_score) or empty_score, "\n".join(rendered_defect) or empty_defect
+
+
+def _thumbnail_data_uri(path: pathlib.Path) -> str | None:
+    try:
+        from PIL import Image
+
+        with Image.open(path) as image:
+            image.thumbnail((256, 256))
+            if image.mode not in ("RGB", "L"):
+                background = Image.new("RGB", image.size, "white")
+                if "A" in image.getbands():
+                    background.paste(image, mask=image.getchannel("A"))
+                else:
+                    background.paste(image)
+                image = background
+            elif image.mode != "RGB":
+                image = image.convert("RGB")
+            payload = io.BytesIO()
+            image.save(payload, format="JPEG", quality=86, optimize=True)
+        return "data:image/jpeg;base64," + base64.b64encode(payload.getvalue()).decode("ascii")
+    except (ImportError, OSError, ValueError):
+        return None
+
+
+def _sample_html(
+    results_dir: pathlib.Path,
+    state: dict[str, Any],
+    best_label: str | None,
+) -> str:
+    labels = [
+        label
+        for label in sorted(state.get("iterations", {}), key=_label_key, reverse=True)
+        if label != "baseline"
+    ]
+    if best_label in labels:
+        labels.remove(best_label)
+        labels.insert(0, best_label)
+    selected: tuple[pathlib.Path, pathlib.Path, str] | None = None
+    for label in labels:
+        number = label.removeprefix("iter")
+        ok_dir = results_dir / label / "dataset" / "images" / f"synthetic_iter{number}_ok"
+        ng_dir = results_dir / label / "dataset" / "images" / f"synthetic_iter{number}_ng"
+        for ok_path in sorted(path for path in ok_dir.glob("*") if path.is_file()):
+            ng_path = ng_dir / ok_path.name
+            if ng_path.is_file():
+                selected = (ok_path, ng_path, label)
+                break
+        if selected:
+            break
+    placeholder = '<div class="sample-img-placeholder">No image</div>'
+    if selected:
+        ok_uri = _thumbnail_data_uri(selected[0])
+        ng_uri = _thumbnail_data_uri(selected[1])
+        ok_html = f'<img class="sample-img" src="{ok_uri}" alt="AnomalyGen input OK">' if ok_uri else placeholder
+        ng_html = f'<img class="sample-img" src="{ng_uri}" alt="AnomalyGen output synthetic NG">' if ng_uri else placeholder
+        label = selected[2]
+    else:
+        ok_html = ng_html = placeholder
+        label = "No completed synthetic pair"
+    generated = 0
+    if selected:
+        phase = state.get("iterations", {}).get(selected[2], {})
+        generated = _csv_row_count(phase.get("anomalygen_sdg_csv")) or 0
+    return (
+        f'<p class="info-text"><strong>AnomalyGen:</strong> enabled · num_SDG: {_fmt(generated)}</p>'
+        f'<div class="sample-iter-block"><h3 class="sub-title">{_escape(label.title())}</h3><div class="sample-strip">'
+        '<div class="sample-col"><div class="sample-col-title">AnomalyGen Input (OK / normal)</div>'
+        f'{ok_html}</div><div class="sample-col"><div class="sample-col-title">AnomalyGen Output (synthetic NG)</div>{ng_html}</div>'
+        '</div></div>'
+    )
+
+
+def _recommendations(
+    terminal: bool, passed: bool, failures: list[str], *, failed: bool = False
+) -> str:
+    if failed:
+        items = [
+            ("Review the hard stop", "Use the canonical audit output and committed error event; do not infer recovery from this report."),
+            ("Start from valid disk evidence", "Resume only when the state audit names a legal next action, or initialize a fresh run."),
+        ]
+    elif not terminal:
+        items = [
+            ("Keep the loop running", "The report refreshes automatically after every committed stage."),
+            ("Review live evidence", "Use the iteration table and augmentation pool to spot regressions early."),
+        ]
+    elif passed:
+        items = [
+            ("Promote the best checkpoint", "Validate the recorded checkpoint in the deployment environment."),
+            ("Archive the evidence", "Keep this self-contained report with the canonical state and loop log."),
+        ]
+    else:
+        detail = ", ".join(failures) if failures else "the remaining KPI gap"
+        items = [
+            ("Continue from the best checkpoint", f"Prioritize {detail} in the next approved run."),
+            ("Inspect augmentation balance", "Review mined versus synthetic volume before increasing the iteration budget."),
+        ]
+    return "\n".join(
+        f'<div class="reco"><div class="num-badge">{index}</div><div class="reco-body"><div class="reco-title">{_escape(title)}</div><div class="reco-desc">{_escape(description)}</div></div></div>'
+        for index, (title, description) in enumerate(items, 1)
+    )
+
+
+def _load_source_template() -> str:
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
+    doc_start = template.index("<!--\n====")
+    outer_close = template.index("-->\n<html")
+    return template[:doc_start] + template[outer_close + 3 :]
+
+
+def _atomic_write(path: pathlib.Path, text: str) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def render(
+    results_dir: pathlib.Path,
+    *,
+    audit_report: dict[str, Any] | None = None,
+) -> pathlib.Path:
+    results_dir = results_dir.expanduser().resolve()
+    state_path = results_dir / "deft_state.json"
+    if not state_path.is_file():
+        raise ValueError(f"state file not found: {state_path}")
+    state = _read_json(state_path)
+    if not isinstance(state, dict):
+        raise ValueError("deft_state.json root must be an object")
+    contract = contract_from_state(state)
+    entries = _read_log(results_dir / "loop_log.jsonl")
+    terminal = (
+        bool(audit_report.get("terminal"))
+        if audit_report is not None
+        else bool(entries and entries[-1].get("stage") == "loop_stop")
+    )
+    run_status = (
+        str(audit_report.get("status", "IN_PROGRESS"))
+        if audit_report is not None
+        else (
+            "FAILED"
+            if any(entry.get("status") == "error" for entry in entries)
+            else ("COMPLETE" if terminal else "IN_PROGRESS")
+        )
+    )
+    candidates = _metric_candidates(state, contract)
+    best_label: str | None = None
+    best_phase: dict[str, Any] = {}
+    best_result: dict[str, Any] | None = None
+    if candidates:
+        best_label, best_phase, best_result = pick_best(candidates, contract)
+
+    passed = False
+    failures: list[str] = []
+    if best_result is not None:
+        passed, failures = result_passes(contract, best_result)
+    unit = _display_unit(contract["unit"])
+    completed_iterations = sum(1 for label, _, _ in candidates if label != "baseline")
+    iteration_rows, iter_cards, pool_rows = _iteration_rows(
+        state, contract, candidates, best_label
+    )
+    problem_html, approach_html = _context_cards(state, contract)
+    score_rows, defect_rows = _rca_rows(results_dir, best_label)
+    low, high, steps = _chart_extent(
+        (result["value"] for _, _, result in candidates), contract["target"]
+    )
+    metric_data = [
+        {
+            "label": "Baseline" if label == "baseline" else label.title(),
+            "value": float(result["value"]),
+            "color": "#76b900" if label == best_label else "#b0b0b0",
+        }
+        for label, _, result in candidates
+    ]
+
+    if run_status == "FAILED":
+        final_status = "RUN ENDED AT A HARD STOP"
+        final_class = ""
+        banner = (
+            '<div class="kpi-banner"><div class="icon">!</div><div class="content">'
+            '<div class="title">Run ended at a hard stop</div>'
+            '<div class="body">Review the committed error event and canonical audit output before starting a fresh run.</div></div></div>'
+        )
+    elif not terminal:
+        final_status = "IN PROGRESS"
+        final_class = ""
+        banner = ""
+    elif passed:
+        final_status = "MET"
+        final_class = "green"
+        banner = (
+            '<div class="kpi-banner" style="background:rgba(118,185,0,0.12);border-color:rgba(118,185,0,0.4);">'
+            '<div class="icon" style="background:var(--nvidia-green);color:#000">✓</div><div class="content">'
+            '<div class="title" style="color:var(--nvidia-green)">KPI MET</div>'
+            f'<div class="body">{_escape(best_label.title() if best_label else "Best result")} achieved <strong>{_escape(render_target(contract))}</strong>.</div></div></div>'
+        )
+    elif best_result is not None:
+        value = float(best_result["value"])
+        gap = value - contract["target"] if contract["operator"] in MINIMIZING_OPERATORS else contract["target"] - value
+        gap_unit = "pp" if contract["unit"] == "%" else unit
+        final_status = f"{_fmt(abs(gap))}{gap_unit} from target"
+        final_class = ""
+        banner = (
+            '<div class="kpi-banner" style="background:rgba(255,188,1,0.10);border-color:rgba(255,188,1,0.35);">'
+            '<div class="icon" style="background:var(--nvidia-yellow);color:#000">i</div><div class="content">'
+            '<div class="title" style="color:var(--nvidia-yellow)">Best result so far</div>'
+            f'<div class="body">{_escape(best_label.title() if best_label else "The run")} finished <strong>{_escape(final_status)}</strong>.</div></div></div>'
+        )
+    else:
+        final_status = "NO EVALUATION"
+        final_class = ""
+        banner = ""
+
+    rca_insight = (
+        f'<strong>Best evaluated phase:</strong> {_escape(best_label.title())} at {_fmt(best_result["value"])}{_escape(unit)}.'
+        if best_label and best_result
+        else "RCA will appear after the first evaluated checkpoint is committed."
+    )
+    threshold_insight = (
+        f'Operating threshold: <code>{_fmt(best_phase.get("threshold"))}</code>. The primary KPI remains {_escape(render_target(contract))}.'
+    )
+    generated_date = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    values = {
+        "GENERATED_DATE": generated_date,
+        "KPI_TARGET": _escape(render_target(contract)),
+        "PRIMARY_METRIC_LABEL": _escape(contract["display_name"]),
+        "PRIMARY_METRIC_UNIT": _escape(unit),
+        "PRIMARY_METRIC_UNIT_JSON": _json_for_html(unit),
+        "METRIC_DIRECTION_LABEL": "Lower is better" if contract["operator"] in MINIMIZING_OPERATORS else "Higher is better",
+        "METRIC_DATA_JSON": _json_for_html(metric_data),
+        "METRIC_TARGET_VALUE": _fmt(contract["target"]),
+        "METRIC_Y_MIN": _fmt(low, 8),
+        "METRIC_Y_MAX": _fmt(high, 8),
+        "METRIC_Y_STEPS_JSON": _json_for_html(steps),
+        "METRIC_MINIMIZES_JSON": json.dumps(contract["operator"] in MINIMIZING_OPERATORS),
+        "MAX_ITERATIONS": _fmt(state.get("max_iterations")),
+        "ITERATIONS_RUN": str(completed_iterations),
+        "KPI_BANNER_HTML": banner,
+        "PROBLEM_STATEMENT_HTML": problem_html,
+        "KPI_DATASET_HTML": _dataset_card(state),
+        "APPROACH_HTML": approach_html,
+        "ITERATION_TABLE_ROWS_HTML": iteration_rows,
+        "MINING_POOL_ROWS_HTML": pool_rows,
+        "RCA_INSIGHT_HTML": rca_insight,
+        "THRESHOLD_INSIGHT_HTML": threshold_insight,
+        "SCORE_DIST_ROWS_HTML": score_rows,
+        "EVALUATOR_DIAGNOSTIC_ROWS_HTML": _diagnostic_rows(contract, best_result),
+        "DEFECT_TYPE_ROWS_HTML": defect_rows,
+        "BEST_ITER_LABEL": _escape(best_label.title() if best_label else "Pending"),
+        "DATA_SAMPLES_HTML": _sample_html(results_dir, state, best_label),
+        "ITER_CARDS_HTML": iter_cards,
+        "RECOMMENDATIONS_HTML": _recommendations(
+            terminal,
+            passed and run_status != "FAILED",
+            failures,
+            failed=run_status == "FAILED",
+        ),
+        "FINAL_KPI_STATUS": _escape(final_status),
+        "FINAL_KPI_STATUS_CLASS": final_class,
+        "FINAL_ITER_COUNT_LABEL": f"{completed_iterations} / {_fmt(state.get('max_iterations'))}",
+        "BEST_METRIC_VALUE": _fmt(best_result.get("value") if best_result else None),
+        "BEST_THRESHOLD": _fmt(best_phase.get("threshold")),
+        "BEST_CHECKPOINT": _escape(best_phase.get("best_ckpt_path", "not available")),
+    }
+    template = _load_source_template()
+    rendered = template
+    for name, value in values.items():
+        rendered = rendered.replace("{{ " + name + " }}", str(value))
+    remaining = sorted(set(re.findall(r"\{\{\s+[A-Z0-9_]+\s+\}\}", rendered)))
+    if remaining:
+        raise ValueError("unfilled report placeholders: " + ", ".join(remaining))
+    required = (
+        "DEFT Loop Final Report",
+        "Progress Overview",
+        "Per-Iteration Results",
+        "Final Status",
+        "--nvidia-green: #76b900",
+    )
+    missing = [token for token in required if token not in rendered]
+    if missing:
+        raise ValueError("rendered report is missing required content: " + ", ".join(missing))
+    output = results_dir / REPORT_NAME
+    _atomic_write(output, rendered)
+    return output
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--require-terminal",
+        action="store_true",
+        help="Refuse to render unless the canonical loop log ends in loop_stop.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        from audit_deft_run import audit
+
+        report = audit(args.results_dir.expanduser().resolve())
+        if report["status"] == "INVALID":
+            raise ValueError("audit failed: " + "; ".join(report["errors"]))
+        if args.require_terminal and not report["terminal"]:
+            raise ValueError("--require-terminal requested but loop_stop is not committed")
+        output = render(args.results_dir, audit_report=report)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"render_report: {exc}", file=sys.stderr)
+        return 2
+    print(f"render_report: wrote {output} ({output.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-aoi/scripts/render_report.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/render_report.py
@@ -188,6 +188,225 @@ def _format_duration(seconds: Any) -> str:
     return f"{secs}s"
 
 
+def _metric_summary_html(
+    result: dict[str, Any] | None, contract: dict[str, Any]
+) -> str:
+    if result is None:
+        return "not available"
+    detail = (
+        f"{_escape(contract['display_name'])} = "
+        f"{_fmt(result.get('value'))}{_escape(_display_unit(contract['unit']))}"
+    )
+    values = result.get("constraints", {})
+    if isinstance(values, dict):
+        constraints: list[str] = []
+        for constraint in contract.get("constraints", []):
+            value = values.get(constraint.get("name"))
+            if value is None:
+                continue
+            constraints.append(
+                f"{_escape(constraint.get('display_name', constraint.get('name')))} "
+                f"{_fmt(value)}{_escape(_display_unit(str(constraint.get('unit', ''))))}"
+            )
+        if constraints:
+            detail += " @ " + ", ".join(constraints)
+    return detail
+
+
+def _dataset_summary_html(state: dict[str, Any]) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    rows = _csv_rows(pathlib.Path(str(config.get("kpi_test_csv", ""))))
+    if not rows:
+        return "dataset not available"
+    counts: dict[str, int] = {}
+    for row in rows:
+        label = str(
+            row.get("label", row.get("object_name", "Unlabeled"))
+        ).strip() or "Unlabeled"
+        counts[label] = counts.get(label, 0) + 1
+    ordered = sorted(
+        counts.items(),
+        key=lambda item: (item[0].upper() not in {"PASS", "OK"}, item[0].lower()),
+    )
+    breakdown = " / ".join(
+        f"{count:,} {_escape(label)}" for label, count in ordered
+    )
+    return f"{len(rows):,} rows: {breakdown}"
+
+
+def _recorded_duration_summary(
+    entries: list[dict[str, Any]], completed_iterations: int
+) -> str:
+    timed = [entry for entry in entries if entry.get("stage") != "loop_stop"]
+    durations = [
+        int(entry["duration_sec"])
+        for entry in timed
+        if isinstance(entry.get("duration_sec"), int)
+        and not isinstance(entry.get("duration_sec"), bool)
+        and int(entry["duration_sec"]) > 0
+    ]
+    if not durations:
+        return f"{completed_iterations} iterations · duration not recorded"
+    total = sum(durations)
+    missing = len(timed) - len(durations)
+    if missing:
+        return (
+            f"{completed_iterations} iterations · {_format_duration(total)} recorded · "
+            f"{missing} stage duration{'s' if missing != 1 else ''} missing"
+        )
+    if completed_iterations <= 0:
+        return f"0 iterations · {_format_duration(total)} recorded"
+    average = max(1, round(total / completed_iterations))
+    return (
+        f"{completed_iterations} iters × ~{_format_duration(average)} = "
+        f"{_format_duration(total)} total time"
+    )
+
+
+def _sdg_summary_html(
+    state: dict[str, Any], entries: list[dict[str, Any]]
+) -> str:
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        return "not available"
+    generated: list[int] = []
+    for label in sorted(iterations, key=_label_key):
+        if label == "baseline" or not isinstance(iterations[label], dict):
+            continue
+        phase = iterations[label]
+        count = (
+            0
+            if phase.get("anomalygen_skipped")
+            else _csv_row_count(phase.get("anomalygen_sdg_csv"))
+        )
+        if isinstance(count, int):
+            generated.append(count)
+    if not generated:
+        return "not available"
+    total = sum(generated)
+    average = round(total / len(generated))
+    detail = f"{average:,} images/iter · {total:,} total"
+    durations = [
+        int(entry["duration_sec"])
+        for entry in entries
+        if entry.get("stage") == "anomalygen"
+        and isinstance(entry.get("duration_sec"), int)
+        and not isinstance(entry.get("duration_sec"), bool)
+        and int(entry["duration_sec"]) > 0
+    ]
+    if durations:
+        detail += f" · {_format_duration(round(sum(durations) / len(durations)))} avg SDG time/iter"
+    else:
+        detail += " · SDG duration not recorded"
+    return detail
+
+
+def _mining_raw_count(phase: dict[str, Any]) -> int | None:
+    summary = phase.get("mining_summary")
+    if not isinstance(summary, str) or not summary:
+        return 0 if phase.get("data_mining_skipped") else None
+    rows = _csv_rows(pathlib.Path(summary))
+    if not rows:
+        return None
+    try:
+        value = int(rows[0]["candidate_count"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return value if value >= 0 else None
+
+
+def _growth_rows(state: dict[str, Any]) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    baseline_total = _csv_row_count(config.get("training_csv"))
+    rows = [
+        '<tr><td><strong>Baseline</strong></td><td class="num">0</td>'
+        '<td class="num">0</td><td class="num">0</td>'
+        f'<td class="num">{_fmt(baseline_total)}</td>'
+        '<td class="num">—</td></tr>'
+    ]
+    previous_total = baseline_total
+    iterations = state.get("iterations", {})
+    if not isinstance(iterations, dict):
+        return "\n".join(rows)
+    for label in sorted(iterations, key=_label_key):
+        phase = iterations[label]
+        if label == "baseline" or not isinstance(phase, dict):
+            continue
+        total = _csv_row_count(phase.get("combined_training_csv"))
+        sdg_generated = (
+            0
+            if phase.get("anomalygen_skipped")
+            else _csv_row_count(phase.get("anomalygen_sdg_csv"))
+        )
+        delta = (
+            total - previous_total
+            if isinstance(total, int) and isinstance(previous_total, int)
+            else None
+        )
+        new_unique = delta if isinstance(delta, int) and delta >= 0 else None
+        delta_html = (
+            "—"
+            if delta is None
+            else (f"+{delta:,}" if delta > 0 else f"{delta:,}")
+        )
+        rows.append(
+            f'<tr><td><strong>{_escape(label.title())}</strong></td>'
+            f'<td class="num">{_fmt(_mining_raw_count(phase))}</td>'
+            f'<td class="num">{_fmt(sdg_generated)}</td>'
+            f'<td class="num">{_fmt(new_unique)}</td>'
+            f'<td class="num">{_fmt(total)}</td>'
+            f'<td class="num">{delta_html}</td></tr>'
+        )
+        if isinstance(total, int):
+            previous_total = total
+    return "\n".join(rows)
+
+
+def _run_summary_rows(
+    state: dict[str, Any],
+    contract: dict[str, Any],
+    candidates: list[tuple[str, dict[str, Any], dict[str, Any]]],
+    entries: list[dict[str, Any]],
+) -> str:
+    config = state.get("config", {})
+    if not isinstance(config, dict):
+        config = {}
+    baseline = next(
+        (result for label, _, result in candidates if label == "baseline"), None
+    )
+    end_label, end_result = (
+        (candidates[-1][0], candidates[-1][2])
+        if candidates
+        else (None, None)
+    )
+    completed = sum(1 for label, _, _ in candidates if label != "baseline")
+    gpu = f"{_fmt(config.get('num_gpus'))}x {_fmt(config.get('gpu_model'))}"
+    baseline_detail = _metric_summary_html(baseline, contract)
+    if baseline is not None:
+        baseline_detail += f" ({_dataset_summary_html(state)})"
+    end_detail = _metric_summary_html(end_result, contract)
+    if end_label is not None and end_result is not None:
+        end_detail += f" ({_escape(end_label.title())})"
+    details = (
+        ("Prompt/Goal", f"Run DEFT loop · KPI: {_escape(render_target(contract))}"),
+        ("Model", "NVIDIA TAO Visual ChangeNet classification"),
+        ("GPU", gpu),
+        ("Baseline (pre-DEFT)", baseline_detail),
+        ("Data Routing", "AnomalyGen SDG &amp; k-NN Mining"),
+        ("Iterations × Time", _escape(_recorded_duration_summary(entries, completed))),
+        ("SDG Images", _escape(_sdg_summary_html(state, entries))),
+        ("End Result", end_detail),
+    )
+    return "\n".join(
+        f'<tr><td><strong>{_escape(item)}</strong></td><td>{detail}</td></tr>'
+        for item, detail in details
+    )
+
+
 def _iteration_rows(
     state: dict[str, Any],
     contract: dict[str, Any],
@@ -582,12 +801,7 @@ def render(
         gap_unit = "pp" if contract["unit"] == "%" else unit
         final_status = f"{_fmt(abs(gap))}{gap_unit} from target"
         final_class = ""
-        banner = (
-            '<div class="kpi-banner" style="background:rgba(255,188,1,0.10);border-color:rgba(255,188,1,0.35);">'
-            '<div class="icon" style="background:var(--nvidia-yellow);color:#000">i</div><div class="content">'
-            '<div class="title" style="color:var(--nvidia-yellow)">Best result so far</div>'
-            f'<div class="body">{_escape(best_label.title() if best_label else "The run")} finished <strong>{_escape(final_status)}</strong>.</div></div></div>'
-        )
+        banner = ""
     else:
         final_status = "NO EVALUATION"
         final_class = ""
@@ -618,6 +832,10 @@ def render(
         "MAX_ITERATIONS": _fmt(state.get("max_iterations")),
         "ITERATIONS_RUN": str(completed_iterations),
         "KPI_BANNER_HTML": banner,
+        "RUN_SUMMARY_ROWS_HTML": _run_summary_rows(
+            state, contract, candidates, entries
+        ),
+        "GROWTH_ROWS_HTML": _growth_rows(state),
         "PROBLEM_STATEMENT_HTML": problem_html,
         "KPI_DATASET_HTML": _dataset_card(state),
         "APPROACH_HTML": approach_html,
@@ -653,6 +871,8 @@ def render(
         raise ValueError("unfilled report placeholders: " + ", ".join(remaining))
     required = (
         "DEFT Loop Final Report",
+        "Run Configuration &amp; Outcome",
+        "Training Set Growth",
         "Progress Overview",
         "Per-Iteration Results",
         "Final Status",

--- a/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+for module_name in ("audit_deft_run", "init_deft_state", "metric_contract", "render_report"):
+    sys.modules.pop(module_name, None)
+sys.path.insert(0, str(SCRIPTS))
+
+import audit_deft_run  # noqa: E402
+import init_deft_state  # noqa: E402
+import render_report  # noqa: E402
+
+
+class ReportRenderingTests(unittest.TestCase):
+    def _state(self, results: pathlib.Path) -> dict:
+        contract = {
+            "name": "escape_cost",
+            "display_name": "Weighted escape cost",
+            "operator": "<=",
+            "target": 0.02,
+            "unit": "cost/board",
+            "evaluator": {
+                "type": "artifact",
+                "producer": "test",
+                "path_template": str(
+                    results / "{iter_label}/evaluate/metric_result.json"
+                ),
+            },
+            "constraints": [],
+        }
+        return {
+            "version": 2,
+            "started_at": "2026-08-04T00:00:00+00:00",
+            "kpi_target": "Weighted escape cost <= 0.02 cost/board",
+            "metric_contract": contract,
+            "results_dir": str(results),
+            "max_iterations": 2,
+            "current_iteration": 1,
+            "config": {
+                "kpi_test_csv": str(results / "kpi.csv"),
+                "training_csv": str(results / "training.csv"),
+                "mining_filter": {"metric": "cosine", "min_similarity": 0.9},
+            },
+            "iterations": {
+                "baseline": {
+                    "status": "complete",
+                    "stage_completed": "evaluate",
+                    "best_ckpt_path": str(results / "baseline/train/model.ckpt"),
+                    "threshold": 0.5,
+                    "metric_result": {
+                        "name": "escape_cost",
+                        "value": 0.031,
+                        "unit": "cost/board",
+                        "constraints": {},
+                    },
+                },
+                "iter1": {
+                    "status": "complete",
+                    "stage_completed": "evaluate",
+                    "best_ckpt_path": "</div><script>alert('x')</script>",
+                    "threshold": 0.47,
+                    "mining_mined_count": 8,
+                    "metric_result": {
+                        "name": "escape_cost",
+                        "value": 0.018,
+                        "unit": "cost/board",
+                        "constraints": {},
+                    },
+                },
+            },
+            "_completed_step_values": [],
+            "_status_values": [],
+        }
+
+    def test_renders_release_style_template_and_escapes_disk_text(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            results = pathlib.Path(temporary)
+            (results / "deft_state.json").write_text(
+                json.dumps(self._state(results)), encoding="utf-8"
+            )
+            (results / "loop_log.jsonl").write_text(
+                json.dumps(
+                    {
+                        "seq": 1,
+                        "ts": "2026-08-04T00:01:00Z",
+                        "iter": "iter1",
+                        "stage": "evaluate",
+                        "status": "ok",
+                        "summary": "done",
+                        "duration_sec": 1,
+                    }
+                )
+                + "\n"
+                + json.dumps(
+                    {
+                        "seq": 2,
+                        "ts": "2026-08-04T00:02:00Z",
+                        "iter": "iter1",
+                        "stage": "loop_stop",
+                        "status": "ok",
+                        "summary": "target met",
+                        "duration_sec": 0,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            output = render_report.render(results)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("DEFT Loop Final Report", text)
+            self.assertIn("--nvidia-green: #76b900", text)
+            self.assertIn("KPI MET", text)
+            self.assertNotRegex(text, r"\{\{\s+[A-Z0-9_]+\s+\}\}")
+            self.assertNotIn("</div><script>alert('x')</script>", text)
+            self.assertIn("&lt;/div&gt;&lt;script&gt;alert", text)
+            self.assertIsNone(audit_deft_run._completion_report_error(results))
+
+    def test_partial_state_still_produces_a_complete_live_shell(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            results = pathlib.Path(temporary)
+            state = self._state(results)
+            state["iterations"] = {}
+            state["current_iteration"] = 0
+            (results / "deft_state.json").write_text(
+                json.dumps(state), encoding="utf-8"
+            )
+            output = render_report.render(results)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("IN PROGRESS", text)
+            self.assertIn("No completed evaluation yet", text)
+            self.assertNotRegex(text, r"\{\{\s+[A-Z0-9_]+\s+\}\}")
+
+    def test_inline_chart_json_cannot_close_the_script_element(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            results = pathlib.Path(temporary)
+            state = self._state(results)
+            state["metric_contract"]["unit"] = "</script><script>alert(1)</script>"
+            for phase in state["iterations"].values():
+                phase["metric_result"]["unit"] = state["metric_contract"]["unit"]
+            (results / "deft_state.json").write_text(
+                json.dumps(state), encoding="utf-8"
+            )
+            text = render_report.render(results).read_text(encoding="utf-8")
+            self.assertNotIn('const metricUnit = "</script>', text)
+            self.assertIn(r"\u003c/script\u003e", text)
+
+    def test_initialization_hook_writes_the_live_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            results = root / "results"
+            rc = init_deft_state.main(
+                [
+                    "--results-dir",
+                    str(results),
+                    "--workspace",
+                    str(root / "workspace"),
+                    "--kpi-target",
+                    "FAR <= 1% at recall=100%",
+                    "--max-iterations",
+                    "1",
+                    "--num-gpus",
+                    "1",
+                    "--num-epochs",
+                    "1",
+                    "--num-sdg",
+                    "2",
+                    "--project",
+                    "nvpcb",
+                    "--step",
+                    "1",
+                    "--train-container",
+                    "example/train:1",
+                    "--ag-container",
+                    "example/anomalygen:1",
+                ]
+            )
+            self.assertEqual(rc, 0)
+            report = results / "DEFT_Loop_Report.html"
+            self.assertTrue(report.is_file())
+            self.assertIn("IN PROGRESS", report.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
@@ -12,16 +12,56 @@ import unittest
 
 SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPTS = SKILL_ROOT / "scripts"
-for module_name in ("audit_deft_run", "init_deft_state", "metric_contract", "render_report"):
+for module_name in (
+    "audit_deft_run",
+    "commit_stage",
+    "init_deft_state",
+    "metric_contract",
+    "render_report",
+):
     sys.modules.pop(module_name, None)
 sys.path.insert(0, str(SCRIPTS))
 
 import audit_deft_run  # noqa: E402
+import commit_stage  # noqa: E402
 import init_deft_state  # noqa: E402
 import render_report  # noqa: E402
 
 
 class ReportRenderingTests(unittest.TestCase):
+    def test_allocation_proof_is_summed_and_rejects_invalid_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            allocation = pathlib.Path(temporary) / "allocation.json"
+            allocation.write_text(
+                json.dumps({"bridge": 3, "missing": 2}), encoding="utf-8"
+            )
+            path, total = commit_stage._required_allocation(
+                allocation.resolve(), "--anomalygen-allocation"
+            )
+            self.assertEqual(path, str(allocation.resolve()))
+            self.assertEqual(total, 5)
+
+            allocation.write_text(json.dumps({"bridge": True}), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                commit_stage._required_allocation(
+                    allocation.resolve(), "--anomalygen-allocation"
+                )
+
+    def test_stage_commit_requires_positive_measured_duration(self) -> None:
+        base = [
+            "--results-dir",
+            "/tmp/deft-duration-contract",
+            "--iter-label",
+            "baseline",
+            "--stage",
+            "loop_stop",
+            "--summary",
+            "done",
+        ]
+        with self.assertRaises(SystemExit):
+            commit_stage._parser().parse_args(base)
+        self.assertEqual(commit_stage.main([*base, "--duration-sec", "0"]), 2)
+
     def _state(self, results: pathlib.Path) -> dict:
         contract = {
             "name": "escape_cost",
@@ -49,6 +89,8 @@ class ReportRenderingTests(unittest.TestCase):
             "config": {
                 "kpi_test_csv": str(results / "kpi.csv"),
                 "training_csv": str(results / "training.csv"),
+                "num_gpus": 1,
+                "gpu_model": "NVIDIA RTX PRO 6000 Blackwell (96 GB)",
                 "mining_filter": {"metric": "cosine", "min_similarity": 0.9},
             },
             "iterations": {
@@ -85,9 +127,35 @@ class ReportRenderingTests(unittest.TestCase):
     def test_renders_release_style_template_and_escapes_disk_text(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             results = pathlib.Path(temporary)
-            (results / "deft_state.json").write_text(
-                json.dumps(self._state(results)), encoding="utf-8"
+            state = self._state(results)
+            (results / "training.csv").write_text(
+                "input_path,label\n" + "".join(f"base-{index}.png,PASS\n" for index in range(118)),
+                encoding="utf-8",
             )
+            (results / "kpi.csv").write_text(
+                "input_path,label\na.png,PASS\nb.png,PASS\nc.png,NG-Missing\n",
+                encoding="utf-8",
+            )
+            combined = results / "iter1-combined.csv"
+            combined.write_text(
+                "input_path,label\n" + "".join(f"train-{index}.png,PASS\n" for index in range(120)),
+                encoding="utf-8",
+            )
+            mining_summary = results / "iter1-knn-summary.csv"
+            mining_summary.write_text(
+                "candidate_count,kept_count,rejected_count,similarity_threshold\n5,2,3,0.9\n",
+                encoding="utf-8",
+            )
+            sdg_csv = results / "iter1-sdg.csv"
+            sdg_csv.write_text(
+                "image,label\n"
+                + "".join(f"sdg-{index}.png,NG\n" for index in range(5)),
+                encoding="utf-8",
+            )
+            state["iterations"]["iter1"]["combined_training_csv"] = str(combined)
+            state["iterations"]["iter1"]["mining_summary"] = str(mining_summary)
+            state["iterations"]["iter1"]["anomalygen_sdg_csv"] = str(sdg_csv)
+            (results / "deft_state.json").write_text(json.dumps(state), encoding="utf-8")
             (results / "loop_log.jsonl").write_text(
                 json.dumps(
                     {
@@ -97,7 +165,7 @@ class ReportRenderingTests(unittest.TestCase):
                         "stage": "evaluate",
                         "status": "ok",
                         "summary": "done",
-                        "duration_sec": 1,
+                        "duration_sec": 120,
                     }
                 )
                 + "\n"
@@ -120,10 +188,49 @@ class ReportRenderingTests(unittest.TestCase):
             self.assertIn("DEFT Loop Final Report", text)
             self.assertIn("--nvidia-green: #76b900", text)
             self.assertIn("KPI MET", text)
+            self.assertIn("Run Configuration &amp; Outcome", text)
+            self.assertIn("NVIDIA RTX PRO 6000 Blackwell (96 GB)", text)
+            self.assertIn("1 iters × ~2m 0s = 2m 0s total time", text)
+            self.assertIn("KNN Raw Mined", text)
+            self.assertIn("SDG Generated", text)
+            self.assertIn("New Unique Images (After Dedup)", text)
+            self.assertIn(">118</td>", text)
+            self.assertIn(">120</td>", text)
+            self.assertIn(">+2</td>", text)
             self.assertNotRegex(text, r"\{\{\s+[A-Z0-9_]+\s+\}\}")
             self.assertNotIn("</div><script>alert('x')</script>", text)
             self.assertIn("&lt;/div&gt;&lt;script&gt;alert", text)
             self.assertIsNone(audit_deft_run._completion_report_error(results))
+
+    def test_terminal_gap_has_no_informational_kpi_banner(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            results = pathlib.Path(temporary)
+            state = self._state(results)
+            state["iterations"]["iter1"]["metric_result"]["value"] = 0.025
+            (results / "deft_state.json").write_text(
+                json.dumps(state), encoding="utf-8"
+            )
+            (results / "loop_log.jsonl").write_text(
+                json.dumps(
+                    {
+                        "seq": 1,
+                        "ts": "2026-08-04T00:02:00Z",
+                        "iter": "iter1",
+                        "stage": "loop_stop",
+                        "status": "ok",
+                        "summary": "iteration budget reached",
+                        "duration_sec": 0,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            text = render_report.render(results).read_text(encoding="utf-8")
+            self.assertIn("0.005 cost/board from target", text)
+            self.assertNotIn("Best result so far", text)
+            self.assertNotIn(">i</div>", text)
+            self.assertNotIn("KPI MET", text)
 
     def test_partial_state_still_produces_a_complete_live_shell(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -170,6 +277,8 @@ class ReportRenderingTests(unittest.TestCase):
                     "1",
                     "--num-gpus",
                     "1",
+                    "--gpu-model",
+                    "NVIDIA RTX PRO 6000 Blackwell (96 GB)",
                     "--num-epochs",
                     "1",
                     "--num-sdg",


### PR DESCRIPTION
## Problem

The DEFT AOI workflows relied on a reporter agent to generate the final HTML report. These are long-running workflows, so their context can become large enough that the final reporter invocation is skipped, leaving the report stale or missing.

## Why this was easy to miss

The workflow still completes and its canonical state and artifacts remain valid. Short runs also tend to invoke the reporter normally, so the issue mainly appears near the end of longer runs.

## Change

Add deterministic renderers for both ChangeNet and Cosmos3. Reports are generated at initialization and refreshed after every committed stage, while the legacy reporter agents remain as compatibility wrappers. Also enrich the report content and add version-aware image resolution.

## Verification

Targeted report-rendering, bare-workflow, and version-contract suites: **35 passed, 16 subtests passed**.