### PR TITLE
Migrate Cosmos Auto-Prompter AutoML from GitLab

### DIFF
--- a/scripts/generate_dataclass_schemas.py
+++ b/scripts/generate_dataclass_schemas.py
@@ -236,7 +236,7 @@ def unwrap_cosmos_non_train_action_schema(schema: dict[str, Any], action: str) -
 
 
 def apply_cosmos_evaluate_autoprompt_metadata(schema: dict[str, Any]) -> dict[str, Any]:
-    """Add bounded Auto-Prompter-style search metadata for Cosmos evaluate."""
+    """Add bounded seeds and reflective Auto-Prompter metadata for Cosmos evaluate."""
     schema["automl_default_parameters"] = list(COSMOS_EVALUATE_AUTOML_DEFAULT_PARAMETERS)
 
     properties = schema.setdefault("properties", {})
@@ -249,9 +249,10 @@ def apply_cosmos_evaluate_autoprompt_metadata(schema: dict[str, Any]) -> dict[st
             {
                 "automl_enabled": True,
                 "description": (
-                    "System prompt for the evaluation tasks. AutoML treats this as a "
-                    "bounded prompt-candidate search for zero-shot Metropolis/VSS "
-                    "evaluation."
+                    "System prompt for zero-shot Metropolis/VSS evaluation. The enum "
+                    "provides seed candidates for bounded algorithms; autoresearch can "
+                    "evolve free-form prompts when dataset.system_prompt is listed in "
+                    "evolvable_text_parameters."
                 ),
                 "enum": list(COSMOS_METROPOLIS_SYSTEM_PROMPT_OPTIONS),
                 "option_weights": [0.4, 0.25, 0.2, 0.15],

--- a/scripts/generate_dataclass_schemas.py
+++ b/scripts/generate_dataclass_schemas.py
@@ -60,6 +60,41 @@ COMMON_ACTION_KEYS = {
     "train",
 }
 
+COSMOS_METROPOLIS_SYSTEM_PROMPT_OPTIONS = [
+    (
+        "You are a helpful assistant that can answer questions about a "
+        "street-view CCTV footage. The vehicles that need attention are "
+        "marked with bounding boxes and IDs."
+    ),
+    (
+        "You are a careful video event verification assistant for traffic "
+        "and security CCTV. Answer only from visible evidence, track object "
+        "IDs and bounding boxes, and state yes/no when the question asks "
+        "whether an event occurred."
+    ),
+    (
+        "You are a Metropolis VLM assistant for surveillance video QA. Focus "
+        "on temporal order, object interactions, near misses, direction of "
+        "travel, and safety-relevant evidence. Prefer concise factual answers."
+    ),
+    (
+        "You are an event-verification assistant. Inspect the full clip before "
+        "answering, compare the question with observed actions, ignore "
+        "unsupported assumptions, and return the most specific answer allowed "
+        "by the evidence."
+    ),
+]
+
+COSMOS_EVALUATE_AUTOML_DEFAULT_PARAMETERS = [
+    "dataset.system_prompt",
+    "vision.nframes",
+    "generation.max_tokens",
+    "generation.temperature",
+    "generation.repetition_penalty",
+    "generation.presence_penalty",
+    "generation.frequency_penalty",
+]
+
 
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
@@ -178,6 +213,87 @@ def filter_schema(schema: dict[str, Any], valid_actions: set[str], current_actio
     return schema
 
 
+def unwrap_cosmos_non_train_action_schema(schema: dict[str, Any], action: str) -> dict[str, Any]:
+    """Keep Cosmos non-train schemas in the flat TOML shape consumed by runtime."""
+    properties = schema.get("properties", {})
+    defaults = schema.get("default", {})
+    action_properties = properties.get(action)
+    action_defaults = defaults.get(action)
+    if not isinstance(action_properties, dict) or not isinstance(action_defaults, dict):
+        return schema
+
+    nested_properties = action_properties.get("properties")
+    if not isinstance(nested_properties, dict):
+        return schema
+
+    properties = {key: value for key, value in properties.items() if key != action}
+    defaults = {key: value for key, value in defaults.items() if key != action}
+    properties.update(nested_properties)
+    defaults.update(action_defaults)
+    schema["properties"] = properties
+    schema["default"] = defaults
+    return schema
+
+
+def apply_cosmos_evaluate_autoprompt_metadata(schema: dict[str, Any]) -> dict[str, Any]:
+    """Add bounded Auto-Prompter-style search metadata for Cosmos evaluate."""
+    schema["automl_default_parameters"] = list(COSMOS_EVALUATE_AUTOML_DEFAULT_PARAMETERS)
+
+    properties = schema.setdefault("properties", {})
+    dataset = properties.get("dataset", {}).get("properties", {})
+    vision = properties.get("vision", {}).get("properties", {})
+    generation = properties.get("generation", {}).get("properties", {})
+
+    if "system_prompt" in dataset:
+        dataset["system_prompt"].update(
+            {
+                "automl_enabled": True,
+                "description": (
+                    "System prompt for the evaluation tasks. AutoML treats this as a "
+                    "bounded prompt-candidate search for zero-shot Metropolis/VSS "
+                    "evaluation."
+                ),
+                "enum": list(COSMOS_METROPOLIS_SYSTEM_PROMPT_OPTIONS),
+                "option_weights": [0.4, 0.25, 0.2, 0.15],
+                "type": "categorical",
+            }
+        )
+    if "nframes" in vision:
+        vision["nframes"].update(
+            {
+                "automl_enabled": True,
+                "enum": [4, 8],
+                "type": "ordered_int",
+            }
+        )
+    if "max_tokens" in generation:
+        generation["max_tokens"].update(
+            {
+                "automl_enabled": True,
+                "enum": [256, 512, 1024, 2048],
+                "type": "ordered_int",
+            }
+        )
+
+    ranges = {
+        "temperature": (0.0, 0.4),
+        "repetition_penalty": (0.8, 1.2),
+        "presence_penalty": (-0.5, 0.5),
+        "frequency_penalty": (-0.5, 0.5),
+    }
+    for parameter, (minimum, maximum) in ranges.items():
+        if parameter in generation:
+            generation[parameter].update(
+                {
+                    "automl_enabled": True,
+                    "minimum": minimum,
+                    "maximum": maximum,
+                }
+            )
+
+    return schema
+
+
 def generate_schema_for_action(
     skill_config: dict[str, Any],
     model_name: str,
@@ -222,6 +338,10 @@ def generate_schema_for_action(
             json_with_meta = dataclass2json_converter.dataclass_to_json(exp_config)
             schema = dataclass2json_converter.create_json_schema(json_with_meta)
             schema = filter_schema(schema, get_valid_action_keys(skill_config, core_module), schema_action)
+            if core_module == "cosmos-rl" and schema_action in {"evaluate", "inference"}:
+                schema = unwrap_cosmos_non_train_action_schema(schema, schema_action)
+            if core_module == "cosmos-rl" and schema_action == "evaluate":
+                schema = apply_cosmos_evaluate_autoprompt_metadata(schema)
             schema["x_tao_schema"] = {
                 "schema_version": 1,
                 "model": model_name,

--- a/scripts/list_automl_support.py
+++ b/scripts/list_automl_support.py
@@ -32,7 +32,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--action",
         default="",
-        help="Filter support to one action such as train, distill, prune, or quantize.",
+        help="Filter support to one action such as train, evaluate, inference, distill, prune, or quantize.",
     )
     return parser.parse_args()
 

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -232,11 +232,9 @@ adjustment in `result["history"][i]["adjustments"]`.
 | `pbt` | Long training where schedules should mutate during training. | population and generation budget |
 | `llm`, `hybrid`, `autoresearch` | User explicitly wants LLM-guided search and has an endpoint configured. | LLM endpoint config plus budget |
 
-For `evaluate` or `inference`, default to Bayesian/BFBO-style search over the
-selected action's prompt, decoding, preprocessing, or runtime config knobs.
-Use a task metric from the action outputs/logs and set `direction` explicitly
-when the metric name is ambiguous. Do not use training-loss assumptions for
-actions that do not update weights.
+For `evaluate` or `inference`, use Bayesian/BFBO over packaged prompt,
+decoding, preprocessing, or runtime knobs. Select a metric from action output
+and set ambiguous directions explicitly; never infer training loss.
 
 For `distill`, use the same train-like policy when the distill action performs
 epoch-based optimization and writes checkpoints. For single-shot `prune` and

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -4,8 +4,9 @@ description: Run container-backed AutoML / hyperparameter optimization (HPO) for
   selection (bayesian, hyperband, asha, bohb, llm, hybrid, autoresearch), WandB experiment tracking, job execution on any TAO SDK
   platform, result interpretation, and per-rec custom evaluation hooks. Use when the user mentions TAO AutoML, hyperparameter
   optimization, HPO, automl, automl_settings, AutoMLRunner, tao_automl, bayesian search, hyperband, ASHA, LLM-guided search,
-  autoresearch, or wants to tune train/distill/prune/quantize action parameters for any TAO network. Model actions use the model skill's
-  resolved container image by default; venv training requires an explicit user request. Platform-agnostic — runs on any SDK (Brev,
+  autoresearch, or wants to tune selected action parameters such as train/evaluate/inference/distill/prune/quantize for any TAO network.
+  Model actions use the model skill's resolved container image by default; venv training requires an explicit user request.
+  Platform-agnostic — runs on any SDK (Brev,
   SLURM, Kubernetes, Docker).
 license: Apache-2.0
 compatibility: Requires docker + nvidia-container-toolkit. Workflows declare additional requirements.
@@ -118,7 +119,7 @@ Collect these before runner construction:
 |---|---|
 | `model_skill` | Resolved model skill directory under `skills/models/`. Accept user aliases such as `network_arch` only after resolving them to the packaged skill directory. |
 | `network_arch` | Read from the resolved model skill metadata. |
-| `action` | Action to optimize, usually `train`, `distill`, `prune`, or `quantize`. |
+| `action` | Action to optimize, usually `train`, `evaluate`, `inference`, `distill`, `prune`, or `quantize` when that action has a packaged schema/template. |
 | `platform` | One of the supported TAO platform skills. |
 | `train_dataset` / `eval_dataset` / action inputs | Use model-specific spec keys and dataset layout. Non-train actions often also require parent checkpoints, teacher checkpoints, calibration data, or pruned artifacts. |
 | `results_root` | Local, Lustre, or S3 path appropriate for the platform. |
@@ -230,6 +231,12 @@ adjustment in `result["history"][i]["adjustments"]`.
 | `bohb`, `dehb` | Mixed Bayesian/evolutionary search with multi-fidelity budgets. | same rung budget fields as Hyperband |
 | `pbt` | Long training where schedules should mutate during training. | population and generation budget |
 | `llm`, `hybrid`, `autoresearch` | User explicitly wants LLM-guided search and has an endpoint configured. | LLM endpoint config plus budget |
+
+For `evaluate` or `inference`, default to Bayesian/BFBO-style search over the
+selected action's prompt, decoding, preprocessing, or runtime config knobs.
+Use a task metric from the action outputs/logs and set `direction` explicitly
+when the metric name is ambiguous. Do not use training-loss assumptions for
+actions that do not update weights.
 
 For `distill`, use the same train-like policy when the distill action performs
 epoch-based optimization and writes checkpoints. For single-shot `prune` and

--- a/skills/applications/tao-run-automl/references/automl-preflight-concepts.md
+++ b/skills/applications/tao-run-automl/references/automl-preflight-concepts.md
@@ -152,8 +152,8 @@ When the user asks what models/networks are supported for AutoML, run the
 packaged model-list helper in AutoML mode. AutoML enablement is **model-level**
 metadata (`skills/models/<network>/references/skill_info.yaml` has
 `automl_enabled: true`), not workflow-level metadata. The helper reads that
-model metadata, then validates whether the model also has a packaged,
-parseable train dataclass schema:
+model metadata, then validates whether the model also has packaged,
+parseable selected-action dataclass schemas:
 
 ```bash
 ${TAO_SKILL_BANK_PATH:-~/tao-skills-external}/scripts/list_tao_models.py \
@@ -171,7 +171,7 @@ Return both sections from that output: runnable AutoML model/actions and
 AutoML-enabled model/actions still blocked on schema packaging. The support
 rule is: AutoML is enabled at model level; runnable AutoML for an action also
 requires `skills/models/<model_skill>/schemas/<action>.schema.json` to be packaged and
-valid. Use `--action distill`, `--action prune`, or `--action quantize` for a
-focused compression-action query.
+valid. Use `--action evaluate`, `--action inference`, `--action distill`,
+`--action prune`, or `--action quantize` for a focused non-train action query.
 
 ---

--- a/skills/applications/tao-run-automl/references/automl-runner-configuration.md
+++ b/skills/applications/tao-run-automl/references/automl-runner-configuration.md
@@ -54,7 +54,7 @@ sdk = BrevSDK()                                  # reads platform credentials fr
 runner = AutoMLRunner(
     sdk=sdk,
     skill_dir=SKILL_BANK / "skills" / "models" / model_skill, # resolved skill dir
-    action=action,                                            # train, distill, prune, quantize, ...
+    action=action,                                            # train, evaluate, inference, distill, prune, quantize, ...
 )
 result = runner.run(
     train_dataset_uri=train_dataset_uri,

--- a/skills/applications/tao-run-automl/references/automl-runner-configuration.md
+++ b/skills/applications/tao-run-automl/references/automl-runner-configuration.md
@@ -182,8 +182,15 @@ print("Best:", automl.get_best().specs)
 | `llm_model` | str | `gcp/google/gemini-3.1-pro-preview` | LLM model name (llm, hybrid, autoresearch) |
 | `llm_api_key` | str | from env | API key for the LLM endpoint |
 | `research_program` | str | None | Free-text research directives for the autoresearch agent |
+| `evolvable_text_parameters` | str \| list[str] | `[]` | Searchable text parameters that `autoresearch` may rewrite beyond schema seed enums. |
 | `automl_delete_intermediate_ckpt` | bool | True | Automatically delete cleanup-supported terminal artifacts once they are safe to prune. The active trial/current best, every non-dominated Pareto-front member in a multi-objective search, and Hyperband-family promotion/resume inputs are protected; Hybrid conservatively retains successful trials when full-fidelity provenance is ambiguous. Cleanup-aware SDKs reject remote Docker binds, named volumes, unsafe output ownership, and unbound S3 identities before the first trial because deletion cannot be verified. Set False only when all trial artifacts and their external cleanup lifecycle are intentionally owned. |
 | `override_automl_disabled_params` | bool | False | Include params whose schema `automl_enabled` is False. For advanced users who want to search over params the network author didn't flag for AutoML. |
+
+`AutoMLRunner.run(..., feedback_fn=...)` accepts a callback with signature
+`(recommendation, job_id) -> JSON-safe value`. For reflective searches, return
+compact per-sample diagnostics such as incorrect IDs, expected/predicted labels,
+and evaluator comments. The runner persists this feedback and supplies it to the
+next `autoresearch` proposal; it does not replace the numeric selection metric.
 
 ### `kpi` metric resolution
 

--- a/skills/applications/tao-run-automl/references/automl-runner-configuration.md
+++ b/skills/applications/tao-run-automl/references/automl-runner-configuration.md
@@ -188,9 +188,12 @@ print("Best:", automl.get_best().specs)
 
 `AutoMLRunner.run(..., feedback_fn=...)` accepts a callback with signature
 `(recommendation, job_id) -> JSON-safe value`. For reflective searches, return
-compact per-sample diagnostics such as incorrect IDs, expected/predicted labels,
-and evaluator comments. The runner persists this feedback and supplies it to the
-next `autoresearch` proposal; it does not replace the numeric selection metric.
+compact training-split records containing the input/query, generated output,
+and a failure-mode comment that does not reveal the correct answer. Do not return
+gold/expected labels, item or media identifiers, or paths. The runner removes
+common ground-truth and identifier fields, persists the sanitized feedback, and
+supplies it to the next `autoresearch` proposal; it does not replace the numeric
+validation selection metric.
 
 ### `kpi` metric resolution
 

--- a/skills/models/automl_support.json
+++ b/skills/models/automl_support.json
@@ -86,7 +86,13 @@
         {
           "action": "evaluate",
           "automl_default_parameters": [
-            "evaluate.vision.fps"
+            "dataset.system_prompt",
+            "vision.nframes",
+            "generation.max_tokens",
+            "generation.temperature",
+            "generation.repetition_penalty",
+            "generation.presence_penalty",
+            "generation.frequency_penalty"
           ],
           "schema": "schemas/evaluate.schema.json",
           "schema_status": "schemas/evaluate.schema.json is packaged and valid",

--- a/skills/models/tao-finetune-cosmos-reason/SKILL.md
+++ b/skills/models/tao-finetune-cosmos-reason/SKILL.md
@@ -108,13 +108,13 @@ exact form. Pass `HF_TOKEN` as an environment variable — never in a spec or lo
 
 ## Dataclass Schemas
 
-Generated TAO Core schemas are packaged in `schemas/<action>.schema.json`, with `schemas/manifest.json` listing available actions. Each generated schema also emits `references/spec_template_<action>.yaml` from the schema top-level `default` field. AutoML enablement is declared at the model layer in `references/skill_info.yaml` via `automl_enabled`. Runnable AutoML still requires `schemas/train.schema.json` and `references/spec_template_train.yaml` to exist and parse. Use the packaged train schema for `automl_default_parameters`, `automl_disabled_parameters`, defaults, min/max bounds, enums, option weights, math conditions, dependencies, and popular parameters. Do not expect `~/tao-core` at runtime; maintainers regenerate schemas/templates before packaging the skill bank.
+Generated TAO Core schemas are packaged in `schemas/<action>.schema.json`, with `schemas/manifest.json` listing available actions. Each generated schema also emits `references/spec_template_<action>.yaml` from the schema top-level `default` field. AutoML enablement is declared at the model layer in `references/skill_info.yaml` via `automl_enabled`. Runnable AutoML for any selected action requires that action's schema and spec template to exist and parse. Use the packaged selected-action schema for `automl_default_parameters`, `automl_disabled_parameters`, defaults, min/max bounds, enums, option weights, math conditions, dependencies, and popular parameters. Do not expect `~/tao-core` at runtime; maintainers regenerate schemas/templates before packaging the skill bank.
 
 ## Train Action Policy
 
 This model is AutoML-enabled at the model layer. Before handling any train-stage request, read `references/skill_info.yaml` and resolve the run override from either an explicit `automl_policy` value or the user's workflow request. Use `automl_policy: on` by default and only expose `on` / `off` in new launch prompts. Treat phrases like "turn off AutoML", "disable AutoML", "no HPO", or "plain training" as `automl_policy: off` for this run only. When `automl_policy: on`, `automl_enabled: true`, and both `schemas/train.schema.json` and `references/spec_template_train.yaml` are packaged, route the train action through `tao-skill-bank:tao-run-automl` by default with this model's `skill_dir`. Preserve workflow/application overrides for datasets, specs, output directories, GPU/platform settings, parent checkpoints, and `automl_policy`. Use direct model training only when `automl_policy: off` or the packaged train schema/template is missing; in the missing-schema case, report that AutoML is enabled but not runnable for this model until schemas are generated.
 
-Non-train actions such as `evaluate`, `inference`, and `quantize` stay in this model skill. The per-run `automl_policy` override does not change model metadata.
+For non-train actions, run this model skill directly unless the user explicitly asks to optimize that action or sets `automl_policy: on`. When an action schema/template is packaged, route that optimization through `tao-skill-bank:tao-run-automl` with `action=<selected-action>`. The Cosmos `evaluate` action has default AutoML search parameters for zero-shot prompt/config tuning: `dataset.system_prompt`, `vision.nframes`, and generation controls. The per-run `automl_policy` override does not change model metadata.
 
 ## Credentials
 
@@ -274,7 +274,8 @@ consistently to train (`policy.model_name_or_path`) and post-training evaluation
 selection, the `eval_fn` per-recommendation evaluate flow, the knob mapping
 (learning rate, batch size, epochs, weight decay, warmup ratio), example
 `custom_param_ranges`, `train_sample_count` batch-size capping,
-`ordered_int` requirements, and the pre-launch recommendation summary.
+`ordered_int` requirements, zero-shot evaluate AutoML prompt/config search,
+and the pre-launch recommendation summary.
 
 ## Parameters, Hardware, Errors, DEFT, Inference
 

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
@@ -105,6 +105,15 @@ four-proposal stopper ends search after four attempts even if substantial metric
 budget remains. Prefer the metric budget plus a wall-time guard, or set a
 proposal cap that cannot become the unintended limiting condition.
 
+For a strict budget comparison, checkpoint one seeded GEPA trajectory by metric
+calls instead of comparing independent stochastic searches. In the full WTS
+Nano run, the best prompt available at 1,124 calls scored 1,721/2,676 (64.31%)
+in a fresh full evaluation; the best prompt through 3,002 calls scored
+1,754/2,676 (65.55%). The same fresh default run scored 1,449/2,676 (54.15%).
+All three specs used the same model, data, order, 8 frames, decoding settings,
+seed, and exact-match metric. Treat these as WTS integration evidence, not as a
+VANTAGE benchmark.
+
 Use the canonical set-level `macro_f1` metric for VANTAGE binary event
 verification. GEPA still needs decomposable per-item feedback for reflection
 and proposal gating, but TAO's `GEPAutoPrompter` reranks every accepted

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
@@ -59,7 +59,8 @@ before fine-tuning or DEFT because it can identify whether prompt wording,
 frame sampling, or generation settings recover enough accuracy without changing
 weights.
 
-The packaged Cosmos evaluate schema defaults to this bounded search space:
+The packaged Cosmos evaluate schema defaults to this joint prompt/config search
+space:
 
 ```text
 dataset.system_prompt
@@ -71,23 +72,48 @@ generation.presence_penalty
 generation.frequency_penalty
 ```
 
-`dataset.system_prompt` is categorical. The packaged candidates cover the
-existing CCTV assistant prompt plus Metropolis-oriented event-verification
-prompts that emphasize visible evidence, object IDs/bounding boxes, temporal
-order, interactions, and concise yes/no answers when applicable. Keep prompt
-search bounded by explicit candidates; do not generate arbitrary free-form
-prompts during a run unless the user explicitly asks for an LLM-guided research
-algorithm and provides the endpoint/key preflight.
+There are two distinct operating modes:
+
+1. **Bounded fallback:** use `algorithm="bayesian"`. The four packaged prompts
+   are an exhaustive categorical choice set. This is useful for a cheap prompt
+   ablation, but it is not the reflective Auto-Prompter described in the
+   Metropolis design.
+2. **Reflective Auto-Prompter:** use `algorithm="autoresearch"`, provide the LLM
+   endpoint/model/key, and set
+   `evolvable_text_parameters=["dataset.system_prompt"]`. The four packaged
+   prompts become seeds; the reflector may write new prompts and jointly change
+   frame-sampling and generation settings. Supply `feedback_fn` so the next
+   proposal sees compact incorrect-sample diagnostics instead of only an
+   aggregate score.
+
+The TAO integration uses the existing autoresearch reflector to provide the
+GEPA-style propose, evaluate, reflect, and keep/discard lifecycle. Do not claim
+exact GEPA optimizer parity or merge behavior unless the dedicated Auto-Prompter
+package is installed and used by the caller.
 
 Use `metric="accuracy"` and `direction="maximize"` for VANTAGE-style
 classification or event-verification prompts. Use BERTScore F1 or another
 model-skill-supported semantic metric only for free-form answers where exact
 matching is not meaningful.
 
-Example evaluate AutoML setup:
+Example reflective evaluate AutoML setup:
 
 ```python
 action = "evaluate"
+automl_settings = {
+    "algorithm": "autoresearch",
+    "metric": "accuracy",
+    "direction": "maximize",
+    "automl_max_experiments": 20,
+    "llm_endpoint": llm_endpoint,
+    "llm_model": llm_model,
+    "llm_api_key": llm_api_key,
+    "evolvable_text_parameters": ["dataset.system_prompt"],
+    "research_program": (
+        "Optimize zero-shot event verification. Use visible temporal evidence; "
+        "learn from the supplied false-positive and false-negative examples."
+    ),
+}
 automl_hyperparameters = [
     "dataset.system_prompt",
     "vision.nframes",
@@ -109,6 +135,38 @@ custom_param_ranges = {
     "generation.temperature": {"valid_min": 0.0, "valid_max": 0.4},
 }
 ```
+
+The per-recommendation `eval_fn` returns the numeric score. The `feedback_fn`
+must read the same result artifacts and return a bounded payload, for example:
+
+```python
+{
+    "false_positives": [
+        {"id": "clip-17", "expected": "no", "predicted": "yes", "reason": "..."}
+    ],
+    "false_negatives": [
+        {"id": "clip-42", "expected": "yes", "predicted": "no", "reason": "..."}
+    ],
+}
+```
+
+Do not put the full result corpus into `feedback_fn`; select representative
+failures and keep the payload compact enough for the reflection model.
+
+### Dataset and reporting protocol
+
+- Tune only on the declared tuning split. For the VANTAGE experiment in the
+  Auto-Prompter thread, that is 98 videos; keep the 65-video holdout completely
+  out of proposal feedback.
+- Select the best prompt/config on tuning results, then use `final_eval_fn` for
+  the untouched holdout and, when required, the full dataset. Report zero-shot
+  baseline, tuned result, absolute percentage-point lift, and job/result paths.
+- For Metropolis alert verification, report VK/model accuracy and AB/end-to-end
+  Alerts accuracy side by side. If both are available for every recommendation,
+  return both metrics and configure `automl_settings["objectives"]`; otherwise
+  optimize VK in-loop and run AB as final system validation.
+- Never describe a four-static-prompt run, a subset-only run, or the WTS video-QA
+  benchmark as validation of the full reflective Auto-Prompter.
 
 If the eval spec uses `vision.nframes`, do not also search `vision.fps` by
 default. Search `vision.fps` only when the user explicitly requests FPS-based

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
@@ -137,7 +137,7 @@ automl_hyperparameters = [
 custom_param_ranges = {
     "vision.nframes": {
         "value_type": "ordered_int",
-        "valid_options": [4, 8],
+        "valid_options": [4, 8, 16],
     },
     "generation.max_tokens": {
         "value_type": "ordered_int",
@@ -196,6 +196,12 @@ text.
 If the eval spec uses `vision.nframes`, do not also search `vision.fps` by
 default. Search `vision.fps` only when the user explicitly requests FPS-based
 sampling and the spec/runtime has been switched away from frame-count sampling.
+Sixteen frames is a higher-cost option intended for detail- or coverage-bound
+failures on sufficiently provisioned local evaluation. The current Cosmos
+evaluator materializes processed video inputs before inference; split a large
+corpus into complete, video-disjoint execution shards when one monolithic action
+would exhaust host memory, then reject missing or duplicate prediction IDs
+before computing the aggregate metric.
 
 For the evaluator prompt "search over learning rate, batch size, number of
 epochs, weight decay, warmup ratio", map the requested knobs to:

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
@@ -49,6 +49,71 @@ review before asking for confirmation to start recommendations. The final
 AutoML summary must compare this baseline accuracy, every recommendation's
 accuracy, and the selected best recommendation.
 
+## Zero-shot Evaluate AutoML / Auto-Prompter
+
+For Metropolis/VSS-style zero-shot video QA, use `action="evaluate"` when the
+user asks to optimize prompts, inference config, or Auto-Prompter behavior
+without training. This launches multiple real Cosmos-RL evaluate jobs over the
+same eval dataset/model and compares the requested task metric. It is useful
+before fine-tuning or DEFT because it can identify whether prompt wording,
+frame sampling, or generation settings recover enough accuracy without changing
+weights.
+
+The packaged Cosmos evaluate schema defaults to this bounded search space:
+
+```text
+dataset.system_prompt
+vision.nframes
+generation.max_tokens
+generation.temperature
+generation.repetition_penalty
+generation.presence_penalty
+generation.frequency_penalty
+```
+
+`dataset.system_prompt` is categorical. The packaged candidates cover the
+existing CCTV assistant prompt plus Metropolis-oriented event-verification
+prompts that emphasize visible evidence, object IDs/bounding boxes, temporal
+order, interactions, and concise yes/no answers when applicable. Keep prompt
+search bounded by explicit candidates; do not generate arbitrary free-form
+prompts during a run unless the user explicitly asks for an LLM-guided research
+algorithm and provides the endpoint/key preflight.
+
+Use `metric="accuracy"` and `direction="maximize"` for VANTAGE-style
+classification or event-verification prompts. Use BERTScore F1 or another
+model-skill-supported semantic metric only for free-form answers where exact
+matching is not meaningful.
+
+Example evaluate AutoML setup:
+
+```python
+action = "evaluate"
+automl_hyperparameters = [
+    "dataset.system_prompt",
+    "vision.nframes",
+    "generation.max_tokens",
+    "generation.temperature",
+    "generation.repetition_penalty",
+    "generation.presence_penalty",
+    "generation.frequency_penalty",
+]
+custom_param_ranges = {
+    "vision.nframes": {
+        "value_type": "ordered_int",
+        "valid_options": [4, 8],
+    },
+    "generation.max_tokens": {
+        "value_type": "ordered_int",
+        "valid_options": [256, 512, 1024],
+    },
+    "generation.temperature": {"valid_min": 0.0, "valid_max": 0.4},
+}
+```
+
+If the eval spec uses `vision.nframes`, do not also search `vision.fps` by
+default. Search `vision.fps` only when the user explicitly requests FPS-based
+sampling and the spec/runtime has been switched away from frame-count sampling.
+
 For the evaluator prompt "search over learning rate, batch size, number of
 epochs, weight decay, warmup ratio", map the requested knobs to:
 

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
@@ -86,24 +86,24 @@ There are three distinct operating modes:
    next proposal sees compact, leak-free training failures instead of only an
    aggregate score. This is TAO autoresearch, not GEPA, and must not be reported
    as the Metropolis Auto-Prompter result.
-3. **Canonical Metropolis Auto-Prompter:** use the `mjhuria/vss_autotuner`
-   package's pinned `GepaOptimizer`, `TargetAdapter`, and `VLMOptimizer`. It uses
-   GEPA's Pareto candidate pool, per-example reflective records, explicit
-   train/validation/test roles, and a text/config/joint axis selector. A TAO
-   evaluate target should expose `run_batch(candidate, items) -> outputs` so one
-   recommendation launches one action job while preserving GEPA's aligned
-   per-example scores. Keep fixed inference settings in the adapter's
-   `base_candidate`; only explicitly declared prompt/config knobs belong in the
-   optimizer seed.
+3. **TAO GEPA Auto-Prompter:** install `nvidia-tao-automl[autoprompter]` and use
+   `tao_automl.GEPAutoPrompter`, `TAOGEPAAdapter`, and
+   `TAOActionBatchRunner`. TAO owns this integration; the original Auto-Tuner
+   and VLMEvalKit repositories are read-only references/metric providers and
+   must not receive TAO feature changes. A TAO evaluate callback launches one
+   action job for `run_batch(candidate, items) -> outputs`, preserving GEPA's
+   aligned per-example scores. Keep fixed inference settings in the base action
+   spec; only prompt components being evolved belong in GEPA's seed. Use the
+   generic TAO autoresearch mode above when prompt and bounded config knobs must
+   be explored jointly.
 
 Use the canonical set-level `macro_f1` metric for VANTAGE binary event
-verification. GEPA's per-item reflection score is class-weighted correctness, a
-balanced-accuracy proxy. The current Auto-Tuner also selects its GEPA candidate
-on that proxy, then reports true Macro-F1; this residual objective mismatch is a
-documented limitation because Macro-F1 is not decomposable per item. Do not claim
-that the current package selects on true Macro-F1. Re-rank the candidate pool on
-true validation Macro-F1 when that follow-up is implemented. Use `accuracy` only
-for tasks whose official metric is accuracy. Use BERTScore F1 or another
+verification. GEPA still needs decomposable per-item feedback for reflection
+and proposal gating, but TAO's `GEPAutoPrompter` reranks every accepted
+candidate with `binary_aggregate` on the complete validation set and selects on
+true Macro-F1 before running test. Pass VLMEvalKit's read-only `binary_metric`
+and `binary_aggregate` callbacks; no scorer changes are required. Use `accuracy`
+only for tasks whose official metric is accuracy. Use BERTScore F1 or another
 model-skill-supported semantic metric only for free-form answers where exact
 matching is not meaningful.
 
@@ -178,12 +178,12 @@ text.
   65 test. The older 98/65 protocol and its reported gains are historical
   two-way results, not validation of the current implementation.
 - For generic TAO autoresearch, select the best prompt/config on validation
-  Macro-F1, then use `final_eval_fn` for the untouched test. For the current
-  canonical package, selection uses its class-balanced per-item proxy on the
-  validation split; report both the proxy and true Macro-F1 and call out the
-  mismatch. In either mode, report zero-shot baseline, tuned result, absolute
-  percentage-point lift, and job/result paths, plus full-dataset results when
-  required.
+  Macro-F1, then use `final_eval_fn` for the untouched test. For TAO GEPA, pass
+  `aggregate_metric_fn=binary_aggregate` and
+  `aggregate_metric_key="macro_f1"`; the returned candidate is then selected on
+  true validation Macro-F1. In either mode, report zero-shot baseline, tuned
+  result, absolute percentage-point lift, and job/result paths, plus
+  full-dataset results when required.
 - For Metropolis alert verification, report VK/model accuracy and AB/end-to-end
   Alerts accuracy side by side. If both are available for every recommendation,
   return both metrics and configure `automl_settings["objectives"]`; otherwise

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
@@ -97,6 +97,14 @@ There are three distinct operating modes:
    generic TAO autoresearch mode above when prompt and bounded config knobs must
    be explored jointly.
 
+For GEPA, distinguish the metric-call budget from any proposal-count stopper.
+Each proposal scores both its parent and new prompt on the reflection minibatch,
+and an accepted proposal is then scored on complete validation. Do not leave a
+small `MaxCandidateProposalsStopper` in place when raising the metric budget: a
+four-proposal stopper ends search after four attempts even if substantial metric
+budget remains. Prefer the metric budget plus a wall-time guard, or set a
+proposal cap that cannot become the unintended limiting condition.
+
 Use the canonical set-level `macro_f1` metric for VANTAGE binary event
 verification. GEPA still needs decomposable per-item feedback for reflection
 and proposal gating, but TAO's `GEPAutoPrompter` reranks every accepted

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-reason-automl.md
@@ -72,27 +72,38 @@ generation.presence_penalty
 generation.frequency_penalty
 ```
 
-There are two distinct operating modes:
+There are three distinct operating modes:
 
 1. **Bounded fallback:** use `algorithm="bayesian"`. The four packaged prompts
    are an exhaustive categorical choice set. This is useful for a cheap prompt
    ablation, but it is not the reflective Auto-Prompter described in the
    Metropolis design.
-2. **Reflective Auto-Prompter:** use `algorithm="autoresearch"`, provide the LLM
+2. **Generic reflective fallback:** use `algorithm="autoresearch"`, provide the LLM
    endpoint/model/key, and set
    `evolvable_text_parameters=["dataset.system_prompt"]`. The four packaged
-   prompts become seeds; the reflector may write new prompts and jointly change
-   frame-sampling and generation settings. Supply `feedback_fn` so the next
-   proposal sees compact incorrect-sample diagnostics instead of only an
-   aggregate score.
+   prompts become seeds; the agent may write new prompts and jointly change the
+   declared frame-sampling and generation settings. Supply `feedback_fn` so the
+   next proposal sees compact, leak-free training failures instead of only an
+   aggregate score. This is TAO autoresearch, not GEPA, and must not be reported
+   as the Metropolis Auto-Prompter result.
+3. **Canonical Metropolis Auto-Prompter:** use the `mjhuria/vss_autotuner`
+   package's pinned `GepaOptimizer`, `TargetAdapter`, and `VLMOptimizer`. It uses
+   GEPA's Pareto candidate pool, per-example reflective records, explicit
+   train/validation/test roles, and a text/config/joint axis selector. A TAO
+   evaluate target should expose `run_batch(candidate, items) -> outputs` so one
+   recommendation launches one action job while preserving GEPA's aligned
+   per-example scores. Keep fixed inference settings in the adapter's
+   `base_candidate`; only explicitly declared prompt/config knobs belong in the
+   optimizer seed.
 
-The TAO integration uses the existing autoresearch reflector to provide the
-GEPA-style propose, evaluate, reflect, and keep/discard lifecycle. Do not claim
-exact GEPA optimizer parity or merge behavior unless the dedicated Auto-Prompter
-package is installed and used by the caller.
-
-Use `metric="accuracy"` and `direction="maximize"` for VANTAGE-style
-classification or event-verification prompts. Use BERTScore F1 or another
+Use the canonical set-level `macro_f1` metric for VANTAGE binary event
+verification. GEPA's per-item reflection score is class-weighted correctness, a
+balanced-accuracy proxy. The current Auto-Tuner also selects its GEPA candidate
+on that proxy, then reports true Macro-F1; this residual objective mismatch is a
+documented limitation because Macro-F1 is not decomposable per item. Do not claim
+that the current package selects on true Macro-F1. Re-rank the candidate pool on
+true validation Macro-F1 when that follow-up is implemented. Use `accuracy` only
+for tasks whose official metric is accuracy. Use BERTScore F1 or another
 model-skill-supported semantic metric only for free-form answers where exact
 matching is not meaningful.
 
@@ -102,7 +113,7 @@ Example reflective evaluate AutoML setup:
 action = "evaluate"
 automl_settings = {
     "algorithm": "autoresearch",
-    "metric": "accuracy",
+    "metric": "macro_f1",
     "direction": "maximize",
     "automl_max_experiments": 20,
     "llm_endpoint": llm_endpoint,
@@ -136,37 +147,51 @@ custom_param_ranges = {
 }
 ```
 
-The per-recommendation `eval_fn` returns the numeric score. The `feedback_fn`
-must read the same result artifacts and return a bounded payload, for example:
+For the generic TAO fallback, `eval_fn` returns the validation score while
+`feedback_fn` reads training-split artifacts and returns a bounded, leak-free
+payload, for example:
 
 ```python
 {
-    "false_positives": [
-        {"id": "clip-17", "expected": "no", "predicted": "yes", "reason": "..."}
-    ],
-    "false_negatives": [
-        {"id": "clip-42", "expected": "yes", "predicted": "no", "reason": "..."}
-    ],
+    "failures": [
+        {
+            "query": "Did a second person cross during the same gate cycle?",
+            "generated_output": "No",
+            "feedback": "The response did not track the complete gate-open interval."
+        }
+    ]
 }
 ```
 
-Do not put the full result corpus into `feedback_fn`; select representative
-failures and keep the payload compact enough for the reflection model.
+Do not include gold/expected labels, sample or video IDs, media paths, or the
+full result corpus in `feedback_fn`. Select representative training failures,
+describe the failure mode without revealing the answer, and keep the payload
+compact enough for the reflection model. TAO removes common identifier and
+ground-truth fields, but callers must also avoid leaking answers in free-form
+text.
 
 ### Dataset and reporting protocol
 
-- Tune only on the declared tuning split. For the VANTAGE experiment in the
-  Auto-Prompter thread, that is 98 videos; keep the 65-video holdout completely
-  out of proposal feedback.
-- Select the best prompt/config on tuning results, then use `final_eval_fn` for
-  the untouched holdout and, when required, the full dataset. Report zero-shot
-  baseline, tuned result, absolute percentage-point lift, and job/result paths.
+- Use three disjoint roles: reflect on train, select candidates on validation,
+  and report once on untouched test. The current deterministic split of the 163
+  VANTAGE event-verification items is approximately 66 train / 32 validation /
+  65 test. The older 98/65 protocol and its reported gains are historical
+  two-way results, not validation of the current implementation.
+- For generic TAO autoresearch, select the best prompt/config on validation
+  Macro-F1, then use `final_eval_fn` for the untouched test. For the current
+  canonical package, selection uses its class-balanced per-item proxy on the
+  validation split; report both the proxy and true Macro-F1 and call out the
+  mismatch. In either mode, report zero-shot baseline, tuned result, absolute
+  percentage-point lift, and job/result paths, plus full-dataset results when
+  required.
 - For Metropolis alert verification, report VK/model accuracy and AB/end-to-end
   Alerts accuracy side by side. If both are available for every recommendation,
   return both metrics and configure `automl_settings["objectives"]`; otherwise
   optimize VK in-loop and run AB as final system validation.
-- Never describe a four-static-prompt run, a subset-only run, or the WTS video-QA
-  benchmark as validation of the full reflective Auto-Prompter.
+- Never describe a four-static-prompt run, a subset-only run, a WTS video-QA
+  run, or the historical two-way VANTAGE result as validation of the current
+  three-way GEPA/VLM implementation. Those remain useful ablations or historical
+  evidence and must be labeled as such.
 
 If the eval spec uses `vision.nframes`, do not also search `vision.fps` by
 default. Search `vision.fps` only when the user explicitly requests FPS-based

--- a/skills/models/tao-finetune-cosmos-reason/references/skill_info.yaml
+++ b/skills/models/tao-finetune-cosmos-reason/references/skill_info.yaml
@@ -96,6 +96,14 @@ actions:
     command: cosmos-rl-evaluate --config {config_path}
     config_format: toml
     mode: config
+    automl_default_parameters:
+    - dataset.system_prompt
+    - vision.nframes
+    - generation.max_tokens
+    - generation.temperature
+    - generation.repetition_penalty
+    - generation.presence_penalty
+    - generation.frequency_penalty
     inputs:
       dataset.annotation_path:
         type: file

--- a/skills/models/tao-finetune-cosmos-reason/schemas/evaluate.schema.json
+++ b/skills/models/tao-finetune-cosmos-reason/schemas/evaluate.schema.json
@@ -130,7 +130,7 @@
         "system_prompt": {
           "automl_enabled": true,
           "default": "You are a helpful assistant that can answer questions about a street-view CCTV footage. The vehicles that need attention are marked with bounding boxes and IDs.",
-          "description": "System prompt for the evaluation tasks. AutoML treats this as a bounded prompt-candidate search for zero-shot Metropolis/VSS evaluation.",
+          "description": "System prompt for zero-shot Metropolis/VSS evaluation. The enum provides seed candidates for bounded algorithms; autoresearch can evolve free-form prompts when dataset.system_prompt is listed in evolvable_text_parameters.",
           "enum": [
             "You are a helpful assistant that can answer questions about a street-view CCTV footage. The vehicles that need attention are marked with bounding boxes and IDs.",
             "You are a careful video event verification assistant for traffic and security CCTV. Answer only from visible evidence, track object IDs and bounding boxes, and state yes/no when the question asks whether an event occurred.",

--- a/skills/models/tao-finetune-cosmos-reason/schemas/evaluate.schema.json
+++ b/skills/models/tao-finetune-cosmos-reason/schemas/evaluate.schema.json
@@ -539,12 +539,13 @@
         "nframes": {
           "automl_enabled": true,
           "default": 8,
-          "description": "Number of frames for vision processing.",
+          "description": "Number of evenly sampled frames for vision processing. Higher values increase host memory, preprocessing time, and inference cost.",
           "enum": [
             4,
-            8
+            8,
+            16
           ],
-          "maximum": 8,
+          "maximum": 16,
           "minimum": 1,
           "title": "Number of frames",
           "type": "ordered_int"

--- a/skills/models/tao-finetune-cosmos-reason/schemas/evaluate.schema.json
+++ b/skills/models/tao-finetune-cosmos-reason/schemas/evaluate.schema.json
@@ -1,6 +1,12 @@
 {
   "automl_default_parameters": [
-    "vision.fps"
+    "dataset.system_prompt",
+    "vision.nframes",
+    "generation.max_tokens",
+    "generation.temperature",
+    "generation.repetition_penalty",
+    "generation.presence_penalty",
+    "generation.frequency_penalty"
   ],
   "automl_disabled_parameters": [
     "metrics",
@@ -68,14 +74,25 @@
       "save_individual_results": true,
       "save_metrics_summary": true
     },
+    "results_dir": "",
     "task": {
       "type": ""
     },
     "vision": {
       "nframes": 8
-    },
-    "results_dir": ""
+    }
   },
+  "evaluate_automl_disabled_parameters": [
+    "evaluate.task",
+    "evaluate.dataset",
+    "evaluate.model",
+    "evaluate.evaluation",
+    "evaluate.vision",
+    "evaluate.generation",
+    "evaluate.metrics",
+    "evaluate.results"
+  ],
+  "evaluate_automl_enabled": false,
   "properties": {
     "automl_disabled_parameters": [
       "metrics",
@@ -89,12 +106,6 @@
       "dataset",
       "generation"
     ],
-    "results_dir": {
-      "default": "",
-      "description": "Directory to save evaluation results",
-      "title": "Results directory",
-      "type": "string"
-    },
     "dataset": {
       "automl_enabled": false,
       "default": {
@@ -117,10 +128,23 @@
           "type": "string"
         },
         "system_prompt": {
+          "automl_enabled": true,
           "default": "You are a helpful assistant that can answer questions about a street-view CCTV footage. The vehicles that need attention are marked with bounding boxes and IDs.",
-          "description": "System prompt for the evaluation tasks",
+          "description": "System prompt for the evaluation tasks. AutoML treats this as a bounded prompt-candidate search for zero-shot Metropolis/VSS evaluation.",
+          "enum": [
+            "You are a helpful assistant that can answer questions about a street-view CCTV footage. The vehicles that need attention are marked with bounding boxes and IDs.",
+            "You are a careful video event verification assistant for traffic and security CCTV. Answer only from visible evidence, track object IDs and bounding boxes, and state yes/no when the question asks whether an event occurred.",
+            "You are a Metropolis VLM assistant for surveillance video QA. Focus on temporal order, object interactions, near misses, direction of travel, and safety-relevant evidence. Prefer concise factual answers.",
+            "You are an event-verification assistant. Inspect the full clip before answering, compare the question with observed actions, ignore unsupported assumptions, and return the most specific answer allowed by the evidence."
+          ],
+          "option_weights": [
+            0.4,
+            0.25,
+            0.2,
+            0.15
+          ],
           "title": "System prompt",
-          "type": "string"
+          "type": "categorical"
         }
       },
       "type": "collection"
@@ -238,10 +262,11 @@
       "description": "Generation parameters",
       "properties": {
         "frequency_penalty": {
+          "automl_enabled": true,
           "default": 0.0,
           "description": "Frequency penalty for generation",
-          "maximum": 2.0,
-          "minimum": -2.0,
+          "maximum": 0.5,
+          "minimum": -0.5,
           "title": "Frequency penalty",
           "type": "float"
         },
@@ -254,33 +279,43 @@
           "type": "int"
         },
         "max_tokens": {
+          "automl_enabled": true,
           "default": 1024,
           "description": "Maximum number of tokens in the generated response",
+          "enum": [
+            256,
+            512,
+            1024,
+            2048
+          ],
           "maximum": 8192,
           "minimum": 1,
           "title": "Maximum tokens",
-          "type": "int"
+          "type": "ordered_int"
         },
         "presence_penalty": {
+          "automl_enabled": true,
           "default": 0.0,
           "description": "Presence penalty for generation",
-          "maximum": 2.0,
-          "minimum": -2.0,
+          "maximum": 0.5,
+          "minimum": -0.5,
           "title": "Presence penalty",
           "type": "float"
         },
         "repetition_penalty": {
+          "automl_enabled": true,
           "default": 1.0,
           "description": "Repetition penalty for generation",
-          "maximum": 2.0,
-          "minimum": 0.1,
+          "maximum": 1.2,
+          "minimum": 0.8,
           "title": "Repetition penalty",
           "type": "float"
         },
         "temperature": {
+          "automl_enabled": true,
           "default": 0.0,
           "description": "Temperature for sampling (0.0 for greedy decoding)",
-          "maximum": 2.0,
+          "maximum": 0.4,
           "minimum": 0.0,
           "title": "Temperature",
           "type": "float"
@@ -306,6 +341,19 @@
       },
       "description": "Metrics configuration for general evaluation",
       "properties": {
+        "bertscore_batch_size": {
+          "default": 1,
+          "description": "Optional BERTScore batch size; lower values reduce peak memory",
+          "minimum": 1,
+          "title": "BERTScore batch size",
+          "type": "int"
+        },
+        "bertscore_device": {
+          "default": "cpu",
+          "description": "Device for BERTScore computation (use cpu to avoid competing with the eval model for GPU memory)",
+          "title": "BERTScore device",
+          "type": "string"
+        },
         "bertscore_lang": {
           "default": "en",
           "description": "Language for BERTScore computation",
@@ -317,19 +365,6 @@
           "description": "Model to use for BERTScore computation (e.g., microsoft/deberta-xlarge-mnli)",
           "title": "BERTScore model",
           "type": "string"
-        },
-        "bertscore_device": {
-          "default": "cpu",
-          "description": "Device for BERTScore computation (use cpu to avoid competing with the eval model for GPU memory)",
-          "title": "BERTScore device",
-          "type": "string"
-        },
-        "bertscore_batch_size": {
-          "default": 1,
-          "description": "Optional BERTScore batch size; lower values reduce peak memory",
-          "minimum": 1,
-          "title": "BERTScore batch size",
-          "type": "int"
         },
         "names": {
           "automl_enabled": false,
@@ -457,6 +492,12 @@
       },
       "type": "collection"
     },
+    "results_dir": {
+      "default": "",
+      "description": "Directory to save evaluation results",
+      "title": "Results directory",
+      "type": "string"
+    },
     "task": {
       "automl_enabled": false,
       "default": {
@@ -496,12 +537,17 @@
           "type": "int"
         },
         "nframes": {
+          "automl_enabled": true,
           "default": 8,
           "description": "Number of frames for vision processing.",
+          "enum": [
+            4,
+            8
+          ],
           "maximum": 8,
           "minimum": 1,
           "title": "Number of frames",
-          "type": "int"
+          "type": "ordered_int"
         },
         "total_pixels": {
           "description": "Total number of pixels for vision processing.",
@@ -523,16 +569,5 @@
     "schema_action": "evaluate",
     "schema_version": 1,
     "source": "tao-core dataclass config"
-  },
-  "evaluate_automl_disabled_parameters": [
-    "evaluate.task",
-    "evaluate.dataset",
-    "evaluate.model",
-    "evaluate.evaluation",
-    "evaluate.vision",
-    "evaluate.generation",
-    "evaluate.metrics",
-    "evaluate.results"
-  ],
-  "evaluate_automl_enabled": false
+  }
 }

--- a/skills/models/tao-finetune-cosmos-reason/schemas/manifest.json
+++ b/skills/models/tao-finetune-cosmos-reason/schemas/manifest.json
@@ -2,7 +2,13 @@
   "actions": {
     "evaluate": {
       "automl_default_parameters": [
-        "evaluate.vision.fps"
+        "dataset.system_prompt",
+        "vision.nframes",
+        "generation.max_tokens",
+        "generation.temperature",
+        "generation.repetition_penalty",
+        "generation.presence_penalty",
+        "generation.frequency_penalty"
       ],
       "automl_disabled_parameters": [
         "evaluate",


### PR DESCRIPTION
## Summary

- migrates GitLab MR !115 onto GitHub `main`
- exposes Cosmos Reason evaluation as a controlled text-parameter AutoML/Auto-Prompter workflow
- adds budget, feedback-sanitization, schema-generation, and monitoring guidance
- preserves the exact GitLab history in `dev/ram/archive/rarunachalam/autoprompt-vlm-automl-20260710`

## Conflict reconciliation

The AutoML skill documentation overlaps newer GitHub checkpoint-retention guidance. The port retains GitHub's safe default and adds the MR's evolvable-text and reflective-feedback contract.

## Validation

- modified Python scripts compile
- modified JSON/schema files parse
- `git diff --check origin/main...HEAD` passed
