### PR TITLE
[TAO-0000][Bugfix] Fix TAO AutoML skill contracts

### DIFF
--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -82,6 +82,11 @@ clearly and keep all child model actions in the resolved container image.
 python -c "import tao_automl; from tao_automl.runner import AutoMLRunner; print('OK')"
 ```
 
+Then verify the selected platform's SDK constructs — importing `tao_automl` does
+not prove the platform backend is installed (e.g. `DockerSDK()` raises
+`CredentialError` without the `docker` package). See
+`automl-preflight-concepts.md`.
+
 If missing, show the exact install command from `versions.yaml` and ask before
 installing:
 
@@ -300,13 +305,13 @@ model_skill = "<resolved-model-skill-directory>"
 skill_dir = skill_bank / "skills" / "models" / model_skill
 
 runner = AutoMLRunner(
+    sdk=sdk,
     skill_dir=str(skill_dir),
-    platform_sdk=sdk,
-    workspace_dir="<automl_workspace>",
+    action=action,                      # train, distill, prune, quantize, ...
 )
 
 result = runner.run(
-    automl_algorithm=algorithm,
+    workspace_path="<automl_workspace>",   # timestamp it to avoid collisions
     automl_settings=automl_settings,
     spec_overrides=spec_overrides,
     automl_hyperparameters=automl_hyperparameters,

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -177,21 +177,21 @@ model skill recommends a smaller shape for evaluation than training, use that
 shape and call it out in the launch review.
 
 Share the eval metric number with the user in the launch review before asking
-for confirmation to launch recommendations. If the model has no packaged
-evaluate action, the eval dataset is missing, or the eval job fails, stop and
-report the blocker instead of silently falling back to a training-loss-only
-AutoML run. Continue without this baseline only when the user explicitly accepts
-that the run will optimize a proxy metric and will not have an impact baseline.
+for confirmation. If a starting checkpoint exists but the baseline cannot be
+produced — no packaged evaluate action, missing eval dataset, failed eval job —
+stop and report the blocker instead of silently falling back to a
+training-loss-only run.
 
-The AutoML runner owns final evaluation of the selected best checkpoint/model.
-When a runnable evaluate action and validation/eval data exist, pass a
-`final_eval_fn(best_rec, train_job_id)` callback to `AutoMLRunner.run`. The
-callback must evaluate the selected best checkpoint/model with the same metric,
-dataset, and direction used for the baseline, store a structured record under
-the workspace, and return the measured metric or a dict containing
-`metric_value` and metadata such as `record_path` and `job_id`. Do not run final
-evaluation as an agent-side step after `runner.run`; the returned result should
-contain `result["final_evaluation"]` with a concrete status and reason.
+**Training from scratch is the exception.** With no pretrained / parent / resume
+checkpoint the baseline has nothing to evaluate, so it is inapplicable rather
+than failed: record it unavailable with that reason and proceed.
+
+The runner owns final evaluation of the selected best checkpoint. When a
+runnable evaluate action and eval data exist, pass `final_eval_fn(best_rec,
+train_job_id)` to `AutoMLRunner.run` rather than evaluating agent-side after
+`runner.run`; the result then carries `result["final_evaluation"]` with a
+concrete status and reason. See `automl-preflight-concepts.md` for the callback
+contract and the from-scratch rules.
 
 ## Dependency And Data Preflight
 

--- a/skills/applications/tao-run-automl/references/automl-preflight-concepts.md
+++ b/skills/applications/tao-run-automl/references/automl-preflight-concepts.md
@@ -70,6 +70,13 @@ Before running AutoML:
    ```
 
    Substitute the matching import for `brev`, `slurm`, or `kubernetes`. Catch a missing platform extra during preflight, before spending time on an image pull or recommendation. Local Docker launches with the host UID:GID when a writable results bind is present, so any model dataloader that writes through a spec path must point that path at a writable mount.
+
+   **Baseline eval when training from scratch.** The required baseline is scoped to runs that have a starting checkpoint. With no pretrained, parent, or resume checkpoint, there is no starting model to evaluate, so the baseline is inapplicable rather than failed:
+
+   - Record the baseline as unavailable with the reason and surface it in the launch review.
+   - Proceed to recommendations; only the impact-versus-starting-point delta is unavailable.
+   - Supply `baseline_fn` or `automl_settings["baseline_metric"]` only when a checkpoint exists. `final_eval_fn` still applies; a from-scratch smoke test may explicitly use `reuse_best_metric_for_final_evaluation=True`.
+
 3. **Dataset**: Training data accessible from the compute backend. URI format depends on the SDK's platform:
    - Brev / cloud: `s3://bucket/path` (S3-compatible; do not generate `aws://...`)
    - Slurm / internal shared storage: an absolute shared filesystem path visible to the Slurm job, e.g. `/lustre/fsw/tao_datasets/<model>/train` and `/lustre/fsw/tao_datasets/<model>/eval`

--- a/skills/applications/tao-run-automl/references/automl-preflight-concepts.md
+++ b/skills/applications/tao-run-automl/references/automl-preflight-concepts.md
@@ -62,7 +62,15 @@ Before running AutoML:
 
 1. **Shared launch preflight**: Run the `tao-launch-workflow` intake pattern first. AutoML must not create runner files, workspaces, state files, logs, compatibility shims, or install dependencies until the selected platform's credentials, access check, dataset visibility, model credentials, container image confirmation, and compute shape are satisfied. This prevents wasting the AutoML budget on fake recommendation failures caused by SSH, storage, image, or credential setup.
 2. **SDK credentials**: env vars read from the session environment (export them in your shell before launching). Required env vars depend on which SDK you choose — see each platform's SKILL.md (`skills/platform/tao-run-on-brev`, `skills/platform/tao-run-on-slurm`, `skills/platform/tao-run-on-kubernetes`, `skills/platform/tao-run-on-local-docker`). Before asking for credentials, read the chosen platform skill's `## Credentials` section and `references/skill_info.yaml` (required_credentials / credential_groups). Ask only for the credentials listed there. For example, SLURM needs SLURM credentials and not Brev or S3 credentials; Kubernetes and local Docker do not need SLURM or Brev credentials. Ask S3 credentials only when the selected platform and dataset/result URIs use `s3://`. For container pulls: `NGC_KEY`. The agent never reads values — only checks presence with `[ -n "$VAR_NAME" ]`. Construct the SDK with no arguments — e.g., `BrevSDK()`, `SlurmSDK()`, `KubernetesSDK()`, or `DockerSDK()`.
-2. **Dataset**: Training data accessible from the compute backend. URI format depends on the SDK's platform:
+
+   **Verify the SDK actually constructs before generating runner files.** A successful `import tao_automl` does not prove the selected AutoML platform extra is installed. Instantiate the SDK class for the chosen platform, for example:
+
+   ```bash
+   python -c "from tao_sdk.platforms.docker import DockerSDK; DockerSDK(); print('OK')"
+   ```
+
+   Substitute the matching import for `brev`, `slurm`, or `kubernetes`. Catch a missing platform extra during preflight, before spending time on an image pull or recommendation. Local Docker launches with the host UID:GID when a writable results bind is present, so any model dataloader that writes through a spec path must point that path at a writable mount.
+3. **Dataset**: Training data accessible from the compute backend. URI format depends on the SDK's platform:
    - Brev / cloud: `s3://bucket/path` (S3-compatible; do not generate `aws://...`)
    - Slurm / internal shared storage: an absolute shared filesystem path visible to the Slurm job, e.g. `/lustre/fsw/tao_datasets/<model>/train` and `/lustre/fsw/tao_datasets/<model>/eval`
    - Azure: `azure://container/path`

--- a/skills/models/tao-train-image-classification/SKILL.md
+++ b/skills/models/tao-train-image-classification/SKILL.md
@@ -72,6 +72,7 @@ TRAIN_IMAGES_DIR = "/workspace/data/extracted/train/images_train"
 VAL_IMAGES_DIR = "/workspace/data/extracted/val/images_val"
 TEST_IMAGES_DIR = "/workspace/data/extracted/test/images_test"
 CLASSES_FILE = "/workspace/data/s3/classes.txt"
+WRITABLE_RESULTS_DIR = "/results"   # must be a writable bind, not the image CWD
 ```
 
 For local Docker, download the S3 archives, extract them first, and point
@@ -89,8 +90,25 @@ local Docker specs; the skill metadata declares these inputs as folders.
     "dataset.train_dataset.images_dir": TRAIN_IMAGES_DIR,
     "dataset.classes_file": CLASSES_FILE,
     "dataset.val_dataset.images_dir": VAL_IMAGES_DIR,
+    "dataset.root_dir": WRITABLE_RESULTS_DIR,
 }
 ```
+
+`dataset.root_dir` is **mandatory for train**, not just for export. `CLDataset`
+writes a `classes.txt` into `root_dir` during setup, so it must point at a
+writable bind mount (the results mount is the natural choice). The spec template
+defaults it to `''`, which makes the write land in the container working
+directory — that succeeds under a root container but fails under any runner that
+drops to a non-root user:
+
+```
+PermissionError: [Errno 13] Permission denied: 'classes.txt'
+  .../classification_pyt/dataloader/dataset.py, in CLDataset.__init__
+```
+
+TAO SDK's `DockerSDK` enables `run_as_user` (host UID:GID) whenever a writable
+results bind is present, so AutoML and any SDK-launched training hit this unless
+`dataset.root_dir` is set.
 
 **export (mandatory data sources):**
 ```python

--- a/skills/models/tao-train-image-classification/SKILL.md
+++ b/skills/models/tao-train-image-classification/SKILL.md
@@ -106,9 +106,9 @@ PermissionError: [Errno 13] Permission denied: 'classes.txt'
   .../classification_pyt/dataloader/dataset.py, in CLDataset.__init__
 ```
 
-TAO SDK's `DockerSDK` enables `run_as_user` (host UID:GID) whenever a writable
-results bind is present, so AutoML and any SDK-launched training hit this unless
-`dataset.root_dir` is set.
+The local Docker launcher uses the host UID:GID whenever a writable results
+bind is present, so non-root training hits this unless `dataset.root_dir` is
+set.
 
 **export (mandatory data sources):**
 ```python


### PR DESCRIPTION
## Summary

Port and validate the reusable TAO AutoML skill corrections against the current standalone skill-bank contract.

This is the GitHub-main replacement for work developed before the GitLab repositories were discontinued.

## Migration contract

- Base: `main`
- Source branch: `dev/ram/tao-automl-skill-fixes`
- Branch prefix: `dev/ram/`
- Repository history, not an image or generated runtime patch, is the source of truth.
- No credentials or user-specific runtime paths are included.