### PR TITLE
[bundle-test] Re-sign 15 skills after migration #74

### DIFF
--- a/skills/applications/tao-analyze-changenet-rca/SKILL.md
+++ b/skills/applications/tao-analyze-changenet-rca/SKILL.md
@@ -85,3 +85,4 @@ Always save into a timestamped folder under the experiment result directory:
 Get the real timestamp by running `date +%Y-%m-%d_%H%M%S` in Bash — never hardcode or guess it. If the user specifies a custom path, use that instead but keep the same structure.
 
 See `references/output-structure.md` for the complete section-by-section report skeleton (every table header and summary line) and the full output layout with hook-copied contents — VERBATIM.
+

--- a/skills/applications/tao-finetune-huggingface-model/SKILL.md
+++ b/skills/applications/tao-finetune-huggingface-model/SKILL.md
@@ -410,3 +410,4 @@ fires twice across runs, lift it into `compat-workarounds.md` with a `detect` ru
 - [tao-rerun-detr-cppe5](references/tao-rerun-detr-cppe5.md)
 - [tao-rerun-segformer-foodseg103](references/tao-rerun-segformer-foodseg103.md)
 - [tao-rerun-smolvlm-vqav2](references/tao-rerun-smolvlm-vqav2.md)
+

--- a/skills/applications/tao-port-huggingface-model/SKILL.md
+++ b/skills/applications/tao-port-huggingface-model/SKILL.md
@@ -208,3 +208,4 @@ Diagnostic categories: accuracy too low; TRT-vs-native gap; training too slow; i
 If provided, interpret `$ARGUMENTS` as the HuggingFace model ID or URL to start Phase 1. If credentials or model short-name are not included, ask the user for them before proceeding.
 
 
+

--- a/skills/applications/tao-run-automl-deft-pipeline/SKILL.md
+++ b/skills/applications/tao-run-automl-deft-pipeline/SKILL.md
@@ -197,3 +197,4 @@ The handoff shape — Phase 1 emits a *spec + checkpoint* (the checkpoint pre-se
 - `references/phase-handoffs.md` — both handoffs, baseline pre-seed, and Phase 3 warm-start, verbatim
 - `references/pitfalls-and-quality-checks.md` — metric pitfalls, run-to-run noise, leakage, compute budget
 - `references/quick-start-example.md` — the customer-facing worked-example message
+

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -387,3 +387,4 @@ At completion:
 - Do not bypass a retention-preflight failure by disabling cleanup unless the
   user has explicitly accepted external ownership and manual lifecycle
   management for every trial artifact.
+

--- a/skills/applications/tao-run-deft-aoi/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi/SKILL.md
@@ -249,3 +249,4 @@ directory to `/results/iterN`.
 Run the full Pre-Flight (`references/preflight.md`), print the Pre-Flight Summary, then STOP at the one user gate. After approval, run the baseline (with the pre-seed/skip-train logic) and the 7-step iteration Pipeline, all detailed in `references/pipeline-and-state.md`.
 
 Hard-stop and never auto-retry on: any stage `status=error`; train/validation leakage; a missing or zero-row mining pool; a failed CSV existence check; silent-drop; and AMP allocation mismatch. The loop stops when the KPI target is met, `max_iterations` is reached, or an unrecoverable gate fires. Each terminal path commits `loop_stop` through `commit_stage.py`, then follows the loop-end sequence in `references/pipeline-and-state.md`.
+

--- a/skills/applications/tao-run-inference-service/SKILL.md
+++ b/skills/applications/tao-run-inference-service/SKILL.md
@@ -242,3 +242,4 @@ Send a `POST` to `{BASE_URL}/v1/chat/completions` with `Content-Type: applicatio
 | **500** | Unhandled exception during inference | Check container logs |
 
 For 202 and 503, the body contains `{"error": {"type": "<error_type>", "message": "<reason>"}}`. See `container_response_shapes` in `references/request.yaml` for error type strings.
+

--- a/skills/applications/tao-train-single-step/SKILL.md
+++ b/skills/applications/tao-train-single-step/SKILL.md
@@ -82,3 +82,4 @@ After platform selection, read the chosen platform skill's `## Credentials`
 section and `references/skill_info.yaml` (required_credentials /
 credential_groups) and ask only for credentials relevant to that platform, plus
 any selected-model credentials. Do not ask for unrelated platform credentials.
+

--- a/skills/core/tao-launch-workflow/SKILL.md
+++ b/skills/core/tao-launch-workflow/SKILL.md
@@ -314,3 +314,4 @@ search parameters, ranges, and generated/default recommendation details as
 described in `skills/applications/tao-run-automl/SKILL.md`. Ask for confirmation after
 this review. If the user supplied a time limit, flag any plan that exceeds it
 and offer concrete reductions before launch.
+

--- a/skills/core/tao-list-capabilities/SKILL.md
+++ b/skills/core/tao-list-capabilities/SKILL.md
@@ -88,3 +88,4 @@ AutoML support for an action requires
 `skills/models/<model_skill>/schemas/<action>.schema.json` to be packaged with the plugin
 and parse successfully as JSON. If that dataclass schema is missing or invalid,
 do not describe the model/action as AutoML-supported.
+

--- a/skills/data/paidf-anomalygen/SKILL.md
+++ b/skills/data/paidf-anomalygen/SKILL.md
@@ -391,3 +391,4 @@ the `0 entries written` halt, mid-round SDG failure resume, off-boundary
 2B-only `check.sh` default, and guardrail-blocked black images) are covered in
 `references/error-handling.md`; see also `references/finetune.md` and
 `references/inference.md` for phase-specific error handling.
+

--- a/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
+++ b/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
@@ -211,3 +211,4 @@ Write `RCA_Report.md` as a tight (1000–1800 word) computational gap analysis �
 5. If `unreachable_kpi.txt` exists, skip Step 6 and write the abridged report. Otherwise continue.
 6. Pick 10 weak samples (5 weakest PASS + 5 weakest NO_PASS) from `kpi_gaps.parquet`, view each test image with Read, classify, and copy each into `rca_images/`.
 7. Write `RCA_Report.md` last — writing it triggers the packaging hook, which copies session logs and skill config alongside.
+

--- a/skills/data/tao-analyze-gaps-vlm-bcq/SKILL.md
+++ b/skills/data/tao-analyze-gaps-vlm-bcq/SKILL.md
@@ -89,3 +89,4 @@ If no gaps are found, no files are written and a message is logged.
 | `ValueError: must be a JSON array` | Predictions file is not a list | Wrap predictions in `[...]` |
 | `ValueError: missing 'gt'/'response'/'video_id'` | A prediction item is missing a required field | Inspect and fix the predictions JSON |
 | Samples silently skipped | `response` or `gt` contains both or neither 'yes'/'no' | Check logs for warnings; inspect those samples |
+

--- a/skills/data/tao-convert-dataset-format/SKILL.md
+++ b/skills/data/tao-convert-dataset-format/SKILL.md
@@ -137,3 +137,4 @@ the full output and partial-read if huge.
   flags (media handling, task subset) via leaf `--help`; a misset
   flag often produces a structurally valid but semantically wrong
   target.
+

--- a/skills/data/tao-generate-image-grounding/SKILL.md
+++ b/skills/data/tao-generate-image-grounding/SKILL.md
@@ -125,3 +125,4 @@ All outputs go to `results_dir/`:
 
 - **Container**: `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` <!-- versions-key: images.tao_toolkit.pyt -->
 - **API access**: At least one VLM endpoint (Gemini API key or OpenAI-compatible endpoint capable of image input)
+


### PR DESCRIPTION
## Bundle-capacity test

Testing whether `/nvskills-ci` can sign **15 skills in one run** (Moshe confirmed the old '3 per PR' limit is soft and eval-dependent).

## Context
Migration #74 (merged today) rewrote skill content without refreshing `skill.oms.sig`, so the catalog is holding 55 skills on their pre-migration signed copy. This re-signs a first batch of 15 (trailing-newline nudge to bring them into the changed-set) against current content.

## Skills in this batch (15)
applications: tao-analyze-changenet-rca, tao-finetune-huggingface-model, tao-port-huggingface-model, tao-run-automl, tao-run-automl-deft-pipeline, tao-run-deft-aoi, tao-run-inference-service, tao-train-single-step · core: tao-launch-workflow, tao-list-capabilities · data: paidf-anomalygen, tao-analyze-gaps-visual-changenet, tao-analyze-gaps-vlm-bcq, tao-convert-dataset-format, tao-generate-image-grounding

If all 15 sign cleanly, we'll fan out the remaining ~52 in similar bundles.