### PR TITLE
ci: add require-nvskills-status.yml — fixes /nvskills-ci startup_failure (signing broken repo-wide)

### DIFF
--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -1,0 +1,390 @@
+name: Require NVSkills CI status
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: read
+
+jobs:
+  require-nvskills-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: read
+    concurrency:
+      group: nvskills-ci-required-${{ github.repository }}-${{ github.event.pull_request.number || github.event.sha || github.sha }}
+      cancel-in-progress: true
+    steps:
+      - name: Require NVSkills CI for watched changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.sha || github.sha }}
+          STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
+          SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
+          SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]' }}
+          SIGNATURE_SERVICE_ACCOUNT_LOGIN: ${{ vars.NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN || vars.NVSKILLS_SIGNATURE_COMMIT_LOGIN || 'svc-nvskills-signing' }}
+          STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
+          MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
+          MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3300' }}
+        run: |
+          set -euo pipefail
+
+          owner="${REPO%%/*}"
+          repo="${REPO#*/}"
+          head_sha="$(printf '%s' "${HEAD_SHA}" | tr '[:upper:]' '[:lower:]')"
+          pr_number="${PR_NUMBER}"
+
+          append_summary() {
+            printf '%s\n' "$@" | tee -a "${GITHUB_STEP_SUMMARY}"
+          }
+
+          positive_integer() {
+            case "$1" in
+              ''|*[!0-9]*|0) printf '%s' "$2" ;;
+              *) printf '%s' "$1" ;;
+            esac
+          }
+
+          bounded_positive_integer() {
+            local value
+            local maximum="$3"
+
+            value="$(positive_integer "$1" "$2")"
+            while [ "${value#0}" != "${value}" ]; do
+              value="${value#0}"
+            done
+            if [ -z "${value}" ] || [ "${value}" = "0" ]; then
+              value="$2"
+            fi
+            if [ "${#value}" -gt "${#maximum}" ] ||
+              { [ "${#value}" -eq "${#maximum}" ] && [[ "${value}" > "${maximum}" ]]; }; then
+              echo "::warning::Configured wait value ${value}s exceeds the safe maximum ${maximum}s; clamping it." >&2
+              value="${maximum}"
+            fi
+            printf '%s' "${value}"
+          }
+
+          case "${HEAD_REF}" in
+            automated/sync-skills|bot/regenerate-skill-metadata)
+              append_summary \
+                "## NVSkills CI required status" \
+                "" \
+                "Skipped: bot-managed branch \`${HEAD_REF}\` is exempt from this check."
+              exit 0
+              ;;
+          esac
+
+          github_get() {
+            curl --fail --silent --show-error --location \
+              --retry 3 \
+              --retry-delay 2 \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$1"
+          }
+
+          get_commit_json() {
+            local commit_sha="$1"
+            local page=1
+            local response
+            local first_response=""
+            local page_files
+            local all_files='[]'
+            local page_count
+
+            while true; do
+              response="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${commit_sha}?per_page=100&page=${page}")"
+              if [ "${page}" -eq 1 ]; then
+                first_response="${response}"
+              fi
+              page_files="$(printf '%s' "${response}" | jq -c '.files // []')"
+              page_count="$(printf '%s' "${page_files}" | jq 'length')"
+              all_files="$(jq -cn \
+                --argjson existing "${all_files}" \
+                --argjson current "${page_files}" \
+                '$existing + $current')"
+
+              if [ "${page_count}" -lt 100 ]; then
+                break
+              fi
+              if [ "${page}" -ge 30 ]; then
+                echo "Commit ${commit_sha} has too many files to classify safely." >&2
+                return 1
+              fi
+              page=$((page + 1))
+            done
+
+            printf '%s' "${first_response}" | jq -c --argjson files "${all_files}" '.files = $files'
+          }
+
+          first_watched_path() {
+            printf '%s' "$1" | jq -r '
+              def watched:
+                (. // "") |
+                startswith("skills/") or
+                startswith("team-skills/") or
+                startswith("rules/team-rules/") or
+                startswith("plugins/");
+              [
+                .files[]? |
+                select((.filename | watched) or (.previous_filename? | watched)) |
+                if (.filename | watched) then .filename else .previous_filename end
+              ][0] // empty
+            '
+          }
+
+          is_generated_signature_artifact_commit() {
+            local commit_json="$1"
+            local commit_title
+
+            commit_title="$(printf '%s' "${commit_json}" | jq -r '.commit.message | split("\n")[0]')"
+            [ "${commit_title}" = "${SIGNATURE_COMMIT_TITLE}" ] || return 1
+
+            printf '%s' "${commit_json}" | jq -e '
+              def generated_artifact:
+                test(
+                  "^(skills/[^/]+|team-skills/[^/]+/[^/]+|" +
+                  "plugins/[^/]+|plugins/[^/]+/skills/[^/]+)/" +
+                  "(BENCHMARK\\.md|skill-card\\.md|skill\\.oms\\.sig|" +
+                  "skill-card-review-needed\\.md|[^/]+-review-needed\\.md)$"
+                );
+              any(.files[]?; .filename | endswith("/skill.oms.sig")) and
+              all(.files[]?;
+                ((.previous_filename? // "") | length) == 0 and
+                (.filename | generated_artifact)
+              )
+            ' >/dev/null
+          }
+
+          is_service_generated_signature_commit() {
+            local commit_json="$1"
+
+            is_generated_signature_artifact_commit "${commit_json}" || return 1
+            printf '%s' "${commit_json}" | jq -e \
+              --arg actor "${SIGNATURE_PUSH_ACTOR}" \
+              --arg service_login "${SIGNATURE_SERVICE_ACCOUNT_LOGIN}" '
+                ((.author.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+                ((.committer.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+                (
+                  ($service_login | length) > 0 and
+                  (
+                    ((.author.login? // "") | ascii_downcase) == ($service_login | ascii_downcase) or
+                    ((.committer.login? // "") | ascii_downcase) == ($service_login | ascii_downcase)
+                  )
+                )
+              ' >/dev/null
+          }
+          if [ -z "${pr_number}" ] || [ -z "${head_sha}" ]; then
+            echo "Pull request metadata is incomplete."
+            exit 1
+          fi
+
+          pr_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}")"
+          current_head_sha="$(printf '%s' "${pr_json}" | jq -r '.head.sha | ascii_downcase')"
+          if [ "${current_head_sha}" != "${head_sha}" ]; then
+            append_summary \
+              "## NVSkills CI required status" \
+              "" \
+              "Skipped: this workflow run is for stale head \`${head_sha}\`; PR #${pr_number} is now at \`${current_head_sha}\`."
+            exit 0
+          fi
+
+          has_watched_change=false
+          page=1
+          while true; do
+            files_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/files?per_page=100&page=${page}")"
+            if printf '%s' "${files_json}" | jq -e '
+              def watched:
+                (. // "") |
+                startswith("skills/") or
+                startswith("team-skills/") or
+                startswith("rules/team-rules/") or
+                startswith("plugins/");
+              any(.[]; (.filename | watched) or (.previous_filename? | watched))
+            ' >/dev/null; then
+              has_watched_change=true
+              break
+            fi
+            if [ "$(printf '%s' "${files_json}" | jq 'length')" -lt 100 ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+
+          if [ "${has_watched_change}" != "true" ]; then
+            append_summary \
+              "## NVSkills CI required status" \
+              "" \
+              "Skipped: PR #${pr_number} has no changes under watched NVSkills paths."
+            exit 0
+          fi
+
+          head_commit_json="$(get_commit_json "${head_sha}")"
+
+          commit_shas_file="$(mktemp)"
+          trap 'rm -f "${commit_shas_file}"' EXIT
+
+          page=1
+          while true; do
+            commits_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/commits?per_page=100&page=${page}")"
+            printf '%s' "${commits_json}" | jq -r '.[].sha | ascii_downcase' >> "${commit_shas_file}"
+            if [ "$(printf '%s' "${commits_json}" | jq 'length')" -lt 100 ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+
+          mapfile -t commit_shas < "${commit_shas_file}"
+          if [ "${#commit_shas[@]}" -eq 0 ]; then
+            echo "Pull request commits could not be resolved."
+            exit 1
+          fi
+
+          latest_watched_sha=""
+          latest_watched_path=""
+          latest_generated_signature_sha=""
+          for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
+            commit_sha="${commit_shas[idx]}"
+            if [ "${commit_sha}" = "${head_sha}" ]; then
+              commit_json="${head_commit_json}"
+            else
+              commit_json="$(get_commit_json "${commit_sha}")"
+            fi
+            if is_service_generated_signature_commit "${commit_json}"; then
+              if [ -z "${latest_generated_signature_sha}" ]; then
+                latest_generated_signature_sha="${commit_sha}"
+              fi
+              continue
+            fi
+            watched_path="$(first_watched_path "${commit_json}")"
+            if [ -n "${watched_path}" ]; then
+              latest_watched_sha="${commit_sha}"
+              latest_watched_path="${watched_path}"
+              break
+            fi
+          done
+
+          if [ -z "${latest_watched_sha}" ]; then
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "## NVSkills CI required status" \
+                "" \
+                "Failed: generated signature commit \`${latest_generated_signature_sha}\` has no preceding watched-path content commit to validate."
+              exit 1
+            fi
+            append_summary \
+              "## NVSkills CI required status" \
+              "" \
+              "Skipped: PR #${pr_number} has no commits that changed watched NVSkills paths."
+            exit 0
+          fi
+
+          status_floor_sha="${latest_watched_sha}"
+          if [ -n "${latest_generated_signature_sha}" ]; then
+            status_floor_sha="${latest_generated_signature_sha}"
+          fi
+
+          poll_seconds="$(bounded_positive_integer "${STATUS_POLL_SECONDS}" 30 300)"
+          missing_grace_seconds="$(bounded_positive_integer "${MISSING_STATUS_GRACE_SECONDS}" 120 600)"
+          max_wait_seconds="$(bounded_positive_integer "${MAX_STATUS_WAIT_SECONDS}" 3300 3300)"
+          elapsed_seconds=0
+          status_sha=""
+          status_state="missing"
+          target_url=""
+
+          while true; do
+            status_sha=""
+            status_state="missing"
+            target_url=""
+            for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
+              commit_sha="${commit_shas[idx]}"
+              statuses_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${commit_sha}/statuses?per_page=100")"
+              candidate_state="$(printf '%s' "${statuses_json}" | jq -r \
+                --arg context "${STATUS_CONTEXT}" \
+                '[.[] | select(.context == $context)][0].state // "missing"')"
+              if [ "${candidate_state}" != "missing" ]; then
+                status_sha="${commit_sha}"
+                status_state="${candidate_state}"
+                target_url="$(printf '%s' "${statuses_json}" | jq -r \
+                  --arg context "${STATUS_CONTEXT}" \
+                  '[.[] | select(.context == $context)][0].target_url // ""')"
+                break
+              fi
+              if [ "${commit_sha}" = "${status_floor_sha}" ]; then
+                break
+              fi
+            done
+
+            case "${status_state}" in
+              success|failure|error)
+                break
+                ;;
+              missing)
+                if [ "${elapsed_seconds}" -ge "${missing_grace_seconds}" ]; then
+                  break
+                fi
+                ;;
+              pending)
+                if [ "${elapsed_seconds}" -ge "${max_wait_seconds}" ]; then
+                  status_state="timeout"
+                  break
+                fi
+                ;;
+              *)
+                echo "Unexpected ${STATUS_CONTEXT} state: ${status_state}"
+                exit 1
+                ;;
+            esac
+
+            echo "Waiting for ${STATUS_CONTEXT} at or after ${status_floor_sha} (state: ${status_state}, elapsed: ${elapsed_seconds}s)."
+            sleep "${poll_seconds}"
+            elapsed_seconds=$((elapsed_seconds + poll_seconds))
+          done
+
+          if [ "${status_state}" = "success" ]; then
+            append_summary \
+              "## NVSkills CI required status" \
+              "" \
+              "Passed: \`${STATUS_CONTEXT}\` succeeded for validation evidence commit \`${status_sha}\`." \
+              "" \
+              "Latest watched-path change: \`${latest_watched_path}\` at \`${latest_watched_sha}\`."
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "" \
+                "Latest generated signature commit: \`${latest_generated_signature_sha}\`."
+            fi
+            if [ "${status_sha}" != "${head_sha}" ]; then
+              append_summary \
+                "" \
+                "PR head \`${head_sha}\` contains only trailing changes outside watched NVSkills paths after the validated tree."
+            fi
+            exit 0
+          fi
+
+          append_summary \
+            "## NVSkills CI required status" \
+            "" \
+            "Failed: no successful \`${STATUS_CONTEXT}\` status was found at or after required evidence commit \`${status_floor_sha}\` (state: \`${status_state}\`)." \
+            "" \
+            "Latest watched-path change: \`${latest_watched_path}\`." \
+            "" \
+            "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
+            "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
+            "" \
+            "For a fork pull request, add \`${SIGNATURE_SERVICE_ACCOUNT_LOGIN}\`, the configured NVSkills signing service account, as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
+          if [ -n "${status_sha}" ]; then
+            append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
+          fi
+          if [ -n "${target_url}" ]; then
+            append_summary "" "Current NVSkills CI run: ${target_url}"
+          fi
+          exit 1


### PR DESCRIPTION
## Problem
Every `/nvskills-ci` on this repo currently fails at workflow load with **`startup_failure`** — no signing runs at all. Root cause: on **2026-08-03**, `NVIDIA/skills/.github/workflows/team-request.yml@main` was rewritten to nest `uses: ./.github/workflows/require-nvskills-status.yml`. That `./` resolves against the **caller** repo, and **tao-skill-bank is the only product repo missing this file** (all 12 others — DALI, cuopt, DeepStream, dynamo, cudf, … — have it).

## Fix
Add the canonical `require-nvskills-status.yml` (verbatim copy from NVIDIA/skills). This restores signing **and** enables the per-PR signing enforcement gate other teams use.

## Impact
- Unblocks re-signing the ~55 skills held after migration #74.
- Adds a PR check that requires `NVSkills CI` success on any PR touching `skills/` — so contributors sign in their own PR going forward.