### PR TITLE
ci: grant statuses:read in request-nvskills-ci — fixes /nvskills-ci startup_failure

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Root cause (real one)
`/nvskills-ci` has been failing at workflow load (`startup_failure`) — no signing runs. On **2026-08-03** `NVIDIA/skills/team-request.yml@main` was refactored so its `require-nvskills-ci` job requests `statuses: read`. A **called** reusable workflow can't exceed the **caller's** permission grant, so any repo whose `request` job grants only `contents`/`pull-requests: read` now fails to load.

**Evidence:** `NVIDIA/cuopt` (which added `statuses: read`) signs fine today; `NVIDIA/DALI` and this repo (stale after migration #74) both `startup_failure`.

## Fix
Add `statuses: read` to the `request` job permissions — matches cuopt's working canonical copy. Together with #90 (which added `require-nvskills-status.yml`), this restores signing.