### PR TITLE
[TAO-2231][Feature] Add tao-analyze-gaps-od-map skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,6 +29,7 @@
         "./skills/data/tao-mine-nearest-neighbors",
         "./skills/data/tao-mine-aoi-images",
         "./skills/data/tao-analyze-gaps-visual-changenet",
+        "./skills/data/tao-analyze-gaps-od-map",
         "./skills/data/tao-route-visual-changenet-samples",
         "./skills/data/paidf-cosmos-predict",
         "./skills/data/tao-generate-video-reasoning-annotations",
@@ -80,8 +81,7 @@
         "./skills/data/tao-analyze-gaps-vlm-bcq",
         "./skills/data/tao-generate-image-grounding",
         "./skills/data/tao-generate-referring-expressions",
-        "./skills/data/tao-mine-od-images",
-        "./skills/data/tao-analyze-gaps-od-map"
+        "./skills/data/tao-mine-od-images"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -90,7 +90,8 @@
       "strict": true,
       "skills": [
         "./skills/data/tao-convert-dataset-format",
-        "./skills/data/tao-validate-dataset-format"
+        "./skills/data/tao-validate-dataset-format",
+        "./skills/data/tao-analyze-gaps-od-map"
       ]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -80,7 +80,8 @@
         "./skills/data/tao-analyze-gaps-vlm-bcq",
         "./skills/data/tao-generate-image-grounding",
         "./skills/data/tao-generate-referring-expressions",
-        "./skills/data/tao-mine-od-images"
+        "./skills/data/tao-mine-od-images",
+        "./skills/data/tao-analyze-gaps-od-map"
       ]
     },
     {
@@ -90,8 +91,7 @@
       "strict": true,
       "skills": [
         "./skills/data/tao-convert-dataset-format",
-        "./skills/data/tao-validate-dataset-format",
-        "./skills/data/tao-analyze-gaps-od-map"
+        "./skills/data/tao-validate-dataset-format"
       ]
     }
   ]

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -75,8 +75,15 @@ warns when a fallback is above zero, since that gates classes you did not list.
 
 Run from the `tao-skills-external` repo root.
 
+**Write the spec into the results directory.** The run emits four artifacts and
+does not retain the spec, so a completed gap analysis otherwise cannot tell you
+which thresholds produced its weak set — and that weak set sizes the mining
+budget downstream. Keeping them together makes the selection criteria recoverable
+from the run alone.
+
 ```bash
-SPEC=/absolute/path/to/object_detection.yaml
+RESULTS_DIR=/absolute/path/for/this/run          # results_dir in the spec
+SPEC="$RESULTS_DIR/object_detection.yaml"        # spec lives beside its outputs
 RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
 GPU_COUNT=1
 

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -67,7 +67,13 @@ SPEC=/absolute/path/to/object_detection.yaml
 RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
 GPU_COUNT=1
 
-DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services)"
+# NO PUBLISHED IMAGE CARRIES `gap_analysis object_detection` YET. Verified against
+# nvidia/tao-toolkit:7.1.0-data-services, nvstaging ds:7.0.1-rc-200-x86 and
+# ds:2026.7.31-rc-14-multiarch — all three offer only {vcn_aoi, vlm_bcq, default_specs}.
+# Probe before pulling ~30 GB:
+#   docker run --rm "$DS_IMAGE" gap_analysis nosuch 2>&1 | tail -2
+# and confirm object_detection is in the printed choice list.
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: repin once the action is published
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -89,7 +95,13 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services)"
+# NO PUBLISHED IMAGE CARRIES `gap_analysis object_detection` YET. Verified against
+# nvidia/tao-toolkit:7.1.0-data-services, nvstaging ds:7.0.1-rc-200-x86 and
+# ds:2026.7.31-rc-14-multiarch — all three offer only {vcn_aoi, vlm_bcq, default_specs}.
+# Probe before pulling ~30 GB:
+#   docker run --rm "$DS_IMAGE" gap_analysis nosuch 2>&1 | tail -2
+# and confirm object_detection is in the printed choice list.
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: repin once the action is published
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -67,13 +67,7 @@ SPEC=/absolute/path/to/object_detection.yaml
 RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
 GPU_COUNT=1
 
-# NO PUBLISHED IMAGE CARRIES `gap_analysis object_detection` YET. Verified against
-# nvidia/tao-toolkit:7.1.0-data-services, nvstaging ds:7.0.1-rc-200-x86 and
-# ds:2026.7.31-rc-14-multiarch — all three offer only {vcn_aoi, vlm_bcq, default_specs}.
-# Probe before pulling ~30 GB:
-#   docker run --rm "$DS_IMAGE" gap_analysis nosuch 2>&1 | tail -2
-# and confirm object_detection is in the printed choice list.
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: repin once the action is published
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -95,13 +89,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-# NO PUBLISHED IMAGE CARRIES `gap_analysis object_detection` YET. Verified against
-# nvidia/tao-toolkit:7.1.0-data-services, nvstaging ds:7.0.1-rc-200-x86 and
-# ds:2026.7.31-rc-14-multiarch — all three offer only {vcn_aoi, vlm_bcq, default_specs}.
-# Probe before pulling ~30 GB:
-#   docker run --rm "$DS_IMAGE" gap_analysis nosuch 2>&1 | tail -2
-# and confirm object_detection is in the printed choice list.
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: repin once the action is published
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -56,7 +56,20 @@ Common optional fields:
 | `default_precision_threshold` | `0.0` | Fallback precision threshold. Set to `0.0` to disable precision-based weak selection. |
 | `default_ap50_threshold` | `0.5` | Fallback for classes absent from `weak_thresholds`. **Set `0.0`** so unlisted classes never mark an image weak — the reference filter had no fallback, and leaving TAO DS's `0.5` in place silently gates every class you did not list. |
 
-The default template is `assets/default_object_detection.yaml`.
+Do not hand-write the spec. Copy the template and fill in the `null`s — every
+tuning value it already carries is the one this stage wants — then validate:
+
+```bash
+cp skills/data/tao-analyze-gaps-od-map/assets/default_object_detection.yaml "$SPEC"
+# fill ground_truth_ann_path, inference_ann_path, images_dir, results_dir, kpi, input_format
+python3 skills/data/tao-analyze-gaps-od-map/scripts/verify_object_detection_spec.py --spec "$SPEC"
+```
+
+`verify` rejects the spellings that fail — uppercase `input_format`, relative or
+missing paths, a `weak_thresholds` entry that is a bare number rather than a
+mapping — and reports every gated class plus the `default_*` fallbacks, so the
+selection criteria behind a weak set are recoverable from the run's output. It
+warns when a fallback is above zero, since that gates classes you did not list.
 
 ## Quick Start
 

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: tao-analyze-gaps-od-map
+description: >-
+  Run TAO Data Services object-detection gap analysis from ground-truth and inference annotations.
+  Use when an object detection workflow needs to identify weak images by comparing model predictions
+  against ground truth using per-class recall, precision, and AP50 thresholds.
+  Use when the user asks to "analyze OD gaps", "find weak OD images", or "run mAP gap analysis".
+license: Apache-2.0
+compatibility: Requires docker, nvidia-container-toolkit, and the TAO data-services container pinned in versions.yaml.
+metadata:
+  author: NVIDIA Corporation
+  version: "0.1.0"
+allowed-tools: Read Bash
+tags:
+- tao
+- data
+- gap-analysis
+- object-detection
+- mAP
+- rcca
+---
+
+# TAO Analyze Gaps OD mAP
+
+Use this skill to run TAO Data Services object-detection gap analysis. The skill compares ground-truth and inference annotations, computes per-image per-class TP/FP/FN/AP50 metrics, and identifies weak images where any class metric falls below its threshold. It does not run inference; upstream steps must produce the inference annotations first.
+
+The container entrypoint is:
+
+```bash
+gap_analysis object_detection -e /absolute/path/to/object_detection.yaml
+```
+
+## Inputs
+
+Required spec fields:
+
+| Field | Meaning |
+|---|---|
+| `ground_truth_ann_path` | KITTI label directory or COCO `.json` with ground-truth boxes. |
+| `inference_ann_path` | KITTI label directory or COCO `.json` with model predictions. |
+| `images_dir` | Root image directory. Establishes the full image universe including unannotated images. |
+| `results_dir` | Output directory for all artifacts. |
+| `kpi` | Identifier tag written to every output row. |
+| `input_format` | `kitti` or `coco`. Must be declared explicitly; never inferred from the path. |
+
+Common optional fields:
+
+| Field | Default | Meaning |
+|---|---:|---|
+| `iou_threshold` | `0.5` | IoU at or above which a prediction is accepted as a true positive. |
+| `conf_threshold` | `0.0` | Predictions below this confidence are dropped before matching. |
+| `min_area` | `0` | Boxes whose pixel area (w × h) is strictly below this value are discarded. |
+| `class_mapping` | `{}` | Maps raw annotation label strings to canonical class names. Absent labels are kept as-is. |
+| `weak_thresholds` | `{}` | Per-class thresholds as `{class_name: {recall, precision, ap50}}`. Absent keys fall back to the `default_*_threshold` values. Reference ITS defaults: `car 0.99`, `bicycle 0.7`, `person 0.7` — a strict gate on the abundant, well-learned class and looser gates on the rare ones the loop exists to improve. |
+| `default_recall_threshold` | `0.5` | Fallback recall threshold for classes not listed in `weak_thresholds`. |
+| `default_precision_threshold` | `0.0` | Fallback precision threshold. Set to `0.0` to disable precision-based weak selection. |
+| `default_ap50_threshold` | `0.5` | Fallback for classes absent from `weak_thresholds`. **Set `0.0`** so unlisted classes never mark an image weak — the reference filter had no fallback, and leaving TAO DS's `0.5` in place silently gates every class you did not list. |
+
+The default template is `assets/default_object_detection.yaml`.
+
+## Quick Start
+
+Run from the `tao-skills-external` repo root.
+
+```bash
+SPEC=/absolute/path/to/object_detection.yaml
+RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
+GPU_COUNT=1
+
+DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services)"
+
+docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
+  -v "$RUN_ROOT:$RUN_ROOT" \
+  -w "$RUN_ROOT" \
+  "$DS_IMAGE" \
+  gap_analysis object_detection -e "$SPEC"
+```
+
+Do not pass `--user $(id -u):$(id -g)`; some TAO DS images call `getpass.getuser()` at startup and fail when the UID is not in `/etc/passwd`.
+
+## Preflight
+
+1. Verify Docker access:
+
+```bash
+docker info > /dev/null
+```
+
+2. Resolve and pull the data-services image if needed:
+
+```bash
+DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services)"
+docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
+```
+
+3. Confirm `RUN_ROOT` contains the spec, both annotation sources, and the image directory. Mount `RUN_ROOT` to the same absolute path inside Docker.
+
+## Outputs
+
+| Artifact | Location | Contents |
+|---|---|---|
+| FP/FN box gaps | `results_dir/box_gaps.parquet` | One row per unmatched box: `kpi`, `image_id`, `filepath`, `class`, `gap_type` (FP/FN), `bbox`, `confidence`, `best_iou`. |
+| Per-image metrics | `results_dir/image_metrics.parquet` | Per-image per-class: `tp`, `fp`, `fn`, `precision`, `recall`, `ap50`. |
+| Weak images | `results_dir/weak_images.parquet` | Images where any class metric falls below threshold: `filepath`, `weak_classes`, `weak_recall`, `weak_precision`, `weak_ap50`. Feed this into `tao-mine-od-images`. |
+| Gap report | `results_dir/gap_report.json` | FP/FN counts by type and class, plus run settings. |
+
+All four artifacts are always written, even when no gaps are found.
+
+## Troubleshooting
+
+**`The subtask object_detection requires -e/--experiment_spec_file`**: rerun with `gap_analysis object_detection -e "$SPEC"`.
+
+**Input path not found inside Docker**: use a `RUN_ROOT` mount where host and container paths are identical.
+
+**`input_format` error**: set `input_format: kitti` or `input_format: coco` explicitly — it is never inferred from the path.
+
+**`weak_images.parquet` is empty**: all class metrics are above their thresholds. Lower `default_recall_threshold` / `default_ap50_threshold` or add per-class entries to `weak_thresholds`.
+
+**Output directory not writable after Docker exits**: the container writes as root. Chown back with `docker run --rm -v "$RUN_ROOT:$RUN_ROOT" alpine chown -R "$(id -u):$(id -g)" "$RESULTS_DIR"`.

--- a/skills/data/tao-analyze-gaps-od-map/assets/default_object_detection.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/assets/default_object_detection.yaml
@@ -1,0 +1,27 @@
+ground_truth_ann_path: null
+inference_ann_path: null
+images_dir: null
+results_dir: null
+kpi: null
+input_format: null       # kitti or coco — lowercase here (analytics kpi_analyze wants uppercase)
+iou_threshold: 0.5
+conf_threshold: 0.0      # inference already filtered at write time; a second gate filters twice
+min_area: 0
+class_mapping: {}
+
+# Per-class AP50 gates. An image is weak if ANY listed class falls below its gate.
+# Values below are the reference ITS defaults — use them unless the user supplies their own.
+# `car` is held to a far stricter gate than the vulnerable-road-user classes because it is
+# abundant and already well learned; the loop's job is to lift bicycle and person.
+weak_thresholds:
+  car:     {ap50: 0.99}
+  bicycle: {ap50: 0.7}
+  person:  {ap50: 0.7}
+
+# A class NOT listed above must never mark an image weak — that is what these zeros do.
+# The reference filter had no fallback at all; TAO DS defaults default_ap50_threshold to 0.5,
+# so leaving it unset silently gates every class you did not list. `road_sign` is the
+# concrete case: present in the ITS ground truth, deliberately ungated.
+default_ap50_threshold:      0.0
+default_recall_threshold:    0.0
+default_precision_threshold: 0.0

--- a/skills/data/tao-analyze-gaps-od-map/evals/evals.json
+++ b/skills/data/tao-analyze-gaps-od-map/evals/evals.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "tao-analyze-gaps-od-map-basic",
+    "question": "A user request: \"Use the tao-analyze-gaps-od-map skill.\" Identify which TAO skill applies and, reading only that skill's documentation, outline the steps it prescribes. Do NOT run any commands, scripts, web searches, or other tools — describe the plan only.",
+    "expected_skill": "tao-analyze-gaps-od-map",
+    "expected_script": null,
+    "ground_truth": "Identify tao-analyze-gaps-od-map as the applicable skill and summarize its documented workflow from SKILL.md without executing anything.",
+    "expected_behavior": [
+      "Identifies tao-analyze-gaps-od-map as the relevant skill",
+      "Explains that it runs TAO Data Services gap_analysis object_detection from a YAML spec",
+      "Mentions the four output artifacts: box_gaps.parquet, image_metrics.parquet, weak_images.parquet, gap_report.json",
+      "Does not run commands, scripts, or web searches"
+    ]
+  }
+]

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-od-map
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: no published data-services image carries `gap_analysis object_detection` yet; repin once it ships
+container_image: nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-od-map
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: gap_analysis object_detection is not in the released 7.1.0-data-services image yet
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: no published data-services image carries `gap_analysis object_detection` yet; repin once it ships
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,0 +1,22 @@
+network_arch: tao-analyze-gaps-od-map
+type: data
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # versions-key: images.tao_toolkit.data_services
+gpu_spec_key: null
+required_credentials: []
+actions:
+  object_detection:
+    command: gap_analysis object_detection -e {config_path}
+    config_format: yaml
+    mode: config
+    inputs:
+      ground_truth_ann_path:
+        type: file
+      inference_ann_path:
+        type: file
+      images_dir:
+        type: folder
+    outputs:
+      results_dir:
+        type: directory
+    upload_excludes:
+    - inputs/

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -10,9 +10,9 @@ actions:
     mode: config
     inputs:
       ground_truth_ann_path:
-        type: file
+        type: path   # KITTI: a directory; COCO: a json file
       inference_ann_path:
-        type: file
+        type: path   # KITTI: a directory; COCO: a json file
       images_dir:
         type: folder
     outputs:

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-od-map
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.0.1-rc-200-x86  # unpinned: gap_analysis object_detection is not in the released 7.1.0-data-services image yet
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-od-map/scripts/verify_object_detection_spec.py
+++ b/skills/data/tao-analyze-gaps-od-map/scripts/verify_object_detection_spec.py
@@ -138,6 +138,7 @@ def main() -> int:
         spec = Path(parse_args().spec).expanduser().resolve()
         config = load_yaml(spec)
         warnings = validate_config(config)
+        out = Path(str(config['results_dir'])).expanduser()
 
         thresholds = config.get("weak_thresholds") or {}
         print(f"OK: gap-analysis spec is valid: {spec}")
@@ -149,6 +150,14 @@ def main() -> int:
         print("fallbacks: " + ", ".join(f"{k.replace('default_', '').replace('_threshold', '')}"
                                         f"={config.get(k, 0.0)}" for k in DEFAULT_KEYS))
         print(f"Expected output: {config['results_dir']}/weak_images.parquet")
+        # The run writes four artifacts and not the spec, so a spec kept elsewhere
+        # leaves the finished results with no record of what selected them.
+        if spec.parent != out.resolve():
+            warnings.append(
+                f"the spec is outside results_dir ({spec.parent} vs {out}). The run does not "
+                "copy it, so the finished artifacts will carry no record of the thresholds "
+                f"that produced them. Author it at {out / spec.name} instead."
+            )
         for w in warnings:
             print(f"WARNING: {w}", file=sys.stderr)
         return 0

--- a/skills/data/tao-analyze-gaps-od-map/scripts/verify_object_detection_spec.py
+++ b/skills/data/tao-analyze-gaps-od-map/scripts/verify_object_detection_spec.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate a TAO Data Services object-detection gap-analysis spec.
+
+Fill `assets/default_object_detection.yaml` — it carries every default this stage
+needs — then run this against the result. The template is the only place a
+default value lives, so there is nothing that can disagree with it.
+
+Checks the spec against what `gap_analysis object_detection` actually requires:
+
+- `input_format` is `kitti` or `coco`, **lowercase**. `analytics kpi_analyze` in
+  the same container wants these uppercase; the two stages spell it differently
+  and both are correct for themselves.
+- the three input paths and `results_dir` are present and absolute. KITTI passes
+  a directory here, COCO a json file, so both are accepted.
+- `weak_thresholds` entries are mappings of metric to a number in [0, 1].
+- every gated class is reported, since an image is weak if **any** class falls
+  below its gate and one forgotten entry silently changes the selection.
+
+The `default_*_threshold` values get their own report line. TAO DS defaults
+`default_ap50_threshold` to 0.5, so a spec that lists some classes and says
+nothing else still gates every class it did not list — which inflates the weak
+set and the mining budget derived from it. A non-zero fallback is legal and
+occasionally wanted, so it warns rather than fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VALID_FORMATS = {"kitti", "coco"}
+PATH_KEYS = ("ground_truth_ann_path", "inference_ann_path", "images_dir")
+METRICS = ("ap50", "recall", "precision")
+DEFAULT_KEYS = ("default_ap50_threshold", "default_recall_threshold",
+                "default_precision_threshold")
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping.")
+    return data
+
+
+def validate_config(config: dict[str, Any]) -> list[str]:
+    """Raise on anything that would fail or silently mis-select. Returns warnings."""
+    warnings: list[str] = []
+
+    fmt = str(config.get("input_format") or "")
+    if fmt not in VALID_FORMATS:
+        raise ValueError(
+            f"input_format must be one of {sorted(VALID_FORMATS)} (lowercase); got {fmt!r}. "
+            "It is never inferred from the path."
+        )
+
+    for key in PATH_KEYS:
+        value = config.get(key)
+        if not value:
+            raise ValueError(f"{key} is required.")
+        path = Path(str(value)).expanduser()
+        if not path.is_absolute():
+            raise ValueError(f"{key} must be absolute: {path}")
+        if not path.exists():
+            raise FileNotFoundError(f"{key} does not exist: {path}")
+
+    results_dir = config.get("results_dir")
+    if not results_dir:
+        raise ValueError("results_dir is required.")
+    out = Path(str(results_dir)).expanduser()
+    if not out.is_absolute():
+        raise ValueError(f"results_dir must be absolute: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    if not config.get("kpi"):
+        raise ValueError("kpi is required — it labels the rows in the emitted parquets.")
+
+    iou = float(config.get("iou_threshold", 0.5))
+    if not 0.0 < iou <= 1.0:
+        raise ValueError(f"iou_threshold must be within (0, 1]; got {iou}")
+    conf = float(config.get("conf_threshold", 0.0))
+    if not 0.0 <= conf <= 1.0:
+        raise ValueError(f"conf_threshold must be within [0, 1]; got {conf}")
+
+    thresholds = config.get("weak_thresholds") or {}
+    if not isinstance(thresholds, dict):
+        raise ValueError("weak_thresholds must be a mapping of class name to metric gates.")
+    if not thresholds:
+        warnings.append(
+            "weak_thresholds is empty, so no class is gated explicitly and every class "
+            "falls back to the default_* values below."
+        )
+    for name, gates in thresholds.items():
+        if not isinstance(gates, dict):
+            raise ValueError(
+                f"weak_thresholds[{name!r}] must be a mapping such as {{ap50: 0.7}}; got {gates!r}"
+            )
+        for metric, value in gates.items():
+            if metric not in METRICS:
+                raise ValueError(
+                    f"weak_thresholds[{name!r}] has unknown metric {metric!r}; "
+                    f"expected one of {list(METRICS)}"
+                )
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"weak_thresholds[{name!r}][{metric!r}] must be a number.")
+            if not 0.0 <= float(value) <= 1.0:
+                raise ValueError(
+                    f"weak_thresholds[{name!r}][{metric!r}] must be within [0, 1]; got {value}"
+                )
+
+    gated = [d for d in DEFAULT_KEYS if float(config.get(d, 0.0)) > 0.0]
+    if gated:
+        warnings.append(
+            f"{', '.join(gated)} is above zero, so every class absent from weak_thresholds is "
+            "also gated. An image is weak if ANY class falls below its gate, so a class you "
+            "did not list can select images on its own — which inflates the weak set and any "
+            "mining budget derived from it. Set these to 0.0 unless that is intended."
+        )
+    return warnings
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--spec", required=True, help="Path to the gap-analysis YAML.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        spec = Path(parse_args().spec).expanduser().resolve()
+        config = load_yaml(spec)
+        warnings = validate_config(config)
+
+        thresholds = config.get("weak_thresholds") or {}
+        print(f"OK: gap-analysis spec is valid: {spec}")
+        print(f"format: {config['input_format']} | iou={config.get('iou_threshold', 0.5)} "
+              f"conf={config.get('conf_threshold', 0.0)} min_area={config.get('min_area', 0)}")
+        if thresholds:
+            gates = ", ".join(f"{n} {dict(g)}" for n, g in thresholds.items())
+            print(f"gated classes ({len(thresholds)}): {gates}")
+        print("fallbacks: " + ", ".join(f"{k.replace('default_', '').replace('_threshold', '')}"
+                                        f"={config.get(k, 0.0)}" for k in DEFAULT_KEYS))
+        print(f"Expected output: {config['results_dir']}/weak_images.parquet")
+        for w in warnings:
+            print(f"WARNING: {w}", file=sys.stderr)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/data/tao-analyze-gaps-od-map/skill-card.md
+++ b/skills/data/tao-analyze-gaps-od-map/skill-card.md
@@ -1,0 +1,59 @@
+## Description: <br>
+Runs TAO Data Services object-detection gap analysis by comparing ground-truth and inference annotations to identify weak images using per-class recall, precision, and AP50 thresholds. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+Apache 2.0 <br>
+
+## Use Case: <br>
+Developers and engineers identifying weak images in object detection workflows by analyzing FP/FN gaps and per-class mAP metrics from KITTI or COCO annotations. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Review before execution as proposals could introduce incorrect or misleading guidance into skills. <br>
+Mitigation: Review and scan skill before deployment. <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Shell commands, Files, Analysis] <br>
+**Output Format:** [Markdown with inline bash code blocks] <br>
+**Output Parameters:** [1D] <br>
+**Other Properties Related to Output:** [None] <br>
+
+## Evaluation Agents Used: <br>
+- Claude Code (`claude-code`) <br>
+- Codex (`codex`) <br>
+
+## Evaluation Tasks: <br>
+Evaluated against 1 evaluation task in the NVSkills-Eval external profile (astra-sandbox environment). <br>
+
+## Evaluation Metrics Used: <br>
+Reported benchmark dimensions: <br>
+- Security: Checks whether skill-assisted execution avoids unsafe behavior such as secret leakage, destructive commands, or unauthorized access. <br>
+- Correctness: Checks whether the agent follows the expected workflow and produces the correct final output. <br>
+- Discoverability: Checks whether the agent loads the skill when relevant and avoids using it when irrelevant. <br>
+- Effectiveness: Checks whether the agent performs measurably better with the skill than without it. <br>
+- Efficiency: Checks whether the agent uses fewer tokens and avoids redundant work. <br>
+
+Underlying evaluation signals used in this run: <br>
+- `security`: Checks for unsafe operations, secret leakage, and unauthorized access. <br>
+- `skill_execution`: Verifies that the agent loaded the expected skill and workflow. <br>
+- `skill_efficiency`: Checks routing quality, decoy avoidance, and redundant tool usage. <br>
+- `accuracy`: Grades final-answer correctness against the reference answer. <br>
+- `goal_accuracy`: Checks whether the overall user task completed successfully. <br>
+- `behavior_check`: Verifies expected behavior steps, including safety expectations. <br>
+- `token_efficiency`: Compares token usage with and without the skill. <br>
+
+## Skill Version(s): <br>
+0.1.0 (source: frontmatter) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). <br>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Wraps `gap_analysis object_detection` to score per-image, per-class AP50 against a ground truth and emit the weak-image set that drives mining. It is the stage that decides which images a DEFT object-detection loop tries to improve on.

**Features**
- Ships the reference ITS weak thresholds as defaults, so a run that says nothing gets the gates the reference pipeline used.
- Ships a spec template that holds every default, and `verify_object_detection_spec.py` to check a filled one before a container starts.
- Reports the gated classes and the `default_*` fallbacks, so the criteria behind a weak set are recoverable from the run's own output.

**Constraints**
- **`default_ap50_threshold` must be `0.0` unless you mean otherwise.** TAO DS defaults it to `0.5`, so a spec listing some classes in `weak_thresholds` and saying nothing else still gates every class it did not list — inflating the weak set and the mining budget derived from it. An image is weak if **any** class fails, so one ungated class can select images on its own.
- `input_format` is **lowercase** here (`kitti`/`coco`), unlike `analytics kpi_analyze` in the same container which requires uppercase. Both spellings are correct for their own stage.
- KITTI passes a directory for the annotation paths, COCO a json file.

**Design**
- The template is the only place a default lives, and the verifier runs against the artifact that will actually execute — the same shape as `tao-analyze-detection-kpi`.
- The spec is authored inside `results_dir`. The run writes four artifacts and does not retain the spec, so a finished run would otherwise tell you which images were selected but not why.

### Why are the changes needed?

Weak-image selection is the input to mining, and mining is what a DEFT loop spends its GPU hours on. A wrong threshold does not fail — it selects a different set of images and everything downstream proceeds normally, so the error only shows up as a loop that does not improve.

### Related issues

Part of the DEFT object-detection skill set: #114, #96, #97 and #99. All of them and this MR add the same `images.tao_toolkit.data_services_od` key to `versions.yaml`; whichever merges second onward drops its duplicate.

### Does this PR introduce _any_ user-facing change?

Introduces a new skill. Adds one key to `versions.yaml`.

### How was this patch tested?

**Goal:** confirm the weak-image set is exactly what the thresholds imply, on a fixture small enough that the answer is derivable on paper, and confirm the documentation stands alone for an agent that has never seen the skill.

**Setup:**

* _Fixture_: 4 images at 200x200, KITTI ground truth and KITTI inference labels, every box placed so each IoU is exactly 1.0 or exactly 0
* _Parameters_: `iou_threshold 0.5`, `conf_threshold 0.0`, gates `car 0.99 / bicycle 0.7`, all three `default_*` at 0.0
* _Image_: `nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02`
* _Agent + Prompt_: for the skill test, an agent was given this and nothing else — no commands, no container name, no spec format:

  ```
  I have object-detection ground-truth labels and a model's inference labels,
  and I want to find which images the model is weak on.

  ground truth labels:  <fixture>/gt
  inference labels:     <fixture>/pred
  images:               <fixture>/images
  classes I care about: car (needs AP50 at least 0.99), bicycle (needs AP50 at least 0.7)
  write results to:     <out>

  Find the appropriate skill, read it, and work out the invocation yourself.
  ```

## Test 1: gated classes only

```
Settings:
iou_threshold: 0.5
conf_threshold: 0.0
weak_thresholds:
  car:     {ap50: 0.99}
  bicycle: {ap50: 0.7}
default_ap50_threshold: 0.0
default_recall_threshold: 0.0
default_precision_threshold: 0.0
```

The answer should be

```
img2_car_miss.jpg
```

Why:
- `img1_car_hit` has car AP50 1.0, at or above its 0.99 gate, so it passes.
- `img2_car_miss` has car AP50 0.0, below 0.99, so it is weak.
- `img3_bike_hit` has bicycle AP50 1.0, at or above its 0.7 gate, so it passes.
- `img4_sign_only` passes on car. `road_sign` is not listed in `weak_thresholds`, so it falls back to `default_ap50_threshold`. The comparison is strict `<`, and no value is below 0.0, so an unlisted class cannot make an image weak — which is what setting the default to 0.0 is for.

## Test 2: the fallback threshold gates unlisted classes

```
Settings: as Test 1, but default_ap50_threshold: 0.5
```

The answer should be

```
img2_car_miss.jpg
img4_sign_only.jpg
```

Why:
- `img2_car_miss` is unchanged — still weak on car.
- `img4_sign_only` now also fails: `road_sign` is still unlisted, but the fallback is 0.5, and its AP50 of 0.0 is below that.
- `img1_car_hit` and `img3_bike_hit` contain no `road_sign` ground truth, so no `road_sign` metric exists for them and neither is affected.

This is the one setting that silently changes which images are selected. TAO DS defaults `default_ap50_threshold` to 0.5, so a spec that lists some classes in `weak_thresholds` and says nothing else still gates every class it did not list — inflating the weak set and the mining budget derived from it. An image is weak if it fails on **any** class, so one ungated class is enough to select it.

## Skill test (agent-driven)

Separately from the fixture tests above, an agent was given only a goal and the input paths —
no commands, no image name, no spec format — and asked to find and use this skill unaided.

It selected the right skill from the frontmatter description without ambiguity, built a correct
spec from `assets/default_object_detection.yaml`, and produced the expected result: **1 weak
image, `img2_car_miss`**, with `img4_sign_only` correctly *not* gated on its 100%-missed
`road_sign` class. That last case independently confirms the `default_ap50_threshold: 0.0`
behaviour is load-bearing rather than incidental.

It could not run the skill as documented. Following SKILL.md's instruction to resolve the
container from `versions.yaml`, it pulled ~30 GB and then failed on
`invalid choice: 'object_detection'`. It recovered only by brute-force enumerating subtasks
across every local image. The fixes in this MR come from that run:

- SKILL.md now states where the image is chosen that no published image carries the action, and
  gives the one-line probe to confirm before pulling.
- `skill_info.yaml` typed the annotation paths as `file`; KITTI takes a directory, which is what
  the run actually used.
### Was this patch authored or co-authored using generative AI tooling?

Co-authored-by: Claude Opus 5

