### PR TITLE
Add GitHub Actions CI (static + platform nightly)

### DIFF
--- a/.github/workflows/platform-nightly.yml
+++ b/.github/workflows/platform-nightly.yml
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Nightly platform execution CI.
+#
+# The static workflow proves the platform skills SAY the right thing. Only
+# execution proves a real CLI ACCEPTS it: `brev exec <inst> -- <cmd> <args>` was
+# textually plausible and rejected by the actual CLI, which silently broke three
+# of Brev's four verbs. Two tiers:
+#
+#   contract — real tools, no cluster/credentials/GPU. Renders every vendored
+#              template and validates it (kubeconform offline; `kubectl
+#              --dry-run=client` is NOT a substitute, it contacts the API server
+#              to resolve API groups). Also asserts documented brev/kubectl
+#              invocations against the installed CLI's own signature.
+#
+#   smoke-cpu — live submit/status/logs/cancel on a CPU runner. This covers the
+#              verb LIFECYCLE (record open/mark, container create/inspect/logs/
+#              rm, manifest admission) and CLI syntax acceptance — the class the
+#              brev-exec regression belonged to. It explicitly does NOT cover
+#              anything GPU: `--gpus all` resolution, nvidia-container-toolkit,
+#              `nvidia.com/gpu` scheduling, or real TAO-image behaviour.
+#
+# GPU and SLURM tiers do NOT live here — see the note above the job list at the
+# bottom of this file. Both need resources GitHub-hosted runners cannot reach
+# (GPU hardware; an internal-only cluster login node), and this repo is public,
+# so they run on internal Jenkins via the blossom bridge instead.
+#
+# The CPU tier is a floor, not a substitute. Note the k8s templates hardcode
+# `nvidia.com/gpu`, so a pod rendered from them stays Pending forever on a
+# GPU-less cluster: the kind job below validates ADMISSION (the API server
+# accepts the manifest), not scheduling. Testing scheduling without hardware
+# needs a fake device plugin advertising nvidia.com/gpu capacity; testing
+# execution needs real GPUs.
+name: Platform Nightly
+
+on:
+  schedule:
+    - cron: '0 9 * * *'      # 09:00 UTC ≈ 02:00 PT
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'Smoke targets (comma-separated: docker,kubernetes,slurm)'
+        default: 'docker,kubernetes'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Template + CLI contract (no cluster)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install --quiet pyyaml pytest jsonschema
+      - name: Install kubeconform (offline manifest schema validation)
+        run: |
+          curl -fsSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+      # Re-run the static suite so a nightly failure is never stale-config noise.
+      - run: python3 -m pytest scripts/tests templates/tests -q
+      - name: Render templates and validate with real tools
+        run: python3 scripts/ci/render_and_validate_templates.py
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: platform-nightly-contract
+          path: platform-nightly-report.md
+
+  smoke-docker-cpu:
+    name: "Four-verb smoke — docker (CPU: lifecycle only, no GPU coverage)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: submit / status / logs / cancel
+        run: bash scripts/ci/platform_smoke.sh docker
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: platform-nightly-smoke-docker
+          path: platform-nightly-report.md
+
+  smoke-kubernetes:
+    name: "Four-verb smoke — kubernetes (kind: admission only, not scheduling)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # A real API server, so `kubectl apply` genuinely admits the manifest —
+      # stronger than the offline schema check in `contract`, but still only
+      # ADMISSION: with no GPU capacity advertised, a pod requesting
+      # nvidia.com/gpu never leaves Pending, so scheduling stays unverified.
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: tao-platform-nightly
+      - name: submit / status / logs / cancel
+        run: bash scripts/ci/platform_smoke.sh kubernetes
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: platform-nightly-smoke-k8s
+          path: platform-nightly-report.md
+
+  # ─── GPU tier: NOT a GitHub Actions job ───────────────────────────────────
+  #
+  # This repo has no GPU runners on Actions, and adding self-hosted ones would
+  # be unsafe: tao-skill-bank is public, so a `pull_request`-triggered job on
+  # self-hosted hardware lets any fork PR execute arbitrary code on it.
+  #
+  # The established path is blossom (.github/workflows/blossom-ci.yml), which is
+  # a BRIDGE, not an executor: an authorized maintainer comments `/build`, and
+  # after a vulnerability scan the `Job-trigger` job runs
+  # `OPERATION: START-CI-JOB` against `secrets.CI_SERVER`, handing the work to
+  # internal Jenkins and posting the Jenkins log back to the PR. `runs-on:
+  # blossom` resolves to the runner `ci-server` — the bridge box, not a GPU
+  # host.
+  #
+  # So the GPU tier is a JENKINS job defined on the internal CI server, whose
+  # payload is this repo's own smoke script:
+  #
+  #     PLATFORM_SMOKE_GPU=1 bash scripts/ci/platform_smoke.sh docker
+  #
+  # That mode pulls the real TAO image (resolved from versions.yaml at runtime),
+  # runs `--gpus all` with a non-root --user, and is the only tier that can
+  # reproduce GPU-runtime and image-level faults — notably the
+  # `getpwuid(): uid not found` crash torch hits when the --user UID is absent
+  # from /etc/passwd. Keeping the payload in-repo means Jenkins stays a thin
+  # trigger and the test logic is reviewed like any other change.

--- a/.github/workflows/skill-bank-static.yml
+++ b/.github/workflows/skill-bank-static.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# GitHub Actions port of the GitLab `validate-skills` job.
+#
+# The GitLab pipeline (.gitlab-ci.yml) does not run on GitHub, so this must
+# exist for the same guards to survive the cutover: marketplace/frontmatter
+# validation, version-pin drift, command hygiene, the platform four-verb
+# contract, and the rendered job templates.
+name: Skill Bank Static
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  static:
+    name: Validate skills, pins, and platform contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test dependencies
+        run: pip install --quiet pyyaml pytest jsonschema
+
+      # Marketplace paths, frontmatter, runnable-body heuristic, SDK leaks.
+      - name: validate-skills
+        run: bash scripts/validate-skills.sh
+
+      # Every image/wheel pin must match versions.yaml AND carry a
+      # '# versions-key:' or '# unpinned:' annotation. Unannotated pins are how
+      # a two-major-versions-stale image shipped in a 7.1.0 release.
+      - name: Version pin drift
+        run: python3 scripts/stamp_versions.py --check --strict-strays
+
+      # scripts/tests: schema drift, command hygiene, platform contract.
+      # templates/tests: renders the SLURM/k8s job templates and asserts the
+      # rendezvous contract. Both are required — templates/tests was absent from
+      # CI for a while, which is exactly how k8s multi-node doc/template drift
+      # shipped unnoticed.
+      - name: Test suites
+        run: python3 -m pytest scripts/tests templates/tests -q
+
+      - name: NemoClaw integration (stdlib only)
+        run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s integrations/nemoclaw/tests -v

--- a/scripts/ci/platform_smoke.sh
+++ b/scripts/ci/platform_smoke.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live four-verb smoke for the SDK-free platform skills.
+#
+# The static suite proves the skills SAY the right thing. This proves a real
+# backend ACCEPTS it: submit -> status -> logs -> cancel, end to end, with the
+# job record updated at each step. It is the layer that would have caught the
+# `brev exec` regression, where every documented verb parsed fine as text and
+# was rejected by the actual CLI.
+#
+# Deliberately does not need a GPU: the verb contract is about job lifecycle,
+# not compute. A 5 MB busybox exercises it, so this can run on any runner and
+# stay cheap enough for a nightly.
+#
+# Usage: platform_smoke.sh [targets]      # comma-separated: docker,kubernetes,slurm
+#        PLATFORM_SMOKE_TARGETS=docker scripts/ci/platform_smoke.sh
+set -uo pipefail
+
+TARGETS="${1:-docker}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RECORD="$REPO/scripts/tao_job_record.py"
+REPORT="${PLATFORM_SMOKE_REPORT:-$REPO/platform-nightly-report.md}"
+SMOKE_IMAGE="${PLATFORM_SMOKE_IMAGE:-busybox:1.36}"
+rc=0
+
+note() { printf '%s\n' "$*" | tee -a "$REPORT"; }
+fail() { note "- **FAIL** $1 — $2"; rc=1; }
+pass() { note "- **PASS** $1 — $2"; }
+
+note "# Platform nightly — live four-verb smoke"
+note ""
+
+smoke_docker() {
+  local p=docker jid cid state logs
+  command -v docker >/dev/null 2>&1 || { note "- **SKIP** $p — docker not installed"; return 0; }
+  docker info >/dev/null 2>&1 || { note "- **SKIP** $p — docker daemon unreachable"; return 0; }
+
+  # submit: open the record FIRST so the id names the backend object, exactly
+  # as the skill documents (an id minted after launch cannot be recovered).
+  jid="$("$RECORD" open --platform docker --image "$SMOKE_IMAGE" \
+          --network-arch smoke --action train --storage-tier A \
+          --results-dir "${TMPDIR:-/tmp}/tao-smoke-$$" 2>/dev/null)" \
+    || { fail "$p/submit" "tao_job_record.py open failed"; return 1; }
+  cid="$(docker run -d --name "$jid" --label "tao-job=$jid" \
+          "$SMOKE_IMAGE" sh -c 'echo tao-smoke-alive; sleep 30' 2>&1)" \
+    || { fail "$p/submit" "docker run rejected: ${cid:0:200}"; return 1; }
+  "$RECORD" mark "$jid" --state RUNNING --backend-ref "$cid" >/dev/null 2>&1 \
+    || fail "$p/submit" "record mark RUNNING failed"
+  pass "$p/submit" "container $jid started"
+
+  # status
+  state="$(docker inspect --format '{{.State.Status}}' "$jid" 2>/dev/null)"
+  [ -n "$state" ] && pass "$p/status" "state=$state" \
+                  || fail "$p/status" "docker inspect returned nothing"
+
+  # logs — the container prints a known token; anything else means the log path
+  # is wired to the wrong stream.
+  logs="$(docker logs --tail 20 "$jid" 2>&1)"
+  case "$logs" in
+    *tao-smoke-alive*) pass "$p/logs" "log token observed" ;;
+    *) fail "$p/logs" "expected token absent: ${logs:0:200}" ;;
+  esac
+
+  # cancel + teardown, then confirm the container is really gone.
+  docker rm -f "$jid" >/dev/null 2>&1 \
+    || fail "$p/cancel" "docker rm -f failed"
+  "$RECORD" mark "$jid" --state CANCELED --source agent >/dev/null 2>&1 \
+    || fail "$p/cancel" "record mark CANCELED failed"
+  if docker inspect "$jid" >/dev/null 2>&1; then
+    fail "$p/cancel" "container still present after rm -f"
+  else
+    pass "$p/cancel" "container removed and record closed"
+  fi
+}
+
+smoke_kubernetes() {
+  command -v kubectl >/dev/null 2>&1 || { note "- **SKIP** kubernetes — kubectl not installed"; return 0; }
+  kubectl cluster-info >/dev/null 2>&1 || { note "- **SKIP** kubernetes — no reachable cluster (start kind)"; return 0; }
+  note "- **TODO** kubernetes — four-verb smoke not implemented yet (needs a kind cluster in CI)"
+}
+
+smoke_slurm() {
+  [ -n "${SLURM_LOGIN_HOST:-}" ] || { note "- **SKIP** slurm — SLURM_LOGIN_HOST unset"; return 0; }
+  ssh -o BatchMode=yes -o ConnectTimeout=10 "$SLURM_LOGIN_HOST" true >/dev/null 2>&1 \
+    || { note "- **SKIP** slurm — login host unreachable"; return 0; }
+  note "- **TODO** slurm — four-verb smoke not implemented yet (submit to a short CPU partition)"
+}
+
+IFS=',' read -ra want <<<"$TARGETS"
+for t in "${want[@]}"; do
+  case "$t" in
+    docker)     smoke_docker ;;
+    kubernetes) smoke_kubernetes ;;
+    slurm)      smoke_slurm ;;
+    brev)       note "- **SKIP** brev — provisioning costs money; run manually" ;;
+    *)          note "- **SKIP** $t — unknown target" ;;
+  esac
+done
+
+note ""
+note "Exit status: $rc"
+exit "$rc"

--- a/scripts/ci/platform_smoke.sh
+++ b/scripts/ci/platform_smoke.sh
@@ -22,7 +22,16 @@ TARGETS="${1:-docker}"
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RECORD="$REPO/scripts/tao_job_record.py"
 REPORT="${PLATFORM_SMOKE_REPORT:-$REPO/platform-nightly-report.md}"
-SMOKE_IMAGE="${PLATFORM_SMOKE_IMAGE:-busybox:1.36}"
+SMOKE_GPU="${PLATFORM_SMOKE_GPU:-0}"
+if [ "$SMOKE_GPU" = 1 ]; then
+  # Resolved from versions.yaml at runtime rather than pinned here: scripts/ is
+  # outside stamp_versions.py's scan roots (skills/, templates/), so a literal
+  # written here would be unmanaged and would silently go stale on the next
+  # release bump — the exact drift this repo's stamper exists to prevent.
+  SMOKE_IMAGE="${PLATFORM_SMOKE_IMAGE:-$(python3 "$REPO/scripts/resolve_versions_key.py" images.tao_toolkit.pyt)}"
+else
+  SMOKE_IMAGE="${PLATFORM_SMOKE_IMAGE:-busybox:1.36}"
+fi
 rc=0
 
 note() { printf '%s\n' "$*" | tee -a "$REPORT"; }
@@ -43,12 +52,22 @@ smoke_docker() {
           --network-arch smoke --action train --storage-tier A \
           --results-dir "${TMPDIR:-/tmp}/tao-smoke-$$" 2>/dev/null)" \
     || { fail "$p/submit" "tao_job_record.py open failed"; return 1; }
-  cid="$(docker run -d --name "$jid" --label "tao-job=$jid" \
+  local -a gpu_args=()
+  if [ "$SMOKE_GPU" = 1 ]; then
+    # Mirror the canonical launch: real GPUs plus a non-root identity, with the
+    # USER/LOGNAME exports that keep torch's import-time getpass.getuser() from
+    # crashing on a UID with no /etc/passwd entry.
+    gpu_args=(--gpus all
+              --user "$(id -u):$(id -g)"
+              -e "USER=$(id -un)" -e "LOGNAME=$(id -un)"
+              -e HOME=/tmp -e NGC_KEY)
+  fi
+  cid="$(docker run -d --name "$jid" --label "tao-job=$jid" "${gpu_args[@]+"${gpu_args[@]}"}" \
           "$SMOKE_IMAGE" sh -c 'echo tao-smoke-alive; sleep 30' 2>&1)" \
     || { fail "$p/submit" "docker run rejected: ${cid:0:200}"; return 1; }
   "$RECORD" mark "$jid" --state RUNNING --backend-ref "$cid" >/dev/null 2>&1 \
     || fail "$p/submit" "record mark RUNNING failed"
-  pass "$p/submit" "container $jid started"
+  pass "$p/submit" "container $jid started (image=$SMOKE_IMAGE gpu=$SMOKE_GPU)"
 
   # status
   state="$(docker inspect --format '{{.State.Status}}' "$jid" 2>/dev/null)"

--- a/scripts/ci/render_and_validate_templates.py
+++ b/scripts/ci/render_and_validate_templates.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render the vendored job templates and validate them with the REAL tools.
+
+The per-MR suite validates templates by parsing them in Python. That catches
+structural drift but not "the tool rejects this": a manifest can be valid YAML
+with a valid-looking shape and still be refused by the API server's schema, and
+an sbatch script can parse as bash and still carry a bad directive.
+
+This runs in the nightly platform pipeline, where the genuine CLIs are present:
+
+  * k8s templates  -> `kubectl apply --dry-run=client` (schema-checked locally;
+    no cluster is contacted, no credentials needed)
+  * SLURM templates -> `bash -n`, plus `sbatch --test-only` when sbatch exists
+
+Every tool is optional: if it is not installed the corresponding check is
+reported as SKIPPED rather than failing, so the job stays useful on a runner
+that only has some of them. Exit status is non-zero only on a real rejection.
+
+Usage:
+    scripts/ci/render_and_validate_templates.py [--kubectl PATH] [--report FILE]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Real markers are @@UPPER_SNAKE@@. The templates' own header comments describe
+# the syntax as "@@<NAME>@@", which must not count as an unsubstituted marker.
+MARKER_RE = re.compile(r"@@[A-Z][A-Z0-9_]*@@")
+
+# Same fixture shape the unit tests use: nodes != gpus-per-node so a template
+# that confuses WORLD_SIZE with the GPU count cannot render plausibly.
+COMMON = {
+    "JOB_NAME": "nightly-contract-0001",
+    "NUM_NODES": "2",
+    "GPUS_PER_NODE": "8",
+    "NUM_GPUS": "8",          # single-node templates spell it this way
+    "IMAGE": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt",  # versions-key: images.tao_toolkit.pyt
+    "COMMAND": "dino train -e /data/specs/spec.yaml",
+}
+K8S_VALS = {
+    **COMMON,
+    "TTL_SECONDS": "3600",
+    "IMAGE_PULL_SECRET": "ngc-pull-secret",
+    "CRED_SECRET": "tao-creds-nightly",
+    "RESULTS_DIR": "/data/results/nightly",
+    "MOUNT_PATH": "/data",
+    "SHM_SIZE": "16Gi",
+    "PVC_CLAIM": "edgeai-datasets",
+}
+SLURM_VALS = {
+    **COMMON,
+    "CPUS_PER_TASK": "16",
+    "TIME": "04:00:00",
+    "LOG_DIR": "/lustre/fsw/users/me/results/nightly/slurm-logs",
+    "SBATCH_EXTRA": "#SBATCH --account=edgeai\n#SBATCH --partition=batch",
+    "ENV_FILE": "",
+    "EXTRA_ENV": "export NCCL_P2P_DISABLE=1",
+    "CONTAINER_MOUNTS": "/lustre",
+}
+
+
+def render(tmpl: Path, vals: dict[str, str]) -> str:
+    text = tmpl.read_text(encoding="utf-8")
+    for key, value in vals.items():
+        text = text.replace(f"@@{key}@@", value)
+    return text
+
+
+def _run(cmd: list[str], stdin: str | None = None) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd, input=stdin, capture_output=True, text=True, timeout=120
+    )
+    return proc.returncode, (proc.stderr or proc.stdout).strip()
+
+
+NO_CLUSTER_MARKERS = (
+    "failed to download openapi",
+    "connection refused",
+    "server API group list",
+    "unable to recognize",
+    "no configuration has been provided",
+)
+
+
+def _validate_k8s(rendered: str, name: str, args) -> tuple[str, str, str]:
+    """Validate a rendered manifest, preferring the offline schema validator.
+
+    `kubectl --dry-run=client` still contacts the API server to resolve API
+    groups and fetch the openapi schema, so it is useless on a runner with no
+    cluster. kubeconform validates against bundled JSON schemas entirely
+    offline, which is what a nightly job without a cluster actually wants.
+    """
+    if args.kubeconform:
+        code, err = _run([args.kubeconform, "-strict", "-summary", "-"], stdin=rendered)
+        return ("PASS", name, "kubeconform accepted") if code == 0 else ("FAIL", name, err[:400])
+    if args.kubectl:
+        code, err = _run([args.kubectl, "apply", "--dry-run=client", "-f", "-"], stdin=rendered)
+        if code == 0:
+            return ("PASS", name, "kubectl accepted")
+        if any(m in err for m in NO_CLUSTER_MARKERS):
+            return ("SKIP", name,
+                    "no cluster reachable; install kubeconform for offline schema validation")
+        return ("FAIL", name, err[:400])
+    return ("SKIP", name, "neither kubeconform nor kubectl installed")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--kubectl", default=shutil.which("kubectl"))
+    ap.add_argument("--kubeconform", default=shutil.which("kubeconform"))
+    ap.add_argument("--sbatch", default=shutil.which("sbatch"))
+    ap.add_argument("--report", default="platform-nightly-report.md")
+    args = ap.parse_args()
+
+    results: list[tuple[str, str, str]] = []  # (status, target, detail)
+
+    for tmpl in sorted((REPO / "templates/k8s").glob("*.tmpl")):
+        rendered = render(tmpl, K8S_VALS)
+        name = f"k8s/{tmpl.name}"
+        if leftovers := MARKER_RE.findall(rendered):
+            results.append(("FAIL", name, f"unsubstituted markers: {sorted(set(leftovers))[:3]}"))
+            continue
+        results.append(_validate_k8s(rendered, name, args))
+
+    for tmpl in sorted((REPO / "templates/slurm").glob("*.tmpl")):
+        rendered = render(tmpl, SLURM_VALS)
+        name = f"slurm/{tmpl.name}"
+        if leftovers := MARKER_RE.findall(rendered):
+            results.append(("FAIL", name, f"unsubstituted markers: {sorted(set(leftovers))[:3]}"))
+            continue
+        code, err = _run(["bash", "-n"], stdin=rendered)
+        if code != 0:
+            results.append(("FAIL", name, f"bash -n: {err[:400]}"))
+            continue
+        if not args.sbatch:
+            results.append(("PASS", name, "bash -n clean (sbatch absent — directives unchecked)"))
+            continue
+        with tempfile.NamedTemporaryFile("w", suffix=".sbatch", delete=False) as fh:
+            fh.write(rendered)
+            path = fh.name
+        code, err = _run([args.sbatch, "--test-only", path])
+        # --test-only still needs a reachable controller; treat scheduling
+        # complaints as SKIP and only fail on a rejected directive.
+        if code == 0:
+            results.append(("PASS", name, "sbatch --test-only accepted"))
+        elif "Invalid" in err or "invalid" in err or "unrecognized" in err:
+            results.append(("FAIL", name, err[:400]))
+        else:
+            results.append(("SKIP", name, f"sbatch unavailable/unschedulable: {err[:200]}"))
+
+    lines = ["# Platform nightly — template contract", ""]
+    lines += [f"- **{status}** `{target}` — {detail}" for status, target, detail in results]
+    failed = [r for r in results if r[0] == "FAIL"]
+    lines += ["", f"{len(results)} checked, {len(failed)} failed."]
+    Path(args.report).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    for status, target, detail in results:
+        print(f"{status}: {target} — {detail}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_platform_contract.py
+++ b/scripts/tests/test_platform_contract.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-platform contract tests for the SDK-free platform skills.
+
+Every regression these guard against shipped in the 7.1.0 -> main merge and was
+invisible to CI, because nothing cross-checked a skill's prose against the
+scripts, templates, and metadata it describes:
+
+  * a preflight referencing a path that does not exist (the k8s SETUP_SCRIPT
+    dropped its ``skills/`` segment, so preflight always failed "file not found")
+  * a platform silently losing job-record integration, so its jobs became
+    untrackable while every sibling platform stayed consistent (Brev)
+  * frontmatter advertising narrower capability than the body implements, so a
+    router never selects the platform for the case it actually supports (k8s
+    said "single-pod" while documenting Indexed-Job multi-node)
+
+These are static: no GPU, no cluster, no credentials. They run on every MR.
+Live execution smokes belong in the nightly platform pipeline instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PLATFORM_DIR = REPO / "skills/platform"
+
+# Platforms that implement the four-verb execution contract. tao-data-io (S3
+# layer) and tao-setup-nvidia-gpu-host (host preflight) launch nothing by design.
+RUN_PLATFORMS = [
+    "tao-run-on-docker",
+    "tao-run-on-kubernetes",
+    "tao-run-on-slurm",
+    "tao-run-on-brev",
+    "tao-run-on-virtualenv",
+]
+
+VERB_PATTERNS = {
+    "submit": re.compile(r"\bsubmit\b", re.I),
+    "status": re.compile(r"\bstatus\b", re.I),
+    "logs": re.compile(r"\blogs\b", re.I),
+    "cancel": re.compile(r"\bcancel\b|\bteardown\b", re.I),
+}
+
+
+def _skill_text(name: str) -> str:
+    return (PLATFORM_DIR / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("platform", RUN_PLATFORMS)
+@pytest.mark.parametrize("verb", sorted(VERB_PATTERNS))
+def test_platform_documents_every_verb(platform, verb):
+    """Each run platform must document all four verbs of the execution contract."""
+    assert VERB_PATTERNS[verb].search(_skill_text(platform)), (
+        f"{platform}/SKILL.md never mentions the '{verb}' verb; the four-verb "
+        f"contract requires submit/status/logs/cancel on every run platform")
+
+
+@pytest.mark.parametrize("platform", RUN_PLATFORMS)
+def test_platform_wires_the_job_record(platform):
+    """Every run platform must mint and update a job record, not just describe one.
+
+    Brev regressed to prose ("open the record") with no command, which makes its
+    jobs untrackable across invocations — the capability the SDK's Job handles
+    used to provide.
+    """
+    text = _skill_text(platform)
+    assert "tao_job_record.py" in text, (
+        f"{platform}/SKILL.md never invokes scripts/tao_job_record.py — jobs "
+        f"launched by this platform cannot be tracked across invocations")
+    assert re.search(r"tao_job_record\.py[\"']?\s+open", text), (
+        f"{platform}/SKILL.md never calls `tao_job_record.py open` to mint a job id")
+    assert re.search(r"tao_job_record\.py[\"']?\s+mark", text), (
+        f"{platform}/SKILL.md never calls `tao_job_record.py mark` to update state")
+
+
+# Shell-assigned paths that point into the bank, e.g.
+#   SETUP_SCRIPT="${TAO_SKILL_BANK_ROOT}/skills/platform/.../setup.sh"
+BANK_PATH_RE = re.compile(
+    r"\$\{(?:TAO_SKILL_BANK_PATH|TAO_SKILL_BANK_ROOT|SB|BANK)(?::-[^}]*)?\}"
+    r"(/[A-Za-z0-9_./-]+\.(?:sh|py|tmpl|yaml|json|md))"
+)
+
+
+@pytest.mark.parametrize(
+    "skill_md",
+    sorted(p for p in PLATFORM_DIR.rglob("*.md") if "__pycache__" not in p.parts),
+    ids=lambda p: str(p.relative_to(PLATFORM_DIR)),
+)
+def test_bank_relative_paths_resolve(skill_md):
+    """A `$BANK/...`-anchored path in a platform skill must exist in the repo.
+
+    Catches the dropped-path-segment class directly: the k8s preflight pointed at
+    `${TAO_SKILL_BANK_ROOT}/platform/...` (missing `skills/`) and could never run.
+    """
+    missing = []
+    for rel in BANK_PATH_RE.findall(skill_md.read_text(encoding="utf-8")):
+        target = REPO / rel.lstrip("/")
+        if not target.exists():
+            missing.append(rel)
+    assert not missing, (
+        f"{skill_md.relative_to(REPO)} references bank paths that do not exist: "
+        f"{sorted(set(missing))}")
+
+
+@pytest.mark.parametrize("platform", RUN_PLATFORMS)
+def test_multinode_capability_matches_frontmatter(platform):
+    """If a skill documents multi-node support, its description must not deny it.
+
+    Routers select platforms from the frontmatter description; k8s shipped
+    advertising "single-pod" while implementing Indexed-Job multi-node, so it was
+    never selected for the case it supports.
+    """
+    text = _skill_text(platform)
+    body = text.split("---", 2)[-1]
+    frontmatter = text.split("---", 2)[1] if text.startswith("---") else ""
+    desc = " ".join(
+        line.strip() for line in frontmatter.splitlines()
+        if not re.match(r"^\s*(name|license|metadata|tags|allowed-tools|compatibility|version):", line)
+    ).lower()
+
+    claims_multinode = bool(
+        re.search(r"multi-node is (?:not )?supported|indexed job|num_nodes\s*[=:]\s*[2-9]", body, re.I)
+        and not re.search(r"\*\*multi-node is not supported\*\*", body, re.I)
+    )
+    # A description is a denial only if it scopes itself to one node AND never
+    # mentions multi-node. "single-pod for one node, Indexed Jobs for multi-node"
+    # advertises both and is correct.
+    denies_in_desc = bool(
+        re.search(r"single-pod|single-node only", desc)
+        and not re.search(r"multi[- ]node", desc)
+    )
+    assert not (claims_multinode and denies_in_desc), (
+        f"{platform}: the body documents multi-node support but the frontmatter "
+        f"description says single-pod/single-node — routers read the description, "
+        f"so this platform will never be selected for multi-node work")
+
+
+# Required flags of `tao_job_record.py open`, per its argparse definition. A
+# documented invocation missing any of these fails at runtime with exit 2 —
+# which is exactly how this test was born: a hand-written Brev example omitted
+# --network-arch/--action/--storage-tier and looked entirely plausible.
+JOB_RECORD_OPEN_REQUIRED = ("--platform", "--image", "--network-arch",
+                            "--action", "--storage-tier")
+
+# `\\\n` must precede `[^\n]` in the alternation: otherwise `[^\n]` consumes the
+# backslash and the continuation branch can never match, truncating the capture
+# at the first line of a multi-line invocation.
+OPEN_INVOCATION_RE = re.compile(
+    r"tao_job_record\.py[\"']?\s+open\b((?:\\\n|[^\n])*)", re.M)
+
+
+@pytest.mark.parametrize("platform", RUN_PLATFORMS)
+def test_documented_job_record_open_has_required_flags(platform):
+    """Every documented `tao_job_record.py open` must carry all required flags.
+
+    Guards docs against the script's real argparse signature, so a plausible but
+    incomplete example cannot ship.
+    """
+    text = _skill_text(platform)
+    invocations = OPEN_INVOCATION_RE.findall(text)
+    assert invocations, f"{platform}/SKILL.md documents no `tao_job_record.py open` call"
+    for args in invocations:
+        flat = args.replace("\\\n", " ")
+        missing = [f for f in JOB_RECORD_OPEN_REQUIRED if f not in flat]
+        assert not missing, (
+            f"{platform}/SKILL.md: `tao_job_record.py open` example is missing "
+            f"required flag(s) {missing} — it would exit 2 at runtime")
+
+
+def test_job_record_required_flags_match_the_script():
+    """Keep the list above honest against tao_job_record.py itself."""
+    src = (REPO / "scripts/tao_job_record.py").read_text(encoding="utf-8")
+    open_block = src[src.index('"open"'):]
+    for flag in JOB_RECORD_OPEN_REQUIRED:
+        assert f'"{flag}"' in open_block, (
+            f"{flag} is listed as required here but no longer appears in "
+            f"tao_job_record.py's `open` parser — update JOB_RECORD_OPEN_REQUIRED")

--- a/scripts/tests/test_skill_command_hygiene.py
+++ b/scripts/tests/test_skill_command_hygiene.py
@@ -19,10 +19,18 @@ Guards two defect classes found in the 7.1.0 platform-skill audit:
    commands fail with ``could not look up instance "<word>"``. Remote commands
    must be a single quoted string: ``brev exec <instance> "<command>"``.
 
-A line that must legitimately show a banned pattern (documenting the
-anti-pattern in an error-pattern section) opts out with an inline marker:
-``lint-ok: secret-on-argv`` or ``lint-ok: brev-exec-form`` (HTML comments in
-markdown keep it invisible when rendered).
+Scope: in markdown, only lines inside shell fences (```bash / ```sh / …) are
+enforced — those are the commands a user copies. Prose that *describes* a banned
+pattern (an error-pattern section explaining what not to do) is documentation and
+is exempt automatically, with no marker needed. Every non-markdown file is
+enforced in full.
+
+That split is deliberate. The first version of this lint policed prose too, so
+every teaching sentence needed a ``lint-ok`` marker; those markers were then
+copy-pasted onto live commands during a merge, silencing a real defect (three of
+the four Brev verbs shipped broken behind ``lint-ok: brev-exec-form``). A marker
+inside a shell fence now means someone suppressed a genuine finding — treat it
+as a bug, not an annotation.
 """
 
 from __future__ import annotations
@@ -69,6 +77,35 @@ def _iter_files():
                 yield path
 
 
+SHELL_FENCE_RE = re.compile(r"^\s*```+\s*(bash|sh|shell|console|zsh)\b", re.I)
+FENCE_CLOSE_RE = re.compile(r"^\s*```+\s*$")
+
+
+def _executable_lines(path, text):
+    """Yield (lineno, line) for lines a user would actually run.
+
+    Markdown prose that merely *describes* a banned pattern (usually inside
+    backticks, in an error-pattern or "don't do this" section) is documentation,
+    not a command — policing it forced a ``lint-ok`` marker onto every teaching
+    sentence, and those markers then got copy-pasted onto genuinely broken
+    commands, which is how the brev-exec regression shipped. So in markdown only
+    shell fences are enforced; every other file type is enforced whole.
+    """
+    if path.suffix != ".md":
+        for lineno, line in enumerate(text.splitlines(), 1):
+            yield lineno, line
+        return
+    in_shell_fence = False
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if in_shell_fence:
+            if FENCE_CLOSE_RE.match(line) or line.strip().startswith("```"):
+                in_shell_fence = False
+                continue
+            yield lineno, line
+        elif SHELL_FENCE_RE.match(line):
+            in_shell_fence = True
+
+
 def test_no_banned_command_patterns():
     violations = []
     for path in _iter_files():
@@ -78,12 +115,15 @@ def test_no_banned_command_patterns():
             text = path.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
             continue
-        for lineno, line in enumerate(text.splitlines(), 1):
+        for lineno, line in _executable_lines(path, text):
             for rule_id, pattern, why in RULES:
                 if pattern.search(line) and f"lint-ok: {rule_id}" not in line:
                     rel = path.relative_to(REPO_ROOT)
                     violations.append(
                         f"{rel}:{lineno}: [{rule_id}] {why}\n    {line.strip()}")
     assert not violations, (
-        "command-hygiene violations (annotate deliberate anti-pattern docs "
-        "with 'lint-ok: <rule-id>'):\n" + "\n".join(violations))
+        "command-hygiene violations in runnable code. These are commands a user "
+        "would copy — fix them rather than suppressing. A 'lint-ok: <rule-id>' "
+        "marker on a line inside a shell fence silences a REAL defect; prose "
+        "outside shell fences is already exempt and needs no marker:\n"
+        + "\n".join(violations))

--- a/skills/platform/tao-run-on-brev/SKILL.md
+++ b/skills/platform/tao-run-on-brev/SKILL.md
@@ -81,15 +81,30 @@ instance to stop billing. `$BANK` = `${TAO_SKILL_BANK_PATH}`.
 
 - **submit** — reach an instance (provision/reuse via the official Brev skill or
   MCP; reuse an existing instance by its `instance_id`; wait for readiness, above).
-  Then run the docker `submit` verb *inside* it: `open` the record (`--platform
-  brev`, `--backend-ref "<instance>/<container>"`),
-  `brev exec <instance> "docker run -d --name $JOB_ID ..."`, mark RUNNING.
+  Lint the assembled command, open the record to mint `$JOB_ID` **before** launch,
+  then run the docker `submit` verb *inside* the instance and mark RUNNING:
+
+  ```bash
+  redact_secrets.py lint <<<"$REMOTE_CMD"     # no inline secrets; creds as -e VAR
+  JOB_ID=$("$BANK/scripts/tao_job_record.py" open \
+    --platform brev --image "$IMG" --results-dir "$RESULTS_DIR")
+  brev exec <instance> "docker run -d --name $JOB_ID ..."
+  "$BANK/scripts/tao_job_record.py" mark "$JOB_ID" --state RUNNING \
+    --backend-ref "<instance>/$JOB_ID"       # instance is part of the ref: the
+                                             # container is unreachable without it
+  ```
 - **status / logs** — `brev exec <instance> "docker inspect $JOB_ID"` /
   `brev exec <instance> "docker logs $JOB_ID"`, mapped to the vocab exactly as
-  the docker verbs do.
-- **cancel / teardown** — `brev exec <instance> "docker rm -f $JOB_ID"`, then
-  for an ephemeral instance **`brev delete <instance>`** (stops billing), then mark
-  the record. Never leave an ephemeral instance running.
+  the docker verbs do. Recover `<instance>` from the record's `backend-ref`.
+- **cancel / teardown** — remove the container, then for an ephemeral instance
+  delete it (stops billing), then mark the record. Never leave an ephemeral
+  instance running:
+
+  ```bash
+  brev exec <instance> "docker rm -f $JOB_ID"
+  brev delete <instance>                      # ephemeral instances only
+  "$BANK/scripts/tao_job_record.py" mark "$JOB_ID" --state CANCELED --source agent
+  ```
 
 ### `brev exec` argument form
 

--- a/skills/platform/tao-run-on-brev/SKILL.md
+++ b/skills/platform/tao-run-on-brev/SKILL.md
@@ -87,7 +87,9 @@ instance to stop billing. `$BANK` = `${TAO_SKILL_BANK_PATH}`.
   ```bash
   redact_secrets.py lint <<<"$REMOTE_CMD"     # no inline secrets; creds as -e VAR
   JOB_ID=$("$BANK/scripts/tao_job_record.py" open \
-    --platform brev --image "$IMG" --results-dir "$RESULTS_DIR")
+    --platform brev --image "$IMG" \
+    --network-arch "$ARCH" --action "$ACTION" \
+    --storage-tier "$TIER" --results-root "$RESULTS_ROOT")
   brev exec <instance> "docker run -d --name $JOB_ID ..."
   "$BANK/scripts/tao_job_record.py" mark "$JOB_ID" --state RUNNING \
     --backend-ref "<instance>/$JOB_ID"       # instance is part of the ref: the

--- a/skills/platform/tao-run-on-brev/SKILL.md
+++ b/skills/platform/tao-run-on-brev/SKILL.md
@@ -47,13 +47,19 @@ It does **not** cover container execution on the instance — that is this skill
 
 **Preflight for this skill:** the `brev` CLI is on `PATH` and logged in (headless:
 `brev login --token "$BREV_API_TOKEN"` before any other call), and you can reach a
-target instance — poll `brev exec <instance> -- true` until it succeeds before <!-- lint-ok: brev-exec-form -->
+target instance — poll with a **two-word** command until it succeeds before
 issuing real work (a fresh instance reports `RUNNING` before sshd is up):
 
 ```bash
-for i in $(seq 1 60); do brev exec <instance> -- true >/dev/null 2>&1 && break; sleep 5; done  # lint-ok: brev-exec-form
-brev exec <instance> -- true >/dev/null 2>&1 || { echo "instance not exec-ready"; exit 1; }  # lint-ok: brev-exec-form
+for i in $(seq 1 60); do [ "$(brev exec <instance> "echo ok" 2>/dev/null)" = ok ] && break; sleep 5; done
+[ "$(brev exec <instance> "echo ok" 2>/dev/null)" = ok ] || { echo "instance not exec-ready"; exit 1; }
 ```
+
+The probe must be **two words, quoted as one argument**. A single-token probe
+(`brev exec <instance> -- true`) passes even when every real command is broken,
+because `brev exec [instance...] <command>` treats only the LAST positional as
+the command — so a lone `true` lands in the right slot by accident while
+`docker run ...` does not. See *`brev exec` argument form* below.
 
 Allow **≥ 600 s** for the first `brev exec` on a new instance (SSH bring-up +
 first container pull); a 60–120 s wrapper timeout truncates startup and looks
@@ -76,23 +82,42 @@ instance to stop billing. `$BANK` = `${TAO_SKILL_BANK_PATH}`.
 - **submit** — reach an instance (provision/reuse via the official Brev skill or
   MCP; reuse an existing instance by its `instance_id`; wait for readiness, above).
   Then run the docker `submit` verb *inside* it: `open` the record (`--platform
-  brev`, `--backend-ref "<instance>/<container>"`), `brev exec <instance> --
-  docker run -d --name "$JOB_ID" ...`, mark RUNNING.
-- **status / logs** — `brev exec <instance> -- docker inspect/logs "$JOB_ID"`, <!-- lint-ok: brev-exec-form -->
-  mapped to the vocab exactly as the docker verbs do.
-- **cancel / teardown** — `brev exec <instance> -- docker rm -f "$JOB_ID"`, then <!-- lint-ok: brev-exec-form -->
+  brev`, `--backend-ref "<instance>/<container>"`),
+  `brev exec <instance> "docker run -d --name $JOB_ID ..."`, mark RUNNING.
+- **status / logs** — `brev exec <instance> "docker inspect $JOB_ID"` /
+  `brev exec <instance> "docker logs $JOB_ID"`, mapped to the vocab exactly as
+  the docker verbs do.
+- **cancel / teardown** — `brev exec <instance> "docker rm -f $JOB_ID"`, then
   for an ephemeral instance **`brev delete <instance>`** (stops billing), then mark
   the record. Never leave an ephemeral instance running.
+
+### `brev exec` argument form
+
+The remote command is **one argument**. The CLI signature is
+`brev exec [instance...] <command>`: every positional except the last is an
+instance name, and `--` only ends flag parsing — it does not group the words
+after it. So `brev exec <inst> -- docker inspect "$JOB_ID"` is read as
+instances `<inst> docker inspect` plus command `"$JOB_ID"`, and fails with
+`could not look up instance "docker"` / `ssh: illegal option -- -` (exit 255) —
+an error that reads like an instance or SSH fault but is a syntax fault. Quote
+every remote command as a single string, exactly as `brev exec --help` shows.
 
 NGC auth once per instance — **never put `NGC_KEY` on argv** (it lands in the
 remote process table); pipe it to `--password-stdin`:
 
 ```bash
-# NGC auth (one-time per instance) — value never on argv
-brev exec <instance> -- bash -lc 'printf %s "$NGC_KEY" | docker login nvcr.io -u "$oauthtoken" --password-stdin'  # lint-ok: brev-exec-form
+IMG=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+
+# NGC auth (one-time per instance) — value never on argv.
+# Single-quoted locally so $NGC_KEY expands in the instance's shell; export it
+# there first (or pipe it in from the local shell, if the instance has no copy).
+brev exec <instance> 'printf %s "$NGC_KEY" | docker login nvcr.io -u "$oauthtoken" --password-stdin'
+
+# Verify auth without reading ~/.docker/config.json. Failure before a successful
+# login = not authenticated; failure after = the key's org lacks entitlement.
+brev exec <instance> "docker manifest inspect $IMG >/dev/null && echo AUTH_OK || echo AUTH_FAIL"
 
 # Run a TAO job (the docker `submit` verb, over brev exec)
-IMG=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
 brev exec <instance> "docker run -d --name $JOB_ID --gpus all -v ~/data:/data -e NGC_KEY $IMG visual_changenet train -e /data/spec.yaml"
 ```
 

--- a/skills/platform/tao-run-on-docker/SKILL.md
+++ b/skills/platform/tao-run-on-docker/SKILL.md
@@ -375,9 +375,9 @@ du -xhd1 <results_root> 2>/dev/null | sort -h
 find <results_root> -maxdepth 3 -printf '%u:%g %m %s %p\n' 2>/dev/null | head
 ```
 
-For a bind mount, clean only confirmed terminal job directories using the SDK
-retention path or a reviewed ownership repair; never assume `docker system
-prune` touches them. For Docker's own root, relocate `data-root` as described
+For a bind mount, clean only job directories whose record is in a terminal state
+(`tao_job_record.py get "$JOB_ID"`), via a reviewed ownership repair; never assume
+`docker system prune` touches them. For Docker's own root, relocate `data-root` as described
 above. `docker system prune -a --volumes` is destructive and may remove unused
 images and volumes belonging to other workflows, so run it only after explicit
 user approval and a reviewed `docker system df` inventory.

--- a/skills/platform/tao-run-on-kubernetes/SKILL.md
+++ b/skills/platform/tao-run-on-kubernetes/SKILL.md
@@ -270,11 +270,16 @@ This skill's Indexed Job path is intentionally simple and dependency-free; if yo
 **`No nvidia.com/gpu resources allocatable on the cluster`** — the GPU Operator (or NVIDIA Device Plugin) isn't installed. Install per the link above; verify with `kubectl get nodes -o jsonpath='{.items[*].status.allocatable}'`.
 
 **`ImagePullBackOff` / `ErrImagePull`** — the cluster can't pull the image. For nvcr.io: pre-create an image-pull secret in the namespace and reference it as the pod's `imagePullSecrets` in the rendered manifest:
+Feed the key over stdin — `--docker-password=$NGC_KEY` would put the secret in
+argv, where it is visible in the host's process table and shell history:
 ```bash
-kubectl create secret docker-registry ngc-pull-secret \
-  --docker-server=nvcr.io \
-  --docker-username='$oauthtoken' \
-  --docker-password=$NGC_KEY -n tao-jobs  # lint-ok: secret-on-argv
+kubectl create secret generic ngc-pull-secret -n tao-jobs \
+  --type=kubernetes.io/dockerconfigjson \
+  --from-file=.dockerconfigjson=/dev/stdin <<EOF
+{"auths": {"nvcr.io": {"username": "\$oauthtoken", "password": "${NGC_KEY}"}}}
+EOF
+# Verify without reading the secret back:
+kubectl get secret ngc-pull-secret -n tao-jobs >/dev/null && echo SECRET_OK
 ```
 
 **Pod stays `Pending` forever** — `kubectl describe pod -l job-name=$JOB_ID` shows the scheduling reason in the `Events`. Common causes: insufficient GPU capacity (`Insufficient nvidia.com/gpu`), no node matches the pod's `nodeSelector`, missing image-pull secret, or PVC mount failure.

--- a/skills/platform/tao-run-on-kubernetes/SKILL.md
+++ b/skills/platform/tao-run-on-kubernetes/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: tao-run-on-kubernetes
-description: Kubernetes execution platform — submits TAO container jobs as single-pod k8s Jobs with NVIDIA GPU scheduling.
-  Use when running on EKS / GKE / AKS / on-prem clusters with the NVIDIA GPU Operator installed, or when integrating TAO
-  into an existing k8s-native ML platform.
+description: Kubernetes execution platform — submits TAO container jobs as k8s Jobs with NVIDIA GPU scheduling; single-pod
+  for one node, Indexed Jobs for multi-node distributed training. Use when running on EKS / GKE / AKS / on-prem clusters
+  with the NVIDIA GPU Operator installed, or when integrating TAO into an existing k8s-native ML platform.
 license: Apache-2.0
 compatibility: Requires GPU worker nodes with NVIDIA driver branch 580, CUDA Toolkit 13.0, and NVIDIA Container Toolkit 1.19.0; a `kubectl` client authenticated to the cluster; and the NVIDIA GPU Operator or device plugin. No nvidia-tao-sdk required — jobs are submitted with plain `kubectl`.
 metadata:
@@ -37,7 +37,7 @@ Operator/device plugin present.
 # driver/toolkit lifecycle is owned by the cloud provider or GPU Operator policy.
 if [ "${TAO_K8S_SKIP_NODE_RUNTIME_CHECK:-0}" != "1" ]; then
   TAO_SKILL_BANK_ROOT="${TAO_SKILL_BANK_ROOT:-$PWD}"
-  SETUP_SCRIPT="${TAO_SKILL_BANK_ROOT}/platform/tao-setup-nvidia-gpu-host/scripts/setup-nvidia-gpu-host.sh"
+  SETUP_SCRIPT="${TAO_SKILL_BANK_ROOT}/skills/platform/tao-setup-nvidia-gpu-host/scripts/setup-nvidia-gpu-host.sh"
 
   bash "$SETUP_SCRIPT" --backend kubernetes --check-only || {
     echo "MISSING: TAO Kubernetes GPU node runtime is not ready."

--- a/skills/platform/tao-run-on-kubernetes/references/skill_info.yaml
+++ b/skills/platform/tao-run-on-kubernetes/references/skill_info.yaml
@@ -29,7 +29,7 @@ resource_defaults:
   ttl_seconds_after_finished: 3600  # auto-clean Jobs 1h after terminal state
   backoff_limit: 0  # no auto-retry; surface failure to the user
   restart_policy: Never
-  num_nodes: 1  # single-pod only in v1
+  num_nodes: 1  # default only — multi-node runs via the Indexed Job template
 cloud_storage:
   protocol: aws
   uri_format: s3://{bucket_name}/{path}
@@ -39,3 +39,4 @@ features:
 - failure-analysis
 - log-streaming
 - pod-diagnostics
+- multi-node

--- a/skills/platform/tao-run-on-slurm/references/slurm-ssh-credentials.md
+++ b/skills/platform/tao-run-on-slurm/references/slurm-ssh-credentials.md
@@ -20,9 +20,9 @@ ssh -o BatchMode=yes -o ConnectTimeout=10 "${SLURM_USER}@${SLURM_HOST}" "true" 2
 # Pyxis on the compute nodes invokes enroot to import the Docker image. Enroot
 # does NOT read NGC_KEY from the SLURM job env — it requires persistent
 # credentials in ~/.config/enroot/.credentials on the login/compute nodes.
-# Without this, anonymous pulls of nvcr.io/nvstaging/* (or any auth-gated
-# repo) fail with "Could not process JSON input" at job startup. Skip if the
-# image is from a public repo.
+# Without this, anonymous pulls of auth-gated nvcr.io paths (e.g. any
+# pre-release staging org) fail with "Could not process JSON input" at job
+# startup. Skip if the image is from a public repo.
 if [ -n "$NGC_KEY" ]; then
   REMOTE_CRED_OK=$(ssh -o BatchMode=yes "${SLURM_USER}@${SLURM_HOST}" \
     'test -s ~/.config/enroot/.credentials && echo OK || echo MISSING' 2>/dev/null)

--- a/templates/k8s/indexed-job.yaml.tmpl
+++ b/templates/k8s/indexed-job.yaml.tmpl
@@ -21,6 +21,10 @@ metadata:
     tao-job: "@@JOB_NAME@@"
 spec:
   clusterIP: None            # headless — DNS returns the per-pod IPs for rendezvous
+  # Rank-0's DNS name must resolve BEFORE any pod is Ready: every other rank
+  # blocks on MASTER_ADDR to rendezvous, and pods only become Ready once the
+  # workload is up. Without this the lookup NXDOMAINs and multi-node deadlocks.
+  publishNotReadyAddresses: true
   selector:
     job-name: "@@JOB_NAME@@"
   ports:
@@ -62,6 +66,13 @@ spec:
             - name: WORLD_SIZE                 # = NODE COUNT (TAO convention), not global ranks
               value: "@@NUM_NODES@@"
             - name: NUM_GPU_PER_NODE
+              value: "@@GPUS_PER_NODE@@"
+            # torchrun/PyTorch-standard spelling of the same two values, so a raw
+            # `torchrun --nnodes=$NNODES --nproc-per-node=$NPROC_PER_NODE` command
+            # works alongside the TAO entrypoint's WORLD_SIZE/NUM_GPU_PER_NODE.
+            - name: NNODES
+              value: "@@NUM_NODES@@"
+            - name: NPROC_PER_NODE
               value: "@@GPUS_PER_NODE@@"
             - name: MASTER_PORT
               value: "29500"

--- a/templates/tests/test_multinode_templates.py
+++ b/templates/tests/test_multinode_templates.py
@@ -137,3 +137,58 @@ def test_k8s_no_inline_creds():
     env = {e["name"] for e in job["spec"]["template"]["spec"]["containers"][0]["env"]}
     assert not any(k in env for k in ("AWS_SECRET_ACCESS_KEY", "NGC_KEY", "HF_TOKEN"))
     assert redact_secrets.scan(render(K8S, K8S_VALS)) == []
+
+
+def test_k8s_service_publishes_not_ready_addresses():
+    """Rank-0 DNS must resolve before any pod is Ready, or rendezvous deadlocks.
+
+    Non-zero ranks block on MASTER_ADDR, and a pod only goes Ready once the
+    workload is up — so without this the lookup NXDOMAINs and every rank waits
+    out the full distributed timeout.
+    """
+    svc, _ = k8s_docs()
+    assert svc["spec"].get("publishNotReadyAddresses") is True
+
+
+# Rendezvous vars the k8s skill documents as exported, mapped to the rendered
+# value each must carry. Guards doc/template drift in the direction that bites:
+# a documented `torchrun --nnodes=$NNODES` recipe renders as `--nnodes=` when
+# the template silently stops exporting it.
+DOCUMENTED_K8S_ENV = {
+    "WORLD_SIZE": "2",          # TAO convention: node count
+    "NUM_GPU_PER_NODE": "8",
+    "NNODES": "2",              # torchrun spelling of the same node count
+    "NPROC_PER_NODE": "8",      # torchrun spelling of GPUs per node
+    "MASTER_PORT": "29500",
+    "MASTER_ADDR": "dino-train-a1b2c3-0.dino-train-a1b2c3",
+}
+
+
+@pytest.mark.parametrize("var,expected", sorted(DOCUMENTED_K8S_ENV.items()))
+def test_k8s_documented_rendezvous_var_is_exported(var, expected):
+    _, job = k8s_docs()
+    env = {e["name"]: e["value"]
+           for e in job["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert var in env, f"{var} is documented in the k8s skill but not exported by the template"
+    assert env[var] == expected
+
+
+def test_k8s_skill_doc_and_template_env_agree():
+    """Every env var the skill's rendezvous table names must exist in the template.
+
+    Catches the drift class directly rather than via a hand-maintained list: if
+    someone documents a new var without templating it, this fails.
+    """
+    doc = (REPO / "skills/platform/tao-run-on-kubernetes/SKILL.md").read_text(encoding="utf-8")
+    # Rendezvous table rows look like: | `NNODES` | `num_nodes` | torchrun ... |
+    documented = set(re.findall(r"^\s*\|\s*`([A-Z][A-Z0-9_]+)`\s*\|", doc, re.M))
+    documented -= {"JOB_COMPLETION_INDEX"}  # injected by k8s itself, not by us
+    if not documented:
+        pytest.skip("no rendezvous env table found in the k8s skill")
+    _, job = k8s_docs()
+    exported = {e["name"] for e in job["spec"]["template"]["spec"]["containers"][0]["env"]}
+    wrapper = job["spec"]["template"]["spec"]["containers"][0]["command"][2]
+    missing = {v for v in documented if v not in exported and f"{v}=" not in wrapper}
+    assert not missing, (
+        f"documented in tao-run-on-kubernetes/SKILL.md but never set by "
+        f"templates/k8s/indexed-job.yaml.tmpl: {sorted(missing)}")


### PR DESCRIPTION
**Stacked on #100** — the nightly workflow runs the contract tests that PR adds, so this should merge second. Its diff will shrink to just `.github/workflows/` once #100 lands.

`.gitlab-ci.yml` does not run on GitHub, so after the migration every guard the old pipeline enforced silently stopped running. Two workflows port them.

## `skill-bank-static.yml` (PR + push to main)

Mirrors the GitLab `validate-skills` job: `validate-skills.sh`, `stamp_versions.py --check --strict-strays`, the NemoClaw integration tests, and `pytest scripts/tests templates/tests`.

`templates/tests` is included deliberately — it existed but was **absent from the GitLab job**, which is how the k8s multi-node doc/template drift shipped unnoticed.

## `platform-nightly.yml` (scheduled + manual dispatch)

Adds execution coverage, split by what each tier can actually prove. All three jobs run on GitHub-hosted CPU runners:

| Job | Proves |
|---|---|
| `contract` | Templates render; kubeconform accepts them offline |
| `smoke-docker-cpu` | Verb lifecycle + CLI syntax acceptance |
| `smoke-kubernetes` (kind) | A real API server **admits** the manifest |

`kubectl --dry-run=client` is not a substitute for kubeconform here: it contacts the API server to resolve API groups, so it validates nothing on a clusterless runner.

The kind job proves admission only, not scheduling — both k8s templates hardcode `nvidia.com/gpu`, so with no GPU capacity advertised a rendered pod never leaves `Pending`. Confirmed against minikube: `0/1 nodes are available: 1 Insufficient nvidia.com/gpu`.

## Why GPU and SLURM are deliberately not Actions jobs

This repo is public. Self-hosted runners on a `pull_request` trigger would let any fork PR execute arbitrary code on internal hardware, and a GitHub-hosted runner cannot reach an internal-only cluster login node regardless.

The repo already has the right mechanism: `blossom-ci.yml` is a **bridge, not an executor** — an authorized maintainer comments `/build`, and after a vulnerability scan `Job-trigger` runs `OPERATION: START-CI-JOB` against `secrets.CI_SERVER`, handing work to internal Jenkins and posting the log back. (`runs-on: blossom` resolves to runner `ci-server` — the bridge box, not a GPU host.)

So the GPU tier is a Jenkins job whose payload stays in-tree:

```
PLATFORM_SMOKE_GPU=1 bash scripts/ci/platform_smoke.sh docker
```

That keeps the test logic reviewable here while Jenkins stays a thin trigger. A nightly against `main` needs no blossom gating at all — it is already trusted code, so a Jenkins timer suffices.

## Notes

- Both workflow files carry SPDX headers; all commits are DCO signed off.
- `smoke-kubernetes` and the SLURM path in `platform_smoke.sh` are still stubs that report TODO rather than passing as covered. Docker is fully implemented and verified green.