### PR TITLE
[TAO-0000][Docs] Fix authoring checklist to match required frontmatter fields

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -513,8 +513,8 @@ Start a session, ask the agent to exercise the skill. Verify the agent reads it,
 ## Checklist
 
 - [ ] Skill directory is kebab-case at the right layer.
-- [ ] Frontmatter has `name`, `description` with trigger phrases, `license: Apache-2.0`.
-- [ ] Optional: `compatibility`, `metadata.author`, `metadata.version`, `allowed-tools` populated.
+- [ ] Frontmatter has all required fields: `name`, `description` with trigger phrases, `license: Apache-2.0`, `compatibility`, `metadata.author`, `metadata.version`, and `tags`.
+- [ ] Optional frontmatter field `allowed-tools` populated (validator warns when missing).
 - [ ] Body has Quick Start (or scripts/, hooks/, references/skill_info.yaml) — agent-runnable.
 - [ ] If the skill is non-trivial: External Dependencies, CLI Reference, Output Structure, Known Pitfalls sections present.
 - [ ] If using `skill_info.yaml`: `container_image` set, each model/data action has `command`, `mode`, `inputs`, `outputs`, and `upload_excludes`.


### PR DESCRIPTION
docs: fix authoring checklist to match required frontmatter fields

### What changes are proposed in this pull request?

Two lines in the `## Checklist` section of `docs/authoring.md` are corrected so the
checklist matches the frontmatter contract the rest of the document and the CI
validator already enforce.

Before:

- [ ] Frontmatter has `name`, `description` with trigger phrases, `license: Apache-2.0`.
- [ ] Optional: `compatibility`, `metadata.author`, `metadata.version`, `allowed-tools` populated.

After:

- [ ] Frontmatter has all required fields: `name`, `description` with trigger phrases, `license: Apache-2.0`, `compatibility`, `metadata.author`, `metadata.version`, and `tags`.
- [ ] Optional frontmatter field `allowed-tools` populated (validator warns when missing).

`compatibility`, `metadata.author`, `metadata.version`, and `tags` move to the
required line, `tags` is added (it was absent from the checklist entirely), and
`allowed-tools` is left as the only optional field. No other file changes.

### Why are the changes needed?

The checklist contradicted both the prose and the tooling in this repo:

- `docs/authoring.md` § 2 lists all four fields under **Required fields**, with
  per-field notes on the constraints (`compatibility` ≤ 500 chars, `metadata.author`
  exactly `NVIDIA Corporation`, `metadata.version` strict semver, `tags` non-empty).
- `scripts/validate-skills.sh` emits a hard **ERROR** for each of them when missing
  or malformed, and only a **WARN** for a missing `allowed-tools`.

An author following the checklist as written would treat four CI-blocking fields as
optional and discover the failure only after pushing. The checklist is the last thing
an author reads before opening a PR, so it is exactly where the contract needs to be
right.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

No. Documentation only.

### How was this patch tested?

Verified the claim against the validator source before editing — the required/optional
split in the new text mirrors which branch of `scripts/validate-skills.sh` each field
falls into (`ERROR` vs `WARN`), and § 2 of the same document.

Ran the repo validator, which passes:

```console
$ PATH="$PWD/.venv/deft/bin:$PATH" ./scripts/validate-skills.sh
...
=== 6. AutoML baseline eval guardrail ===
  OK: AutoML baseline eval guidance is guarded

=== 7. skill_info.yaml + legacy model_info.yaml (when present) ===
  OK: skill_info.yaml / model_info.yaml validation passed

✓ validate-skills passed
```

Pre-commit hooks ran on commit: `license header` skipped (no source files in the
diff), `DCO sign-off check` passed. Also grepped the repo for the stale wording to
confirm it is not duplicated in `skill-requirements.md` or elsewhere; the only
remaining match is the corrected line itself.

No automated test was added: the change is prose in a Markdown checklist, and the
underlying rule it now describes is already enforced by `validate-skills.sh`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)

### Release note

```release-note
NONE
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change — N/A, documentation-only (see test plan)
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it — N/A
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this) — N/A, no code
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

The whole diff is two lines; the substance is whether the required/optional split is
right. Cross-check against `scripts/validate-skills.sh` (the `compatibility`, `tags`,
and `allowed-tools` branches) and § 2 of `docs/authoring.md`.

One open question: `allowed-tools` is documented as optional and only warned on, but
`skill-requirements.md` § 2.8 describes signer behavior around it. If the signing
pipeline actually requires it, this line should be tightened further in a follow-up —
I left it as optional to match current validator behavior rather than change the
contract in a docs PR.