### PR TITLE
[TAO-0000][Feature] Add IAA DEFT workflow with bounded archive discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "NVIDIA TAO skill bank with generated capability discovery for model training, data processing, application workflows, AutoML, and platform execution.",
-    "version": "0.1.11"
+    "version": "0.1.12"
   },
   "plugins": [
     {
@@ -24,6 +24,7 @@
         "./skills/applications/tao-port-huggingface-model",
         "./skills/applications/tao-run-deft-aoi",
         "./skills/applications/tao-run-deft-aoi-cosmos3",
+        "./skills/applications/tao-run-deft-iaa",
         "./skills/applications/tao-validate-recipe-transfer",
         "./skills/data/tao-mine-nearest-neighbors",
         "./skills/data/tao-mine-aoi-images",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "tao-skill-bank",
   "description": "NVIDIA TAO skill bank with generated capability discovery for model training, data processing, application workflows, AutoML, and platform execution.",
-  "version": "0.1.11"
+  "version": "0.1.12"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tao-skill-bank",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "NVIDIA TAO skill bank with generated capability discovery for model training, data processing, application workflows, AutoML, and platform execution.",
   "skills": "./skills/core/",
   "interface": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,20 +14,29 @@ The skill bank works **standalone**. Model and data skills run with just
 helper scripts (`scripts/tao_job_record.py`, `scripts/redact_secrets.py`, and
 the `tao-data-io` skill) — no TAO SDK install.
 
+User-facing DEFT shorthand resolves to canonical application skills:
+`tao-deft-aoi` → `tao-run-deft-aoi` and `tao-deft-iaa` →
+`tao-run-deft-iaa`. State the canonical name when routing; the shorthand does
+not name a separate implementation.
+
 ## Discovery flow
 
-0. **Preflight the chosen platform.** Open `skills/platform/<chosen>/SKILL.md` and run
-   its Preflight section. If a missing prerequisite is a small Python helper that
-   can be installed with `python -m pip install ...` (e.g. `boto3` for
-   `tao-data-io`), install it in the active Python environment, then rerun
-   preflight. Bail on missing non-Python/system prerequisites — do not draft
-   launch commands against an unconfigured environment.
-
-1. **Read the task skill.** `skills/models/<arch>/SKILL.md` (network specifics),
+0. **Read the task skill.** `skills/models/<arch>/SKILL.md` (network specifics),
    `skills/data/<name>/SKILL.md` (transforms), or `skills/applications/<name>/SKILL.md`
    (workflows that compose model + data + platform — `tao-run-automl`,
-   `tao-run-deft-aoi`, etc.). Get the model facts, data format, action
-   parameters, and known error patterns.
+   `tao-run-deft-aoi`, `tao-run-deft-iaa`, etc.). Get the model facts, data
+   format, action parameters, supported-platform contract, and known error
+   patterns. Resolve documented shorthand names to the canonical frontmatter
+   name before continuing.
+
+1. **Resolve and preflight the platform.** If the application supports exactly
+   one platform, treat that contract as the selection. If it supports several
+   and the user did not select one, ask once among its supported installed
+   platforms. Then open `skills/platform/<chosen>/SKILL.md` and run its
+   Preflight section. If a missing prerequisite is a small Python helper that
+   can be installed with `python -m pip install ...` (for example `boto3` for
+   `tao-data-io`), install it in the active environment, report it, and rerun
+   preflight. Bail on missing non-Python/system prerequisites.
 
 2. **Read `references/skill_info.yaml`** for the structured contract:
    - `container_image` — image key or absolute URI
@@ -82,9 +91,10 @@ the bank:
   verbs over `kubectl` / `ssh`+`sbatch` / `brev exec`; `tao-run-on-virtualenv`
   adds docker-free local Python execution.
 
-All installed platforms — the bank's five plus any external platform skill
-(e.g. kratos) — are **equal-class peers, no default**. If the user hasn't
-chosen, ask.
+When an application supports several platforms, all supported installed
+peers—the bank's five plus external platform skills—are equal class with no
+default; ask if the user has not chosen. A single-platform application has
+already made the selection.
 
 > AutoML hyperparameter search (`tao-run-automl`) is the one workflow that
 > additionally uses the `nvidia-tao-automl` wheel — and its transitive
@@ -99,16 +109,15 @@ chosen, ask.
   `spec_overrides` argument is the one exception: it accepts dotted path keys as
   an override map and expands them into the nested spec before launch. Do not
   pass that override map directly to a config file or container boundary.
-- **Never default to one platform** when several would fit. If the user hasn't
-  said which platform (Docker, SLURM, Kubernetes, Brev, virtualenv, or an
-  installed external one), ask. Installed platforms are equal-class peers;
-  biasing toward one is wrong.
+- **Never default to one platform when several fit.** If the application
+  supports several and the user did not select one, ask among its supported
+  installed peers. Do not ask again for a single-platform application.
 - **Never start a side-effecting action without user confirmation.** This
-  means: `docker run` / the `submit` verb, `git push`, file mutations outside
-  the working directory. Missing small Python helpers (e.g. `boto3` for
-  `tao-data-io`) installable with `python -m pip install ...` are an explicit
-  exception for TAO workflows: install them by default and report what was
-  installed.
+  means: `docker run` / the `submit` verb, registry login or pulls, asset
+  downloads, `git push`, and workspace/state mutations. Missing small Python
+  helpers installable with `python -m pip install ...` retain the established
+  exception: install them by default and report what was installed. An
+  application may impose a stricter approval gate for its own runtime.
 - **Never ask for API keys, tokens, or passwords via chat.** Credentials come
   from the **session environment** — the user exports them in their own shell
   before launching. If a required var is missing, tell the user which one to

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In a Claude Code session, add the marketplace and install the plugin:
 /plugin install tao-skills@tao-skill-bank
 ```
 
-That's it — no `git clone`, no `pip install`. The TAO Skill Bank plugin bundles all 65 skills (every model, data, platform, and application). The plugin's [`SessionStart`](hooks/session_start.sh) hook loads the [`AGENTS.md`](AGENTS.md) identity at the start of every session.
+That's it — no `git clone`, no `pip install`. The TAO Skill Bank plugin bundles all 66 skills (every model, data, platform, and application). The plugin's [`SessionStart`](hooks/session_start.sh) hook loads the [`AGENTS.md`](AGENTS.md) identity at the start of every session.
 
 ### Codex
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NVIDIA [TAO Skill Bank](https://github.com/NVIDIA-TAO/tao-skills-bank)
 
-Portable agent skills for training, evaluating, and running inference on NVIDIA TAO models. Works with Claude Code, Codex, Gemini CLI, or any coding agent that speaks the [Agent Skills open standard](https://agentskills.io). **Zero Python required** for local docker workflows — install the plugin, install docker + nvidia-container-toolkit, and an agent can run every skill by constructing `docker run` commands directly. Advanced features — job tracking, multi-node, S3 I/O — are built in, not bolted on: platform skills implement a four-verb execution contract over their native CLI with no `nvidia-tao-sdk`. See [Execution: no SDK required](#execution-no-sdk-required).
+Portable agent skills for training, evaluating, and running inference on NVIDIA TAO models. Works with Claude Code, Codex, Gemini CLI, or any coding agent that speaks the [Agent Skills open standard](https://agentskills.io). Most local Docker model/data actions need only Docker plus NVIDIA Container Toolkit; application workflows may declare small host-Python requirements for deterministic state and analysis adapters. Advanced features—job tracking, multi-node, S3 I/O—are built in, not bolted on: platform skills implement a four-verb execution contract over their native CLI with no `nvidia-tao-sdk`. See [Execution: no SDK required](#execution-no-sdk-required).
 
 ## Install
 
@@ -97,7 +97,16 @@ If a readiness check reports a missing CLI, container image, backbone, or creden
 
 ### Do I need to install anything else?
 
-No. Model and data skills run with just `docker run`; platform skills add job tracking, S3 I/O, and multi-node over their native CLI with no `nvidia-tao-sdk` — see [Execution: no SDK required](#execution-no-sdk-required). The one exception is AutoML search (`tao-run-automl`), whose Preflight lazily installs the `nvidia-tao-automl` wheel; its pin lives in [`versions.yaml`](versions.yaml) (`wheels.tao_automl_*`).
+Usually there is no up-front setup beyond the chosen platform prerequisites.
+Model and data skills run with just `docker run`; platform skills add job
+tracking, S3 I/O, and multi-node over their native CLI with no
+`nvidia-tao-sdk` — see [Execution: no SDK required](#execution-no-sdk-required).
+Application workflows such as IAA DEFT may provision documented host-Python
+dependencies into an isolated workspace environment, but only after the
+workflow's approval gate. AutoML search (`tao-run-automl`) remains the one
+special SDK exception: its Preflight lazily installs the
+`nvidia-tao-automl` wheel, whose pin lives in [`versions.yaml`](versions.yaml)
+(`wheels.tao_automl_*`).
 
 ### Updating
 
@@ -147,8 +156,10 @@ In a Claude Code session with the plugin installed, ask:
 The agent will read `skills/models/tao-train-visual-changenet/SKILL.md` (skill name `tao-train-visual-changenet`, plus its `references/skill_info.yaml` if present), construct a `docker run --gpus all ...` invocation, and execute via Bash. **No Python needed.** No SDK install. Just docker + the plugin. For classify mode, expect per-image PASS/NO_PASS-style predictions and result files under `/tmp/vcn-out/`. For segment mode, expect binary change-mask outputs under the requested results directory.
 
 For more complex workflows, see `skills/applications/tao-run-deft-aoi/SKILL.md`
-(`tao-run-deft-aoi`) for iterative fine-tuning with synthetic data augmentation
-and `skills/applications/tao-run-automl/SKILL.md` (`tao-run-automl`) for
+(`tao-run-deft-aoi`, shorthand `tao-deft-aoi`) for AOI iterative fine-tuning,
+`skills/applications/tao-run-deft-iaa/SKILL.md` (`tao-run-deft-iaa`, shorthand
+`tao-deft-iaa`) for the self-contained local-Docker IAA loop, and
+`skills/applications/tao-run-automl/SKILL.md` (`tao-run-automl`) for
 hyperparameter optimization. AutoML launch reviews should show the number of
 recommendations, metric, search space, expected runtime, and resolved train
 image before long-running jobs start.
@@ -160,7 +171,7 @@ image before long-running jobs start.
 | `skills/models/` | Network-centric skills: containers, commands, data formats, checkpoints | `tao-finetune-cosmos-reason`, `tao-train-visual-changenet`, `tao-finetune-clip`, `tao-train-dino`, `tao-train-segformer`, … |
 | `skills/data/` | Data preparation, analysis, and enhancement | `tao-mine-aoi-images`, `tao-analyze-gaps-visual-changenet`, `tao-route-visual-changenet-samples`, `tao-analyze-gaps-vlm-bcq`, `tao-convert-dataset-format`, `tao-validate-dataset-format`, `tao-generate-image-grounding`, `tao-generate-referring-expressions`, `tao-generate-video-reasoning-annotations` |
 | `skills/platform/` | Where and how jobs run | `tao-run-on-docker` (local daemon or `DOCKER_HOST=ssh://`), `tao-run-on-brev` (instance-based GPU), `tao-run-on-slurm` (remote SLURM cluster), `tao-run-on-kubernetes` (k8s), `tao-run-on-virtualenv` (docker-free local venv), `tao-data-io` (S3/data staging), `tao-setup-nvidia-gpu-host` (host runtime) |
-| `skills/applications/` | End-to-end workflows composing the layers above | `tao-run-deft-aoi`, `tao-run-automl-deft-pipeline`, `tao-analyze-changenet-rca`, `tao-train-single-step`, `tao-run-automl`, `tao-finetune-huggingface-model`, `tao-port-huggingface-model`, `tao-run-inference-service` |
+| `skills/applications/` | End-to-end workflows composing the layers above | `tao-run-deft-aoi`, `tao-run-deft-iaa`, `tao-run-automl-deft-pipeline`, `tao-analyze-changenet-rca`, `tao-train-single-step`, `tao-run-automl`, `tao-finetune-huggingface-model`, `tao-port-huggingface-model`, `tao-run-inference-service` |
 
 Each skill is a directory with `SKILL.md` (agent-readable instructions). Optional `references/skill_info.yaml` provides structured metadata (container image, per-action command/mode/inputs/outputs) the agent uses to construct the container command; optional `scripts/` bundles supporting code.
 
@@ -239,7 +250,7 @@ tao-skills-external/
 │   ├── install-codex-agents.sh       # one-shot Codex install: marketplace + plugin + AGENTS.md
 │   └── migrate-to-version-keys.py    # one-shot: literal nvcr.io paths → versions.yaml keys
 └── skills/
-    ├── applications/                 # 12 end-to-end workflow skills
+    ├── applications/                 # 13 end-to-end workflow skills
     ├── data/                         # 10 data preparation/analysis skills
     ├── models/                       # 53 network-centric skills
     ├── platform/                     # 7 compute backend / runtime skills

--- a/scripts/tests/test_iaa_deft_container.py
+++ b/scripts/tests/test_iaa_deft_container.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for IAA DEFT Docker GPU scoping."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+IAA_SCRIPTS = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "applications"
+    / "tao-run-deft-iaa"
+    / "scripts"
+)
+sys.path.insert(0, str(IAA_SCRIPTS))
+import run_deft_container as container  # noqa: E402
+
+
+def test_docker_gpu_args_use_exact_approved_devices():
+    assert container._docker_gpu_args(  # noqa: SLF001
+        {"gpu_ids": [0, 2], "num_gpus": 2}
+    ) == ["--gpus", '"device=0,2"']
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"gpu_ids": [], "num_gpus": 0},
+        {"gpu_ids": [0, 0], "num_gpus": 2},
+        {"gpu_ids": [0, 2], "num_gpus": 1},
+        {"gpu_ids": [True], "num_gpus": 1},
+    ],
+)
+def test_docker_gpu_args_reject_invalid_or_mismatched_state(config):
+    with pytest.raises(ValueError):
+        container._docker_gpu_args(config)  # noqa: SLF001

--- a/skills/applications/tao-run-deft-iaa/.env.example
+++ b/skills/applications/tao-run-deft-iaa/.env.example
@@ -1,0 +1,24 @@
+# tao-run-deft-iaa — optional shell-export template.
+#
+# The skill never loads an env file. If you use this template, source it in
+# your own shell before launching the agent; the workflow reads only inherited
+# environment-variable presence. Keep populated copies outside source control.
+#
+# The workflow checks only variable presence and never prints, persists, or
+# places credential values in argv. Do not commit populated copies.
+
+# === Container registry (NGC) ===
+# Gates nvcr.io pulls of the two TAO Toolkit images this workflow uses
+# (the pinned 7.1 PyTorch and data-services references recorded in run state).
+# Not needed when both images are already present locally.
+# Get a key at https://ngc.nvidia.com → Setup → API Key.
+export NGC_KEY=""
+
+# === HuggingFace ===
+# Usually NOT required: the SigLIP2 base weights this workflow pulls
+# (google/siglip2-so400m-patch16-256 — used for train/evaluate starts and
+# for text/image embedding in mining) are public. Set a token only behind a
+# deployment environment that requires authenticated model access.
+# Weights are cached under <workspace>/cache/huggingface between runs.
+# Get a token at https://huggingface.co/settings/tokens (read access is enough).
+export HF_TOKEN=""

--- a/skills/applications/tao-run-deft-iaa/SKILL.md
+++ b/skills/applications/tao-run-deft-iaa/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: tao-run-deft-iaa
+description: >
+  Run the self-contained DEFT improvement loop for NVIDIA TAO CLIP /
+  SigLIP2 Image Attribute Augmentation (IAA): dataset preparation, zero-shot
+  evaluation, attribute gap analysis, caption-space k-NN mining,
+  history-aware selection, retraining, and re-evaluation against an IAA
+  retrieval KPI. Use for requests to run or resume the IAA DEFT loop or improve
+  an IAA model until a metric target or iteration budget is reached. Treat
+  `tao-deft-iaa` as shorthand for this canonical `tao-run-deft-iaa` workflow.
+  Do not use for standalone CLIP training, one-off evaluation or embedding,
+  generic k-NN mining, or AOI/ChangeNet DEFT workflows.
+license: Apache-2.0 AND CC-BY-4.0
+compatibility: Requires Docker, NVIDIA Container Toolkit, accessible NVIDIA GPUs, the two IAA dataset export archives, and Python 3.9+ with the documented runtime dependencies.
+metadata:
+  author: NVIDIA Corporation
+  version: "0.3.3"
+allowed-tools: Read Bash Write
+tags:
+- application
+- workflow
+- deft
+- iaa
+- clip
+- retrieval
+- loop
+---
+
+# IAA DEFT Workflow
+
+> **Standalone install?** If this session was not initialized by the TAO skill
+> bank plugin, run the `tao-setup` skill first for host preflight, credential
+> checks, and cross-skill discovery.
+
+Run the canonical IAA flow as one resumable, disk-backed workflow. All IAA
+workflow logic, templates, and host adapters ship with this skill; customers do
+not need a separate source checkout. The bundled scripts make stage calls
+deterministic without adding another orchestration layer.
+
+This skill supports local Docker only. Do not ask the user to choose a
+platform or silently translate the workflow to SLURM, Kubernetes, or Brev.
+
+## Entry Contract
+
+`tao-deft-iaa` and `tao-run-deft-iaa` select this same workflow. IAA supports
+local Docker only, so that declaration is the platform selection. State it and
+do not ask the user to choose a platform.
+
+Use two intake phases:
+
+1. Perform only bounded, lightweight path discovery. Two explicit archive file
+   paths win and suppress all archive searching. An explicit archive directory
+   is treated as one approved search root. Otherwise, resolve the conventional
+   `~/workspace` and use only these deduplicated search roots: `~/iaa`, the
+   workspace root, and its `iaa/`, `input/`, and `inputs/` children. Check the
+   workspace root itself only; beneath each other search root, inspect the root
+   and directories at most two levels below it. This AOI-style bounded-subtree
+   lookup supports nested export/drop directories without turning into a home
+   or repository scan. Never follow symlinks or add the current checkout,
+   source repositories, tutorial/notebook trees, or workspace dataset-output
+   trees as implicit search roots.
+
+   An archive candidate contains direct regular-file children
+   `images_raw.tar` and `meta.tar.gz`; the workflow needs one such pair, not
+   multiple dataset directories. Follow the classification and provenance
+   format in `references/preflight.md` so the user sees every search root, its
+   reason and depth bound, the directory in which a pair was found, and whether
+   it is archive-only or mixed with extracted data.
+
+   Enumerate run-state files only at
+   `<workspace>/results/run_*/deft_state.json`. Read the minimal identity fields
+   and present a resume candidate only when `workflow` is exactly
+   `tao-run-deft-iaa`; never offer AOI or unidentified DEFT state as IAA.
+   Do not validate large archives to EOF or inspect Docker, images, GPUs, or
+   credentials yet.
+2. If `max_iterations` or a time budget is absent, ask one consolidated
+   question for that required value and any genuinely ambiguous path/run
+   choice. State the documented defaults and that a complete read-only
+   preflight plus approval summary follows. Do not ask whether the user wants
+   optional KPI, authentication, or parameter overrides; apply their defaults
+   unless the prompt already supplies an override.
+
+After required intake is resolved, discover and validate:
+
+- workspace and either a new `${RESULTS_DIR}` or one existing run to resume;
+- `images_raw.tar` and `meta.tar.gz`; `SHA256SUMS` is optional;
+- `max_iterations`, or a user-supplied time budget from which an iteration
+  limit can be estimated;
+- metric name, query type, operator, and optional target;
+- whether the deployment requires authenticated Hugging Face model access;
+- any explicit epoch, GPU, mining, continual-learning, or visualization
+  overrides.
+
+For a new run, `RESULTS_DIR` must be a child of `WORKSPACE`. `DATASET_ROOT`
+must be below a workspace data directory (for example
+`$WORKSPACE/data/iaa_v31_tao_ft`), not directly below the workspace; neither
+path may contain the other. All approved paths are absolute and non-symlink.
+
+Never replace an explicit value with a heuristic. Defaults apply only to
+unspecified values and must be identified as defaults in the pre-flight
+summary. `max_iterations` has no default. An absent metric target means an
+ungated run that stops after `max_iterations`. Hugging Face token forwarding
+defaults to disabled because the bundled model is public.
+
+If required information remains missing after full discovery, ask one
+consolidated follow-up. A normal invocation should need no knowledge of stage
+modules, container mounts, state files, or bundled-runtime function
+signatures.
+
+## Safety Gate
+
+Perform only read-only discovery before approval: resolve paths, inspect file
+metadata and archives, check process-environment variable presence, inspect
+local images, inspect GPUs, and audit an existing run. Credentials come only
+from the launching process environment. Never open, source, grep, or copy a
+credential file. If a required variable is absent, tell the user which name to
+export in the shell that launches the agent; never ask for its value in chat.
+Do not inspect credential-file metadata when no credential is needed. If the
+user explicitly asks for a file-permission check, `stat` only that named file,
+warn about group/other readability, and still do not load it.
+
+Show the summary defined in `references/preflight.md`, including every
+parameter and source, planned file creation/extraction, image pulls, estimated
+runtime, and resume status. Wait for explicit approval before Docker login or
+pulls, package installation, archive extraction, config/state creation, or any
+write under the workspace.
+
+If an approved parameter later changes, show the changed summary rows and get
+approval again before continuing. No confirmation is needed between unchanged,
+already-approved stages.
+
+## Execution Contract
+
+1. After approval, follow `references/preflight.md` to prepare the runtime,
+   materialize the immutable run config, and initialize state once. Never
+   reinitialize an existing run.
+2. Before every stage, after context compaction, and before any completion
+   claim, run:
+
+   ```bash
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/audit_deft_run.py" --results-dir "$RESULTS_DIR"
+   ```
+
+   Continue only when the audit reports `IN_PROGRESS` and its `next_action`
+   matches the intended stage. For `INVALID`, stop launching work and report
+   the listed inconsistency. For nonterminal `FAILED` whose `next_action` is
+   `loop_stop`, follow the pipeline reference and commit `hard_stop`; for
+   terminal `FAILED`, report the failure and launch no more work. For
+   `COMPLETE`, do not rerun a stage.
+3. Read only the current stage reference named by `read_before_action`. Use
+   `run_iaa_stage.py` for bundled IAA host stages and
+   `run_deft_container.py` for every TAO container command. These wrappers
+   reconstruct paths and images from state on each call, so do not depend on a
+   previous `cd` or `export`.
+4. A command succeeds only when its exit status is zero and its documented
+   output checks pass. Redirect verbose output to the wrapper-owned log;
+   inspect the final error block or at most the last 40 lines.
+5. Commit each successful or terminally failed stage exactly once with
+   `commit_stage.py`. It validates artifact structure, freshness, iteration
+   scope, command evidence, leakage, and transition order before applying a
+   recoverable, journaled update to `deft_state.json` and `loop_log.jsonl`.
+   Never call
+   `log_stage.py` or `record_metric_result.py` directly, and never hand-edit
+   canonical state, log, metric, or history files.
+6. Render the HTML report with `render_deft_report.py`. Reporting is a
+   deterministic read of audited state; it does not require another agent.
+
+All recorded artifact paths are absolute host paths under `${RESULTS_DIR}`.
+Baseline artifacts live under `zs/`, iteration N under `iter_N/`, and run-wide
+splits, source embeddings, and history files at the run root.
+
+## Workflow
+
+The normal path is linear, with only two meaningful decisions:
+
+```text
+pre-flight approval
+  -> dataset_setup -> pool_embed -> baseline evaluate
+  -> KPI met? yes: loop_stop
+              no: baseline gap_analysis
+  -> for N = 1..max_iterations:
+       data_mining -> history_select -> visualize -> train -> evaluate
+       -> KPI met? yes: loop_stop
+                   no and N < max: gap_analysis -> next iteration
+                   no and N = max: loop_stop
+  -> final audit -> HTML report
+```
+
+Stage ownership and exact commands are in
+`references/scripts-and-agents.md`. Read the detailed reference only when its
+stage is next:
+
+| Stage | Reference | Required result |
+|---|---|---|
+| dataset setup | `references/data-layout.md` | verified rebuilt dataset, five split files, non-empty source-pool parquet |
+| pool embedding and mining | `references/mining.md` | fresh command evidence plus non-empty, schema-checked parquet outputs |
+| evaluate and train | `references/clip-train-eval.md`, `references/metric-contract.md` | successful TAO status, bound metric evidence; for train, a fresh best and normalized checkpoint |
+| gap analysis | `references/gap-analysis.md` | non-empty iteration-scoped gaps parquet |
+| history selection | `references/mining.md` | budgeted mined set, cumulative/history entry, zero eval leakage |
+| visualization | `references/visualization.md` | enabled artifacts and command evidence, or a config-authorized skip |
+
+`visualize` is the only optional stage. Commit it with `--skip` only when both
+visualization settings are false in the approved config. Do not turn off a
+failing visualization mid-run without revising and reapproving the config.
+
+## Loop and Recovery Rules
+
+- The loop is bounded by `max_iterations`; never create an iteration outside
+  that range. Once the KPI passes, the only legal next transition is
+  `loop_stop`. Do not mine or train again.
+- Do not use open-ended polling. For a deliberately backgrounded container,
+  retain the process handle and poll no more often than every 30 seconds while
+  continuing to update the user.
+- Never repeat an unchanged failed command speculatively. Classify the failure,
+  inspect its final log block, make one evidence-based correction permitted by
+  the stage reference, then retry once. Stable command status records persist
+  attempt 1/2, and the wrappers refuse a third attempt after context loss. The
+  audit must pass before advancing.
+- A transient registry/network interruption or GPU contention may be retried
+  once after evidence shows the condition changed. A second equivalent failure
+  is terminal for the run.
+- Never retry checksum or rebuild verification failure, zero-row mining,
+  schema/cardinality failure, missing eval-split evidence, eval leakage,
+  history conflict that fails documented resume, metric-contract mismatch,
+  stale/cross-iteration output, or an unsupported GPU architecture. Commit an
+  error when state permits and stop with the exact recovery action.
+- If a command wrote outputs but crashed before stage commit, run the audit.
+  Reuse outputs only when their command status is successful, fresh, correctly
+  scoped, and all stage validators pass. History selection has one supported
+  recovery: rerun the deterministic adapter with `--resume`; never delete or
+  edit a history entry by hand.
+- Manual modification or truncation of `deft_state.json` or `loop_log.jsonl`
+  invalidates the run. Preserve it for diagnosis and start a new results
+  directory.
+
+## Metric and Stop Semantics
+
+The approved metric contract is immutable for the run. Evaluation must parse
+the exact iteration's `nvidia_iaa_metrics_aggregate.csv`; the result records
+its source path and is re-derived during commit and audit. Checkpoint ranking
+and best-run reporting follow the approved operator (`>=`/`>` chooses the
+higher value, `<=`/`<` the lower), not a hard-coded metric convention.
+
+Successful completion is exactly one of:
+
+- `loop_stop(reason=kpi_met)` after a bound evaluation satisfies its target;
+- `loop_stop(reason=max_iterations)` after the final allowed evaluation when
+  the target is unmet or absent.
+
+`hard_stop` is a failed terminal outcome, not successful completion.
+
+## Completion
+
+At a normal loop boundary:
+
+1. commit `loop_stop` with the audit-selected reason;
+2. render `${RESULTS_DIR}/DEFT_Loop_Report.html` with trigger `loop-end`;
+3. require this command to exit zero:
+
+   ```bash
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/audit_deft_run.py" \
+       --results-dir "$RESULTS_DIR" --require-complete
+   ```
+
+Report the stop reason, baseline and best metric, best iteration/checkpoint,
+completed iteration count, report path, and any warnings. A checkpoint, CSV,
+HTML file, or assistant statement alone is not completion evidence.
+
+## Progressive References
+
+| Need | Read |
+|---|---|
+| read-only checks, approval summary, initialization | `references/preflight.md` |
+| stage commands and script interfaces | `references/scripts-and-agents.md` |
+| state transitions and resume behavior | `references/pipeline-and-state.md` |
+| dataset/archive contract | `references/data-layout.md` |
+| KPI parsing and evidence | `references/metric-contract.md` |
+| gap generation | `references/gap-analysis.md` |
+| embeddings, k-NN, selection | `references/mining.md` |
+| contact sheets and t-SNE | `references/visualization.md` |
+| train/evaluate/checkpoints | `references/clip-train-eval.md` |

--- a/skills/applications/tao-run-deft-iaa/eval.config
+++ b/skills/applications/tao-run-deft-iaa/eval.config
@@ -1,0 +1,40 @@
+{
+  "type": "plugin-workflow-eval",
+  "plugin_name": "tao-skills",
+  "plugin_source": ".",
+  "skills_dir": [
+    "skills/applications/tao-run-deft-iaa"
+  ],
+  "orchestrator_skill": "skills/applications/tao-run-deft-iaa",
+  "evals": [
+    {
+      "id": "iaa-deft-plan",
+      "prompt": "Plan, but do not execute, a Docker-based two-iteration IAA DEFT run using the self-contained tao-run-deft-iaa skill, the default Rank-1 (medium) metric, and no target. Explain read-only preflight, the approval boundary, deterministic config/state initialization, dataset_setup and one-time pool_embed, zero-shot evaluation, the bounded per-iteration gap/mining/history/visualization/train/evaluate flow, recovery, state commits, and completion evidence. Do not run commands, scripts, containers, installs, web searches, or any other tools; describe the documented plan only.",
+      "expected_outcome": "The answer describes Docker as the sole execution path rather than asking the user to select a platform. It preserves max_iterations=2, inventories the two IAA archives and optional SHA256SUMS without reading credential files, requires no implementation checkout, and places all image pulls, dependency installs, extraction, config rendering, and state creation after one explicit approval summary. It uses prepare_deft_config.py and init_deft_state.py once, run_deft_container.py for reproducible container launches and command-status evidence, run_iaa_stage.py with the bundled IAA runtime for deterministic host stages, and deft_python.sh --workspace ... --runtime for runtime Python. The plan runs dataset_setup, embeds the caption pool once, evaluates the zero-shot baseline, then uses a bounded gap_analysis -> data_mining -> history_select -> optional visualize -> train -> evaluate loop. Every transition is validated and committed, iteration labels and metric CSVs are evidence-bound, recovery is bounded, and completion requires audit_deft_run.py --require-complete plus deterministic render_deft_report.py output. The response remains plan-only."
+    }
+  ],
+  "credentials": [
+    {
+      "name": "NGC_KEY",
+      "description": "NGC API key for nvcr.io pulls of the two pinned TAO Toolkit 7.1 images. Not required when both images are already present locally. The skill checks process-environment presence only and never opens or sources a credential file."
+    },
+    {
+      "name": "HF_TOKEN",
+      "description": "HuggingFace token. Usually not required because google/siglip2-so400m-patch16-256 is public. Needed only when the deployment environment requires authenticated model access. The skill checks process-environment presence only; immutable approval records only whether forwarding is required, and the wrapper forwards the environment name without persisting the value."
+    }
+  ],
+  "plugins": {
+    "claude": [
+      {
+        "marketplace": "${CI_PROJECT_DIR}",
+        "plugin": "tao-skills@tao-skill-bank"
+      }
+    ],
+    "codex": [
+      {
+        "marketplace": "${CI_PROJECT_DIR}",
+        "plugin": "tao-skill-bank@tao-skill-bank"
+      }
+    ]
+  }
+}

--- a/skills/applications/tao-run-deft-iaa/evals/evals.json
+++ b/skills/applications/tao-run-deft-iaa/evals/evals.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "tao-run-deft-iaa-basic",
+    "question": "A user says: \"Use the tao-run-deft-iaa skill to plan an IAA DEFT run.\" Identify the applicable skill and outline its documented workflow. This is a planning evaluation: do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Identify tao-run-deft-iaa and describe its self-contained Docker-only, disk-backed workflow: read-only preflight and one approval boundary; deterministic config/state initialization; dataset setup and one-time pool embedding; zero-shot evaluation; a bounded gap, mining, history-selection, optional-visualization, train, and evaluate loop; validated commits; final audit and deterministic report. The customer supplies data archives, not an implementation checkout. Do not execute anything.",
+    "expected_behavior": [
+      "Identifies tao-run-deft-iaa as the relevant self-contained skill and does not request an implementation checkout",
+      "Describes Docker as the sole execution path without asking the user to choose a platform",
+      "Outlines read-only preflight, one approval boundary, deterministic initialization, dataset_setup, pool_embed, zero-shot evaluate, and the bounded per-iteration loop",
+      "Explains that each stage is artifact-validated before a canonical state commit and that completion requires a successful require-complete audit",
+      "Does not run commands, scripts, containers, installs, web searches, audits, or other tools"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-clean-intake",
+    "question": "Plan the initial intake after installing the TAO skill bank and asking to run tao-deft-iaa. Do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Resolve tao-deft-iaa as shorthand for canonical tao-run-deft-iaa and describe its initial intake without executing it. State that IAA fixes the platform to local Docker. If no archive input was supplied, explain the documented bounded search: candidate depth 0..2 beneath ~/iaa and workspace iaa/input/inputs roots, and depth 0 at the workspace root. Never search home broadly or add repositories, tutorial/notebook trees, or workspace data outputs as implicit roots. Do not follow symlinks. Explain that execution will report each absolute search root, reason, depth bound and status, then each archive candidate's containing directory, depth, classification, exact archive file paths and sizes, and IAA-only resume candidates. Ask one consolidated question for max_iterations or a time budget plus any genuinely ambiguous archive/run choice. Apply and state all other documented defaults rather than asking about optional KPI, Hugging Face authentication, or overrides. Explain that full archive/Docker/GPU/environment-presence discovery and one complete approval summary follow, and do not install, create files, inspect credential files, log in, pull, or run containers yet.",
+    "expected_behavior": [
+      "Routes tao-deft-iaa to the canonical tao-run-deft-iaa skill",
+      "Treats local Docker as fixed by the application and does not ask for a platform",
+      "Asks only for max_iterations or a time budget and any genuinely ambiguous input selection",
+      "Explains that execution will report each bounded archive search root, reason, depth cap and status, identify one required archive pair rather than present directory names as multiple required datasets, and avoid broad home or repository/tutorial searches",
+      "Presents only state whose workflow is exactly tao-run-deft-iaa as a resume candidate",
+      "States the metric, epoch, GPU, mining, history, continual, visualization, and token-forwarding defaults without asking the user to customize them",
+      "Defers full archive, Docker, image, GPU, and credential-presence checks until required intake is resolved",
+      "Promises a complete preflight summary and explicit approval before installs, writes, logins, pulls, downloads, extraction, or container execution",
+      "Does not read or source credential files"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-discovery-provenance",
+    "question": "Plan the first read-only intake for tao-deft-iaa with no archive path and no iteration bound. Assume ~/iaa directly contains images_raw.tar and meta.tar.gz; a tao-tutorials checkout elsewhere under the home directory contains copies plus extracted images/captions/pair files; and ~/workspace/results/run_old/deft_state.json identifies workflow tao-run-deft-aoi. Do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Use canonical tao-run-deft-iaa and local Docker. Describe checking only the documented conventional archive roots, not recursively scanning home or the tao-tutorials checkout. Report ~/iaa as the sole archive-only candidate, show its two exact archive file paths as one required pair, and explain that it came from current-filesystem discovery of the conventional ~/iaa root. Exclude the AOI state from IAA resume choices and label it ignored as non-IAA. Then ask for max_iterations or a time budget while stating the documented defaults and deferring full preflight and all mutations.",
+    "expected_behavior": [
+      "Names tao-run-deft-iaa as canonical and local Docker as fixed",
+      "States that ~/iaa was checked because it is the documented conventional IAA archive root and that recursive home/repository searches were not performed",
+      "Describes ~/iaa as one archive-only root containing the required images_raw.tar and meta.tar.gz pair, not as one of two required dataset folders",
+      "Does not surface the tao-tutorials extracted development directory as an automatically discovered candidate",
+      "Excludes run_old because its workflow is tao-run-deft-aoi and does not offer it for IAA resume",
+      "Asks for max_iterations or a time budget, states defaults, and performs no writes, installs, archive validation, credential inspection, or workload execution"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-bounded-nested-discovery",
+    "question": "Plan the first read-only intake for tao-deft-iaa with no archive path. Assume ~/iaa/drop/iaa_v31_tao_ft contains the required images_raw.tar and meta.tar.gz; ~/iaa/too/deep/export/iaa_v32 contains another pair; a tao-tutorials checkout elsewhere under the home directory also contains a pair; and ~/workspace/input/latest is a symlink to that tutorial directory. Do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Use canonical tao-run-deft-iaa and fixed local Docker. Explain the bounded AOI-style subtree lookup: inspect candidate directories only at depth 0..2 under ~/iaa and the workspace iaa/input/inputs roots, inspect the workspace root only at depth 0, and do not follow symlinks. Therefore select ~/iaa/drop/iaa_v31_tao_ft as the sole in-scope archive candidate, with provenance showing it was found at depth 2 under the conventional ~/iaa root. Do not discover the depth-3 IAA pair, the unrelated tutorial checkout, or the target of the workspace/input/latest symlink. Report the exact two files as one pair, then ask for the missing iteration/time bound while stating defaults and deferring full preflight and all mutations.",
+    "expected_behavior": [
+      "Names tao-run-deft-iaa as canonical and local Docker as fixed",
+      "Uses only the documented semantic search roots and caps candidate-directory recursion at depth 2, while checking the workspace root at depth 0 only",
+      "Finds ~/iaa/drop/iaa_v31_tao_ft at candidate depth 2 and reports the conventional ~/iaa search-root reason and exact archive pair",
+      "Does not include the depth-3 pair, scan the unrelated tao-tutorials checkout, or follow the workspace/input/latest symlink",
+      "Auto-selects the sole in-scope archive-only candidate and does not describe the two archive files as two dataset folders",
+      "Asks for max_iterations or a time budget, states defaults, and performs no writes, installs, full archive validation, credential inspection, or workload execution"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-explicit-root-ambiguity",
+    "question": "Plan IAA DEFT intake when I explicitly give /mnt/iaa-drop as the archive directory. It contains valid pairs under release/v31 and release/v32, while ~/iaa also contains a valid pair. I have not supplied an iteration bound. Do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Treat /mnt/iaa-drop as the sole user-approved search root, search candidate directories only at depth 0..2 beneath it, and suppress all conventional-root searching. Report release/v31 and release/v32 as alternative archive roots with exact pair paths, candidate depth and user-supplied-root provenance. Do not inspect or mention ~/iaa as a discovered candidate and do not choose by order, name, timestamp, or size. Ask one consolidated question for the archive-root choice and max_iterations or a time budget; state all other defaults and defer full validation and mutations.",
+    "expected_behavior": [
+      "Uses canonical tao-run-deft-iaa and fixed local Docker",
+      "Searches only the explicit /mnt/iaa-drop subtree to candidate depth 2 and does not fall back to conventional roots",
+      "Reports both nested pairs as alternatives with exact paths, depths, and user-supplied-root provenance",
+      "Does not guess between candidates using search order, name, modification time, or archive size",
+      "Combines the archive choice and missing iteration/time bound into one question while applying documented optional defaults",
+      "Performs no filesystem inspection in this plan-only evaluation and defers full validation and every mutation"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-resume-plan",
+    "question": "Describe how you would safely resume an existing IAA DEFT run at $RESULTS_DIR and determine its single next action before GPU work. Do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": "scripts/audit_deft_run.py",
+    "ground_truth": "Explain that execution would begin with deft_python.sh invoking the read-only audit_deft_run.py against $RESULTS_DIR. Canonical deft_state.json and loop_log.jsonl override prose or reports; INVALID is a hard stop; the audit's read_before_action and next_action identify the only permitted stage. No work is executed in this evaluation.",
+    "expected_behavior": [
+      "Names scripts/audit_deft_run.py as the first command that would be used, through scripts/deft_python.sh",
+      "Treats deft_state.json plus loop_log.jsonl as canonical rather than inferring status from checkpoints, reports, metrics, or prior prose",
+      "States that DEFT_RUN_STATUS=INVALID is a hard stop requiring repair of the reported inconsistency",
+      "Uses the audit's read_before_action and next_action as the only permitted continuation",
+      "Does not inspect the run, launch containers or GPU work, mutate files, or execute any command"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-metric-contract",
+    "question": "Plan a Docker-based IAA DEFT run whose gate is Rank-1 >= 0.25 on medium queries, for at most 3 iterations. Explain deterministic configuration, state, evaluation evidence, checkpoint selection, stopping, audit, and reporting. Do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": "scripts/prepare_deft_config.py",
+    "ground_truth": "Render and approve the immutable metric contract {Rank-1, medium, >=, 0.25} with max_iterations=3, then initialize state from the rendered config. At execution time, bind every baseline/iteration result to its exact nvidia_iaa_metrics_aggregate.csv and iteration label, recompute the value with bundled metric tooling, stop when the gate passes or the budget is exhausted, select the highest Rank-1 result because the approved operator is >=, verify completion with audit_deft_run.py --require-complete, and render the HTML report deterministically. This evaluation executes nothing.",
+    "expected_behavior": [
+      "Preserves the metric contract as metric_name Rank-1, query_type medium, operator >=, target 0.25 and max_iterations=3",
+      "Uses prepare_deft_config.py before one-time state initialization so approved values and config hashes are recorded",
+      "Requires each result to be bound to the exact iteration label and aggregate metrics CSV, with the metric value recomputed rather than trusted from prose",
+      "Requires training evidence to bind the exact approved clip train command, TAO success status, and a current-iteration raw checkpoint behind the canonical best path before evaluation",
+      "Runs the zero-shot evaluation before training, stops early on a passing gate, and otherwise stops after three iterations",
+      "Selects the highest Rank-1 result under the >= operator and claims completion only after a successful require-complete audit and deterministic report render",
+      "Does not run scripts, containers, training, inference, audits, web searches, or other tools"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-history-recovery-plan",
+    "question": "While planning recovery for iteration 2, you learn that mining_selection_history.json already contains iter2 but canonical state does not show history_select committed. Explain the likely interruption and the sanctioned recovery. Do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": "scripts/run_iaa_stage.py",
+    "ground_truth": "The prior attempt likely stopped after iaa_deft atomically wrote the iteration-2 history ledger entry but before commit_stage.py committed canonical stage state. After an audit confirms this exact recoverable condition, rerun the deterministic history-select adapter once with --resume so it validates and reuses the matching ledger/artifacts, then commit and re-audit. Never hand-edit the ledger, deft_state.json, or loop_log.jsonl, and never delete earlier iteration history. This evaluation executes nothing.",
+    "expected_behavior": [
+      "Diagnoses an interruption between the iaa_deft history ledger write and the canonical history_select commit",
+      "Uses scripts/run_iaa_stage.py history-select --resume only after the audit identifies the matching recoverable state",
+      "Requires the adapter to validate the existing iteration entry and artifacts before reuse",
+      "Never proposes hand-editing mining_selection_history.json, deft_state.json, or loop_log.jsonl, or deleting earlier history",
+      "Bounds recovery to one rerun followed immediately by commit validation and a read-only re-audit",
+      "Does not inspect files, mutate the run, or execute any command"
+    ]
+  }
+]

--- a/skills/applications/tao-run-deft-iaa/patches/sitecustomize.py
+++ b/skills/applications/tao-run-deft-iaa/patches/sitecustomize.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Allow numpy checkpoint scalars under torch's weights-only loader.
+
+TAO CLIP optimizer checkpoints may contain numpy scalar/dtype objects.  Torch
+2.6+ rejects those objects unless their concrete dtype classes are allowlisted.
+The container wrapper mounts this module through ``PYTHONPATH``; keep this behavior
+for the skill until the container includes the fix.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from importlib.abc import Loader, MetaPathFinder
+
+
+def _register_safe_globals(torch_module):
+    try:
+        import numpy as np
+
+        serialization = importlib.import_module("torch.serialization")
+        safe_globals = [np.dtype, np.ndarray]
+        dtypes_module = getattr(np, "dtypes", None)
+        if dtypes_module is not None:
+            for name in dir(dtypes_module):
+                candidate = getattr(dtypes_module, name)
+                if isinstance(candidate, type) and issubclass(candidate, np.dtype):
+                    safe_globals.append(candidate)
+        try:
+            from numpy._core.multiarray import scalar as np_scalar
+        except ImportError:
+            from numpy.core.multiarray import scalar as np_scalar
+        safe_globals.append(np_scalar)
+        serialization.add_safe_globals(safe_globals)
+    except Exception:
+        # A compatibility patch must never make plain interpreter startup fail.
+        pass
+
+
+class _PostImportLoader(Loader):
+    def __init__(self, loader):
+        self._loader = loader
+
+    def create_module(self, spec):
+        return self._loader.create_module(spec)
+
+    def exec_module(self, module):
+        self._loader.exec_module(module)
+        _register_safe_globals(module)
+
+    def __getattr__(self, name):
+        return getattr(self._loader, name)
+
+
+class _TorchImportHook(MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != "torch":
+            return None
+        sys.meta_path.remove(self)
+        try:
+            spec = importlib.util.find_spec(fullname)
+        except Exception:
+            return None
+        finally:
+            sys.meta_path.insert(0, self)
+        if spec is None or spec.loader is None:
+            return None
+        spec.loader = _PostImportLoader(spec.loader)
+        return spec
+
+
+if "torch" in sys.modules:
+    _register_safe_globals(sys.modules["torch"])
+else:
+    sys.meta_path.insert(0, _TorchImportHook())

--- a/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
+++ b/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
@@ -1,0 +1,189 @@
+# CLIP Train and Evaluate
+
+Read with `metric-contract.md` when the audit selects `train` or `evaluate`.
+The IAA workflow uses plain TAO CLIP train/evaluate commands. There is no
+AutoML branch and no hand-authored per-stage YAML.
+
+## Contents
+
+- [Evaluate](#evaluate)
+- [Train](#train)
+- [Failure handling](#failure-handling)
+
+## Evaluate
+
+The baseline uses the public SigLIP2 base weights and the `zs/` directory.
+Iteration N uses its freshly published best checkpoint and `iter_N/`.
+
+1. Generate the exact eval config:
+
+   ```bash
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/run_iaa_stage.py" eval-config \
+       --results-dir "$RESULTS_DIR" \
+       --deft-config "$RESULTS_DIR/config/deft_config.yaml" \
+       --iter-label "$LABEL"
+   ```
+
+2. Set `PHASE_DIR="$RESULTS_DIR/zs"` and `CONTAINER_PHASE=zs` for `baseline`;
+   otherwise set `PHASE_DIR="$RESULTS_DIR/iter_$N"` and
+   `CONTAINER_PHASE="iter_$N"`. Launch evaluation with both canonical outputs
+   marked fresh:
+
+   ```bash
+   EVAL_DIR="$PHASE_DIR/evaluate"
+   METRICS="$EVAL_DIR/nvidia_iaa_metrics_aggregate.csv"
+   TAO_STATUS="$EVAL_DIR/status.json"
+   HF_ARGS=()
+   if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+     HF_ARGS=(--pass-hf-token)
+   fi
+
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+     "$SKILL_ROOT/scripts/run_deft_container.py" \
+       --results-dir "$RESULTS_DIR" --image pyt \
+       --stage-dir "$EVAL_DIR" --name evaluate \
+       "${HF_ARGS[@]}" \
+       --fresh-output "$METRICS" --fresh-output "$TAO_STATUS" -- \
+       clip evaluate -e "/results/$CONTAINER_PHASE/specs/eval_config.yaml"
+   ```
+
+   The Docker exit must be zero, the aggregate CSV must be non-empty, and the
+   TAO status must contain `Evaluate finished successfully`. A stale CSV next
+   to a failed status is not evidence.
+3. Parse the approved metric contract exactly as shown in
+   `metric-contract.md`. For an iteration, also bind the canonical summary:
+
+   ```bash
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/run_iaa_stage.py" iteration-summary \
+       --results-dir "$RESULTS_DIR" \
+       --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N"
+   ```
+
+   Do not run `iteration-summary` for baseline.
+4. Commit evaluation with exact paths:
+
+   ```bash
+   SUMMARY_ARGS=()
+   if [ "$LABEL" != baseline ]; then
+     SUMMARY_ARGS=(
+       --iteration-summary "$PHASE_DIR/iteration_summary.json"
+       --iteration-summary-status \
+         "$PHASE_DIR/iteration-summary.host.status.json"
+     )
+   fi
+
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/commit_stage.py" \
+       --results-dir "$RESULTS_DIR" --iter-label "$LABEL" --stage evaluate \
+       --metrics-aggregate-csv "$METRICS" \
+       --eval-status-json "$TAO_STATUS" \
+       --metric-result "$EVAL_DIR/metric_result.json" \
+       --eval-command-status "$EVAL_DIR/evaluate.status.json" \
+       --eval-config "$PHASE_DIR/specs/eval_config.yaml" \
+       --eval-config-status "$PHASE_DIR/specs/eval-config.host.status.json" \
+       "${SUMMARY_ARGS[@]}" \
+       --summary "$LABEL IAA evaluation completed"
+   ```
+
+The commit reopens the CSV and re-derives the metric. It rejects a result from
+another label/path even when its numeric value is plausible.
+
+## Train
+
+1. Generate the canonical train config:
+
+   ```bash
+   ITER_DIR="$RESULTS_DIR/iter_$N"
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/run_iaa_stage.py" train-config \
+       --results-dir "$RESULTS_DIR" \
+       --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N"
+   ```
+
+   In the default continual-dataset/non-continual-model mode, the accumulated
+   mined datasets are included but training starts from the configured base
+   model each iteration. With approved continual-model mode, the adapter uses
+   the prior iteration's normalized state. Never hand-edit the generated YAML.
+2. Recheck occupancy for the approved GPU IDs. If the shape must change, stop
+   for a revised pre-flight approval and begin a new immutable run; do not
+   patch the current config.
+3. Launch plain training. Mark TAO's own training status fresh; the canonical
+   best checkpoint does not exist until the following publisher step:
+
+   ```bash
+   TRAIN_DIR="$ITER_DIR/train"
+   BEST="$TRAIN_DIR/best/clip_best_val_t2i_mAP.pth"
+   TRAIN_TAO_STATUS="$TRAIN_DIR/status.json"
+   HF_ARGS=()
+   if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+     HF_ARGS=(--pass-hf-token)
+   fi
+
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+     "$SKILL_ROOT/scripts/run_deft_container.py" \
+       --results-dir "$RESULTS_DIR" --image pyt \
+       --stage-dir "$TRAIN_DIR" --name train \
+       "${HF_ARGS[@]}" \
+       --fresh-output "$TRAIN_TAO_STATUS" -- \
+       clip train -e "/results/iter_$N/specs/train_config.yaml"
+   ```
+
+4. Only after a zero container exit, select the best validation
+   checkpoint and create the normalized warm-start state:
+
+   ```bash
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/run_iaa_stage.py" publish-checkpoint \
+       --results-dir "$RESULTS_DIR" \
+       --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N" \
+       --train-command-status "$TRAIN_DIR/train.status.json"
+   ```
+
+   This must produce both:
+
+   ```text
+   iter_N/train/best/clip_best_val_t2i_mAP.pth
+   iter_N/pretrained/model_state.pth
+   ```
+
+   The first is the raw evaluation checkpoint; the second is the normalized
+   model-only warm-start form.
+5. Commit:
+
+   ```bash
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/commit_stage.py" \
+       --results-dir "$RESULTS_DIR" --iter-label "iter$N" --stage train \
+       --best-ckpt "$BEST" \
+       --pretrained-state "$ITER_DIR/pretrained/model_state.pth" \
+       --train-config "$ITER_DIR/specs/train_config.yaml" \
+       --train-config-status "$ITER_DIR/specs/train-config.host.status.json" \
+       --train-command-status "$TRAIN_DIR/train.status.json" \
+       --train-tao-status-json "$TRAIN_TAO_STATUS" \
+       --publish-checkpoint-status \
+         "$TRAIN_DIR/publish-checkpoint.host.status.json" \
+       --summary "iter$N TAO CLIP training and checkpoint publication completed"
+   ```
+
+The validator requires TAO's `Train finished successfully.` marker, an exact
+approved `clip train` argv digest, and a selected raw checkpoint newer than
+that launch. The canonical relative symlink is allowed only when it
+resolves directly to a regular checkpoint inside this iteration's `train/`;
+its metadata-backed hardlink/copy fallbacks are also accepted. Symlink chains,
+stale targets, and cross-iteration targets are rejected.
+
+## Failure handling
+
+- Nonzero Docker exit: inspect the wrapper log's last meaningful error block,
+  do not publish or evaluate outputs, and apply at most one documented retry.
+- CUDA OOM caused by changed occupancy: retry the same approved shape once
+  after those GPUs are free. Config reshaping requires a new run.
+- Hydra reports an unknown key: regenerate the config; never add `workflow` or
+  `automl_policy` to TAO YAML.
+- A PyTorch 2.6+ NumPy dtype allowlist error: the container wrapper already
+  mounts the bundled `sitecustomize.py`. If the error persists, hard-stop
+  rather than weakening checkpoint loading.
+- Eval success marker absent: treat all CSVs from that launch as partial and
+  do not parse or commit them.

--- a/skills/applications/tao-run-deft-iaa/references/data-layout.md
+++ b/skills/applications/tao-run-deft-iaa/references/data-layout.md
@@ -1,0 +1,154 @@
+# Dataset Setup and Layout
+
+Read during pre-flight and when the audit selects
+`baseline/dataset_setup`.
+
+## Contents
+
+- [Input contract](#input-contract)
+- [Approved extraction and rebuild](#approved-extraction-and-rebuild)
+- [Materialize run splits and pool](#materialize-run-splits-and-pool)
+- [Run output layout](#run-output-layout)
+
+## Input contract
+
+The IAA TAO-FT export contains:
+
+| File | Required | Expected content |
+|---|---|---|
+| `images_raw.tar` | yes | source images under `images_raw/<source_split>/...` |
+| `meta.tar.gz` | yes | pair/list metadata, README/vocabulary files, and `rebuild.py` |
+| `SHA256SUMS` | no | checksums for the two archives |
+
+There is no download branch. Preserve the archives in place; extraction goes
+to the approved `DATASET_ROOT`. Do not copy multi-gigabyte archives into the
+dataset tree.
+
+## Approved extraction and rebuild
+
+Only after the pre-flight gate:
+
+```bash
+set -e
+set -o pipefail
+mkdir -p "$DATASET_ROOT" "$RESULTS_DIR/dataset_setup"
+
+# Execute only when a manifest was approved. Persist pass/fail, not digest
+# values or the manifest contents.
+if [ -n "${CHECKSUMS_FILE:-}" ]; then
+  if (cd "$(dirname "$CHECKSUMS_FILE")" && \
+      sha256sum --check --status "$(basename "$CHECKSUMS_FILE")"); then
+    printf 'CHECKSUM_VERIFY: PASS\n' \
+      >"$RESULTS_DIR/dataset_setup/checksum_verify.log"
+  else
+    printf 'CHECKSUM_VERIFY: FAIL\n' \
+      >"$RESULTS_DIR/dataset_setup/checksum_verify.log"
+    exit 1
+  fi
+fi
+
+tar -xzf "$METADATA_ARCHIVE" -C "$DATASET_ROOT"
+tar -xf "$IMAGES_ARCHIVE" -C "$DATASET_ROOT"
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$DATASET_ROOT/rebuild.py" --workers 16 \
+  2>&1 | tee "$RESULTS_DIR/dataset_setup/rebuild_verify.log"
+```
+
+Omit the checksum command when no manifest was approved. A checksum mismatch,
+tar failure, missing `rebuild.py`, or nonzero rebuild is a hard stop. The
+rebuild log must contain `VERIFY: PASS`; `VERIFY: FAIL` or a missing pass line
+is not valid evidence. Do not continue using a partly rebuilt dataset.
+
+The rebuild creates the canonical TAO-facing structure:
+
+```text
+DATASET_ROOT/
+├── images_raw/
+├── images/
+├── captions/
+├── train_pairs.json
+├── val_pairs.json
+└── rebuild.py
+```
+
+## Materialize run splits and pool
+
+Run the deterministic adapter; it calls the bundled
+`materialize_iaa_eval_split`, `materialize_iaa_pool_split`, and
+`convert_clip_image_list_to_parquet` with the immutable config:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/run_iaa_stage.py" dataset-materialize \
+    --results-dir "$RESULTS_DIR" \
+    --deft-config "$RESULTS_DIR/config/deft_config.yaml"
+```
+
+Required outputs are exact, not glob-selected:
+
+```text
+iaa_splits/eval_list.txt
+iaa_splits/eval_pairs.json
+iaa_splits/val_list.txt
+iaa_splits/aug_pool_list.txt
+iaa_splits/aug_pool_pairs.json
+embeddings/source/source_pool.parquet
+```
+
+The commit validator checks all split files, JSON structure, non-empty parquet
+rows/schema, and dataset links/files. When a checksum manifest was approved,
+also pass its exact verification log. Commit only after the adapter succeeds:
+
+```bash
+CHECKSUM_ARGS=()
+if [ -n "${CHECKSUMS_FILE:-}" ]; then
+  CHECKSUM_ARGS+=(--checksum-verify-log \
+    "$RESULTS_DIR/dataset_setup/checksum_verify.log")
+fi
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label baseline \
+    --stage dataset_setup \
+    --iaa-splits-dir "$RESULTS_DIR/iaa_splits" \
+    --source-pool-parquet "$RESULTS_DIR/embeddings/source/source_pool.parquet" \
+    --verify-log "$RESULTS_DIR/dataset_setup/rebuild_verify.log" \
+    --dataset-materialize-status \
+      "$RESULTS_DIR/dataset_setup/dataset-materialize.host.status.json" \
+    "${CHECKSUM_ARGS[@]}" \
+    --summary "IAA dataset rebuilt and run splits materialized"
+```
+
+Then run the audit. The only legal next stage is `baseline/pool_embed`.
+
+## Run output layout
+
+These names are canonical IAA conventions and must not be renamed:
+
+```text
+RESULTS_DIR/
+├── config/                         immutable copied specs
+├── deft_state.json
+├── loop_log.jsonl
+├── dataset_setup/                  rebuild_verify.log; optional checksum_verify.log
+├── iaa_splits/                     eval, validation, and mining-pool files
+├── embeddings/source/              source_pool.parquet, embeddings.parquet
+├── caption_selection_history.json
+├── mining_selection_history.json
+├── zs/                             baseline eval
+└── iter_N/
+    ├── gaps/
+    ├── embeddings/
+    ├── mining/
+    ├── visualization/
+    ├── specs/
+    ├── train/
+    ├── pretrained/
+    ├── evaluate/
+    └── iteration_summary.json
+```
+
+The caption mining pool comes from training pairs. The eval split comes from
+validation pairs. History selection still rechecks basename disjointness
+before every training iteration; source assumptions never replace that gate.

--- a/skills/applications/tao-run-deft-iaa/references/gap-analysis.md
+++ b/skills/applications/tao-run-deft-iaa/references/gap-analysis.md
@@ -1,0 +1,57 @@
+# Gap Analysis
+
+Run gap analysis only after an evaluation fails its KPI gate (or has no target)
+and another iteration remains.
+
+The stage is committed under the label whose evaluation it analyzes, but its
+artifact belongs to the iteration it feeds:
+
+| Evaluated label | `--iter-label` at commit | Feed iteration / output |
+|---|---|---|
+| baseline | `baseline` | `iter_1/gaps/kpi_gaps.parquet` |
+| iterN | `iterN` | `iter_<N+1>/gaps/kpi_gaps.parquet` |
+
+Do not run a gap stage after a passing KPI or after the final allowed
+iteration. The transition validator rejects both paths.
+
+## Command
+
+Let `FEED_N=1` for baseline, otherwise the evaluated iteration plus one:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/run_iaa_stage.py" gap-analysis \
+    --results-dir "$RESULTS_DIR" \
+    --deft-config "$RESULTS_DIR/config/deft_config.yaml" \
+    --iter-num "$FEED_N"
+```
+
+The adapter resolves the exact preceding eval directory through the bundled IAA runtime,
+uses the configured IAA eval split and gap metric, applies caption-diversity
+limits, and writes the iteration-scoped parquet. It also maintains
+`caption_selection_history.json` using the runtime's idempotent iteration
+semantics.
+
+The output must be a non-empty parquet with `filepath`, `text`, and
+`weak_attribute`. If the metric gate is unmet but no gap row can be produced,
+hard-stop: the query type, metric, or slicing contract is inconsistent. Do not
+mine the full pool as a fallback.
+
+Commit:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "$EVALUATED_LABEL" \
+    --stage gap_analysis \
+    --gaps-parquet "$RESULTS_DIR/iter_$FEED_N/gaps/kpi_gaps.parquet" \
+    --caption-history "$RESULTS_DIR/caption_selection_history.json" \
+    --gap-analysis-status \
+      "$RESULTS_DIR/iter_$FEED_N/gaps/gap-analysis.host.status.json" \
+    --summary "$EVALUATED_LABEL gap analysis prepared iteration $FEED_N"
+```
+
+Run the audit. The only legal next action is `iter$FEED_N/data_mining`.
+If a process ended after the caption ledger write but before this commit, the
+audit reports the one in-flight feed as a warning. Rerun the same idempotent
+adapter once and commit; never edit the ledger manually.

--- a/skills/applications/tao-run-deft-iaa/references/metric-contract.md
+++ b/skills/applications/tao-run-deft-iaa/references/metric-contract.md
@@ -1,0 +1,80 @@
+# IAA Metric Contract
+
+The immutable metric contract controls evaluation parsing, KPI stopping, and
+best-iteration reporting:
+
+```json
+{
+  "metric_name": "Rank-1",
+  "query_type": "medium",
+  "op": ">=",
+  "target": 0.25
+}
+```
+
+## Valid values
+
+- metric: `mAP`, `Rank-1`, `Rank-5`, `Separability`, `Match@5`, or `Zero@5`;
+- query type: `easy`, `medium`, or `hard` (the rows emitted by the IAA
+  aggregate evaluator; broader caption categories are gap filters, not KPI
+  rows);
+- operator: `<`, `<=`, `>`, or `>=`;
+- target: finite number or null.
+
+Defaults are `Rank-1`, `medium`, `>=`, and null. Null means no gate: every
+allowed iteration runs and completion is `max_iterations`. All listed metrics
+are naturally higher-is-better except `Zero@5`, but the user's approved
+operator is authoritative. An unusual direction is warned about during
+initialization and must be visible in pre-flight; it is not silently corrected.
+Best-result selection follows the operator.
+
+Gap analysis uses the same approved metric by default. Do not change either
+metric after state initialization.
+
+## Bind evaluation evidence
+
+After the TAO evaluation has a zero container exit and its canonical
+`status.json` contains `Evaluate finished successfully`, parse the exact
+label's CSV:
+
+```bash
+TARGET_ARGS=()
+if [ -n "${METRIC_TARGET:-}" ]; then
+  TARGET_ARGS=(--target "$METRIC_TARGET")
+fi
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/parse_iaa_metrics.py" \
+    --metrics-csv "$PHASE_DIR/evaluate/nvidia_iaa_metrics_aggregate.csv" \
+    --metric-name "$METRIC_NAME" --query-type "$QUERY_TYPE" \
+    --op "$METRIC_OP" "${TARGET_ARGS[@]}" \
+    --iter-label "$LABEL" \
+    --output "$PHASE_DIR/evaluate/metric_result.json"
+```
+
+`LABEL` is exactly `baseline` or `iterN`; `PHASE_DIR` is exactly `zs` or
+`iter_N`. The parser rejects missing files, absent/duplicate query rows,
+unknown columns, and non-finite values. It writes source path, full selected
+row, normalized contract, numeric value, and computed `passed`. Its exit is
+zero for a valid non-passing result; gate failure is workflow data, not a
+parser error.
+
+Pass the aggregate CSV, TAO status, parser result, container status, and (for
+iterN) iteration summary together to `commit_stage.py`, as shown in
+`clip-train-eval.md`. Commit reopens the CSV, verifies label/path provenance,
+re-derives the value and comparison, and records the canonical result. Never
+call `record_metric_result.py` directly.
+
+## Decision after commit
+
+Run the audit and follow only its state-aware next action:
+
+- target present and comparison passes: commit `loop_stop --reason kpi_met`;
+- comparison fails and another iteration remains: baseline proceeds to gap
+  analysis; iterN proceeds to gap analysis for N+1;
+- comparison fails or target is absent at the final iteration: commit
+  `loop_stop --reason max_iterations`.
+
+Once a passing result is committed, mining/training transitions are illegal.
+A numeric metric printed in a log, CSV, or report that was not bound through
+this transaction cannot stop the loop.

--- a/skills/applications/tao-run-deft-iaa/references/mining.md
+++ b/skills/applications/tao-run-deft-iaa/references/mining.md
@@ -1,0 +1,179 @@
+# Pool Embedding, Mining, and History Selection
+
+Read only when the audit selects `pool_embed`, `data_mining`, or
+`history_select`. All container calls use the immutable `/specs` mount prepared
+for the run.
+
+## Contents
+
+- [Baseline pool embedding](#baseline-pool-embedding)
+- [Iteration data mining](#iteration-data-mining)
+- [History-aware selection](#history-aware-selection)
+
+## Baseline pool embedding
+
+Embed the dataset-setup caption pool once:
+
+```bash
+HF_ARGS=()
+if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+  HF_ARGS=(--pass-hf-token)
+fi
+POOL_DIR="$RESULTS_DIR/embeddings/source"
+POOL_OUT="$POOL_DIR/embeddings.parquet"
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/run_deft_container.py" \
+    --results-dir "$RESULTS_DIR" --image ds \
+    --stage-dir "$POOL_DIR" --name pool_embed \
+    "${HF_ARGS[@]}" \
+    --fresh-output "$POOL_OUT" -- \
+    embedding text_embeddings -e /specs/text_embed_spec.yaml \
+    input_parquet=/results/embeddings/source/source_pool.parquet \
+    output_parquet=/results/embeddings/source/embeddings.parquet
+```
+
+Commit with the exact generated status file:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label baseline --stage pool_embed \
+    --pool-embeddings-parquet "$POOL_OUT" \
+    --pool-embed-command-status "$POOL_DIR/pool_embed.status.json" \
+    --summary "IAA caption pool embedded"
+```
+
+On resume, an existing parquet is reusable only when the matching status has
+exit code zero, names that file as a fresh output, and passes commit/audit
+schema and row checks. Otherwise rerun the wrapper; it removes only the exact
+output before launch. File existence alone is never a cache hit.
+
+## Iteration data mining
+
+For iteration N, `iter_N/gaps/kpi_gaps.parquet` was created by the prior
+label's gap analysis. Run these three steps in order.
+
+### 1. Embed target gap captions
+
+```bash
+ITER_DIR="$RESULTS_DIR/iter_$N"
+TARGET_DIR="$ITER_DIR/embeddings/target"
+TARGET_OUT="$TARGET_DIR/embeddings.parquet"
+HF_ARGS=()
+if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+  HF_ARGS=(--pass-hf-token)
+fi
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/run_deft_container.py" \
+    --results-dir "$RESULTS_DIR" --image ds \
+    --stage-dir "$TARGET_DIR" --name target_embed \
+    "${HF_ARGS[@]}" \
+    --fresh-output "$TARGET_OUT" -- \
+    embedding text_embeddings -e /specs/text_embed_spec.yaml \
+    input_parquet=/results/iter_$N/gaps/kpi_gaps.parquet \
+    output_parquet=/results/iter_$N/embeddings/target/embeddings.parquet
+```
+
+### 2. Mine source neighbors
+
+```bash
+MINING_DIR="$ITER_DIR/mining"
+MINED_OUT="$MINING_DIR/mined_samples.parquet"
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/run_deft_container.py" \
+    --results-dir "$RESULTS_DIR" --image ds \
+    --stage-dir "$MINING_DIR" --name knn \
+    --fresh-output "$MINED_OUT" -- \
+    tmm nearest_neighbors -e /specs/mining_spec.yaml \
+    source_parquet=/results/embeddings/source/embeddings.parquet \
+    target_parquet=/results/iter_$N/embeddings/target/embeddings.parquet \
+    output_parquet=/results/iter_$N/mining/mined_samples.parquet \
+    topn="$MINING_TOPN" knn_metric="$KNN_METRIC"
+```
+
+`MINING_TOPN` and `KNN_METRIC` must equal immutable state/config. Do not tune
+them between iterations without starting a separately approved run.
+
+### 3. Convert candidates
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/run_iaa_stage.py" mining-postprocess \
+    --results-dir "$RESULTS_DIR" \
+    --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N"
+```
+
+With history enabled, uncapped candidates live under
+`mining/history_candidates/`; history selection owns the budget. With history
+disabled, the adapter writes the budgeted outputs directly under `mining/`.
+Zero gaps, zero mined rows, missing embeddings, invalid parquet schema, or an
+empty candidate-pairs JSON is a hard stop.
+
+Commit data mining:
+
+```bash
+CANDIDATE_DIR="$MINING_DIR"
+if [ "$HISTORY_AWARE" = true ]; then
+  CANDIDATE_DIR="$MINING_DIR/history_candidates"
+fi
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "iter$N" --stage data_mining \
+    --target-embeddings-parquet "$TARGET_OUT" \
+    --target-embed-command-status "$TARGET_DIR/target_embed.status.json" \
+    --mined-parquet "$MINED_OUT" \
+    --knn-command-status "$MINING_DIR/knn.status.json" \
+    --candidate-pairs "$CANDIDATE_DIR/mined_pairs.json" \
+    --mining-postprocess-status \
+      "$MINING_DIR/mining-postprocess.host.status.json" \
+    --summary "iter$N gap captions embedded and neighbors mined"
+```
+
+## History-aware selection
+
+Run the adapter without `--resume` on a clean attempt:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/run_iaa_stage.py" history-select \
+    --results-dir "$RESULTS_DIR" \
+    --deft-config "$RESULTS_DIR/config/deft_config.yaml" \
+    --iter-num "$N"
+```
+
+It partitions candidates into novel/replay samples, spends the configured
+budget, updates cumulative names, and compares mined/eval basenames. Any eval
+overlap is a hard stop. When history is enabled, its root ledger must contain
+an entry for exactly N.
+
+If the adapter reports that N is already committed while the DEFT audit still
+selects `history_select`, rerun once with `--resume` as documented in
+`scripts-and-agents.md`. Never delete selection artifacts or edit the ledger.
+
+Commit:
+
+```bash
+HISTORY_ARGS=()
+if [ "$HISTORY_AWARE" = true ]; then
+  HISTORY_ARGS=(--mining-history "$RESULTS_DIR/mining_selection_history.json")
+fi
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "iter$N" \
+    --stage history_select \
+    --mined-image-list "$MINING_DIR/mined_image_list.txt" \
+    --mined-pairs "$MINING_DIR/mined_pairs.json" \
+    --mined-manifest "$MINING_DIR/mined_dataset.json" \
+    --cumulative-names "$MINING_DIR/cumulative_mined_unique_names.json" \
+    --history-select-status "$MINING_DIR/history-select.host.status.json" \
+    "${HISTORY_ARGS[@]}" \
+    --summary "iter$N history-aware mining selection completed"
+```
+
+Run the audit after each commit. Advancing without a successful stage commit
+is prohibited.

--- a/skills/applications/tao-run-deft-iaa/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-iaa/references/pipeline-and-state.md
@@ -1,0 +1,185 @@
+# Pipeline, State, and Resume
+
+The workflow is a linear transaction log with KPI/max-iteration branching. It
+does not require a general graph engine, scheduler, or multiple agents.
+
+## Contents
+
+- [Legal transitions](#legal-transitions)
+- [Disk contract](#disk-contract)
+- [Stage transaction](#stage-transaction)
+- [Resume](#resume)
+- [Terminal paths](#terminal-paths)
+
+## Legal transitions
+
+```text
+baseline/dataset_setup
+  -> baseline/pool_embed
+  -> baseline/evaluate
+       -> baseline/loop_stop                  KPI passed
+       -> baseline/gap_analysis               otherwise
+  -> iter1/data_mining
+
+iterN/data_mining
+  -> iterN/history_select
+  -> iterN/visualize                          real or config-approved skip
+  -> iterN/train
+  -> iterN/evaluate
+       -> iterN/loop_stop                     KPI passed or N=max
+       -> iterN/gap_analysis                  otherwise; feeds iter N+1
+  -> iterN+1/data_mining
+
+any committed error -> same-label loop_stop(reason=hard_stop)
+```
+
+Baseline does not consume an iteration. Gap analysis is owned by the
+evaluation it analyzes and writes the next iteration's input. Never create a
+terminal gap artifact after the last evaluation.
+
+The transition is decided from committed metric evidence and immutable
+`max_iterations`, not prose or an in-memory loop counter. `commit_stage.py`
+rejects duplicate, skipped-ahead, post-KPI, and out-of-range transitions.
+
+## Disk contract
+
+`deft_state.json` is a schema-v3 resume snapshot. It records:
+
+- immutable workspace, archives, intended dataset root, bundled-runtime hash,
+  Docker images, config paths and hashes;
+- immutable loop/config values and metric contract;
+- current iteration, gate flag, per-label stage proofs, and stop reason.
+
+`loop_log.jsonl` is the ordered event history. It contains one gap-free
+sequence entry per committed stage with label, stage, `ok|skip|error`, summary,
+duration, and timestamp. Both files are initialized/updated only through the
+bundled state scripts.
+
+Artifact files are additional evidence, not alternate state. The audit checks
+their exact paths, structure, row counts, provenance, freshness, and
+cross-file invariants. It also reopens metric CSVs and selection history.
+
+Do not display the full state or log in conversation. The audit's compact
+fields are sufficient:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/audit_deft_run.py" --results-dir "$RESULTS_DIR"
+```
+
+Interpret statuses as follows:
+
+| Status | Action |
+|---|---|
+| `IN_PROGRESS` | perform exactly `next_action` after reading `read_before_action` |
+| `COMPLETE` | do not launch more work; render/report after final verification |
+| `FAILED` | if nonterminal, perform only the selected `loop_stop` hard-stop commit; if terminal, render/report and launch no work |
+| `INVALID` | stop all mutations; preserve the run and report audit errors |
+
+## Stage transaction
+
+For each stage:
+
+1. Audit and confirm the selected next action.
+2. Read only its named reference.
+3. Run the documented adapter/container commands with verbose output in logs.
+4. Validate and commit once with the exact artifact and command-status flags.
+5. Audit again. Advance only when the committed event is accepted.
+6. Tell the user one line: `[label · stage] outcome · next: <action>`.
+
+If execution fails and the documented single correction also fails, record
+the expected current stage as an error when canonical state is still valid:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "$LABEL" --stage "$STAGE" \
+    --status error --summary "<specific failed command/check and log path>"
+```
+
+Then use the hard-stop terminal path below. Do not commit an error merely to
+paper over an `INVALID` audit; invalid canonical state is preserved for
+diagnosis.
+
+## Resume
+
+On startup or after context compaction:
+
+1. Resolve the existing results directory explicitly.
+2. Run the audit with the workspace argument on `deft_python.sh`.
+3. Trust its transition calculation, not remembered progress or output
+   existence.
+4. Read one reference and continue the selected stage.
+
+Uncommitted outputs can be reused only when that stage's validators accept a
+successful matching command status and fresh scoped artifacts. Otherwise the
+documented wrapper reruns the exact stage after deleting only named fresh
+outputs. For history selection, use its one `--resume` path. Never backfill a
+log entry or manually mark a stage complete.
+
+If an existing run's config hashes, inputs, metric, or requested parameters no
+longer match, do not mutate it. Preserve the directory and initialize a new,
+separately approved run.
+
+## Terminal paths
+
+### KPI or iteration budget
+
+Use the label of the evaluation that selected the stop:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "$LABEL" --stage loop_stop \
+    --reason "$REASON" --summary "$SUMMARY"
+```
+
+`REASON` is `kpi_met` only when committed evidence passed, otherwise
+`max_iterations` only after final iteration evaluation. The validator rejects
+premature or false stop reasons.
+
+Render and prove completion:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/render_deft_report.py" \
+    --results-dir "$RESULTS_DIR" --trigger loop-end
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/audit_deft_run.py" \
+    --results-dir "$RESULTS_DIR" --require-complete
+```
+
+An optional progress render after a successfully committed iterN evaluation
+uses `--trigger iteration-complete`. It does not affect state and cannot prove
+completion.
+
+### Hard stop
+
+After a committed stage error, commit the only legal transition:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "$LABEL" --stage loop_stop \
+    --reason hard_stop --summary "run stopped after $LABEL/$STAGE failure"
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/render_deft_report.py" \
+    --results-dir "$RESULTS_DIR" --trigger loop-end
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/audit_deft_run.py" \
+    --results-dir "$RESULTS_DIR" --require-terminal
+```
+
+Report it as `FAILED`, never completed. Include the failed stage, command log,
+auditor recovery statement, and preserved results directory.
+
+### User-facing result
+
+For a successful terminal run, report the stop reason, contract and target,
+baseline value, operator-directed best value/label, best raw checkpoint and
+normalized state (when an iteration trained), completed iterations, warnings,
+HTML report path, and passing `--require-complete` evidence. For failure,
+replace metric claims with the last validated metric and failure evidence.

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -1,0 +1,408 @@
+# Pre-flight and Initialization
+
+Use this reference for a new run or to resolve an existing run. Discovery is
+read-only. Installation, pulls, probes that start containers, extraction, and
+run creation occur only after approval.
+
+## Contents
+
+- [Initial intake](#initial-intake)
+- [Read-only discovery](#read-only-discovery)
+- [Defaults](#defaults)
+- [Approval summary](#approval-summary)
+- [Approved initialization](#approved-initialization)
+- [Resume](#resume)
+
+## Initial intake
+
+IAA fixes the execution platform to local Docker. Before full preflight, do
+only bounded, lightweight discovery that can reduce user questions:
+
+1. Resolve an explicitly named workspace or the conventional `~/workspace`
+   candidate without creating it.
+2. Resolve the archive root using this exact precedence and scope:
+
+   - If the user supplied both archive file paths, require the exact names
+     `images_raw.tar` and `meta.tar.gz`, a shared non-symlink parent, and two
+     non-symlink regular files. Validate only that explicit pair's parent
+     location during intake. If it is invalid, report why and ask for a
+     corrected pair; do not search for alternatives.
+   - If the user supplied an archive directory, treat it as the sole approved
+     search root. Inspect that root and directories at candidate depth `1` or
+     `2` beneath it. Do not search outside it.
+   - Otherwise use, in order, `~/iaa` at candidate depth `0..2`, the resolved
+     workspace root at depth `0` only, then `<workspace>/iaa`,
+     `<workspace>/input`, and `<workspace>/inputs` at depth `0..2`. Normalize
+     absolute paths and deduplicate overlapping search-root/depth pairs and
+     discovered candidate directories.
+   - A candidate is a non-symlink directory whose direct children include both
+     `images_raw.tar` and `meta.tar.gz` as non-symlink regular files. Use a
+     non-symlink-following, depth-limited directory enumeration inside each
+     search root, then check the two exact child names; do not run a filename
+     search over `$HOME`. Missing roots are reported as checked/missing.
+     Permission errors and unsafe symlinks are reported and never cause the
+     search to widen.
+   - Do not add the current repository, tutorial/notebook checkouts, or
+     `<workspace>/data` as implicit search roots. If the user explicitly names
+     one of those locations, its bounded subtree is user-authorized and may be
+     checked.
+   - If no candidate exists in that bounded set, ask for the archive root. Do
+     not broaden the search automatically.
+
+   Candidate depth counts directories relative to the search root: the root is
+   depth `0`, its direct directory children are depth `1`, and their directory
+   children are depth `2`. Do not follow a symlink supplied as a search root or
+   encountered below one. This mirrors AOI's useful discovery pattern: recurse
+   only below a semantically selected subtree, with an explicit IAA depth cap.
+
+   The archive root is an input location. It is distinct from `DATASET_ROOT`,
+   which is the approved extraction/rebuild destination under workspace data.
+   The run consumes one archive pair from one root; multiple roots are
+   alternatives, not multiple required datasets.
+
+   Classify a candidate from direct-child metadata only:
+
+   - `archive-only`: the required pair is present and extracted-dataset markers
+     such as `images_raw/`, `images/`, `captions/`, `rebuild.py`, or
+     `train_pairs.json` are absent. Auto-select it only when it is the sole
+     candidate.
+   - `archive-with-extracted-data`: the pair is present alongside one or more
+     extracted-dataset markers. Describe it as a mixed/development location
+     and require an explicit user choice unless the user supplied it.
+
+   Record file sizes, but do not open, hash, compare, or validate either large
+   archive yet.
+3. Enumerate only `<workspace>/results/run_*/deft_state.json`. For each small
+   state file, read only enough JSON to identify `workflow`, `schema_version`,
+   `results_dir`, `current_iteration`, and `max_iterations`. Present it as a
+   resume option only when `workflow` is exactly `tao-run-deft-iaa`. Ignore and
+   briefly label malformed, unidentified, AOI, or other-workflow states; do not
+   offer them as IAA runs. Do not run the full audit yet.
+4. Report discovery provenance before asking for missing intake. Use absolute
+   paths and this compact shape, omitting sections that do not apply:
+
+   ```text
+   IAA DEFT intake (read-only)
+     workspace: <absolute path> (source=<user | conventional ~/workspace>)
+     archive lookup:
+       search root: <absolute path> (reason=<user-supplied | conventional ~/iaa | workspace root | workspace child>; candidate_depth=<0 | 0..2>; status=<searched | missing | inaccessible | unsafe-symlink>)
+       broad home/repository search: not performed
+       candidate: <absolute archive root> (found_under=<search root>; depth=<0..2>; type=<archive-only | archive-with-extracted-data>)
+         images: <absolute path>/images_raw.tar (<size>)
+         metadata: <absolute path>/meta.tar.gz (<size>)
+       selection: <selected sole archive-only root | user choice required | none found>
+     resume lookup:
+       checked: <workspace>/results/run_*/deft_state.json
+       IAA candidates: <none | concise list with iteration/budget>
+       ignored: <none | concise path and non-IAA/unreadable reason>
+   ```
+
+   If more than one valid archive root remains, say explicitly that they are
+   alternatives and ask the user to select one. Never label a list of directory
+   names as "dataset archives"; name the archive root and the two files under
+   it. Paths found this way come from the current filesystem and must be labeled
+   `source=discovery` with the search-root reason, scope, and candidate depth,
+   not implied to come from session memory or packaged defaults.
+   Never resolve ambiguity by search order, directory name, modification time,
+   or archive size.
+
+If `max_iterations` or a time budget is absent, stop here and ask one
+consolidated question for that value plus any ambiguous archive/run selection.
+State the defaults below and explain that full read-only discovery and the one
+approval summary come next. Do not ask whether the user wants a KPI target,
+authenticated Hugging Face access, or other overrides; their documented
+defaults apply unless the prompt already provides an override.
+
+## Read-only discovery
+
+Run this section only after required intake is resolved.
+
+1. Resolve absolute paths for `WORKSPACE`, the two archives, and the intended
+   dataset root. IAA workflow code and templates are bundled under
+   `SKILL_ROOT`; never ask the user for an implementation checkout.
+   `RESULTS_DIR` must be a child of `WORKSPACE`; `DATASET_ROOT` must be nested
+   below a workspace data directory (for example
+   `$WORKSPACE/data/iaa_v31_tao_ft`), not directly below `WORKSPACE`. Neither
+   may contain the other, and approved paths may not traverse symlinks.
+2. Resolve either one identity-filtered IAA run directory from initial intake,
+   or a new path such as `<workspace>/results/run_<UTC timestamp>`. Never select
+   among multiple IAA runs by guessing; summarize the candidates or ask once.
+   Never send a state from another workflow to the IAA audit as a resume
+   candidate.
+3. Verify `images_raw.tar` and `meta.tar.gz` are regular, non-empty, readable
+   archives. Check them to end without printing their member lists:
+
+   ```bash
+   set -e
+   tar -tf "$IMAGES_ARCHIVE" >/dev/null
+   tar -tzf "$METADATA_ARCHIVE" >/dev/null
+   ```
+
+   Record the presence of adjacent `SHA256SUMS`. Its absence is a warning, not
+   a blocker; `rebuild.py` verification remains mandatory.
+4. Inspect, but do not modify, Docker/GPU state:
+
+   ```bash
+   docker version --format '{{.Server.Version}}'
+   docker image inspect nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt >/dev/null 2>&1  # versions-key: images.tao_toolkit.pyt
+   docker image inspect nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services >/dev/null 2>&1  # versions-key: images.tao_toolkit.data_services
+   nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader
+   ```
+
+   Missing local images are planned pulls. Do not run a CUDA container probe
+   yet.
+5. Check only whether `NGC_KEY` and `HF_TOKEN` exist in the current process
+   environment. Never open or source a credential file and never echo a value.
+   `NGC_KEY` is required only if an image must be pulled or registry login is
+   otherwise needed. The default SigLIP2 model is public, so `HF_TOKEN` is
+   optional unless the deployment environment requires authenticated access.
+   Do not inspect credential-file metadata when neither variable is required.
+   If the user explicitly asks for a permissions check, `stat` only that named
+   file, warn about group/other readability, and still require credentials to
+   be exported in the launching environment.
+6. Resolve the approved GPU shape. SigLIP2-so400m training commonly needs
+   roughly 30–45 GB free per selected GPU at the bundled batch size. Treat this
+   as a planning estimate, not a capability guarantee. Surface occupied GPUs;
+   do not silently reshape `gpu_ids`.
+7. Resolve all run values and their sources. Validate the metric contract
+   vocabulary against `references/metric-contract.md`. Do not create a config
+   to discover defaults; read the bundled templates.
+8. For resume, use the bundled IAA runtime with the prior workspace venv. The
+   audit verifies the bundled runtime hash recorded when the run was created:
+
+   ```bash
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/audit_deft_run.py" --results-dir "$RESULTS_DIR"
+   ```
+
+   Report the audit status and next action. Do not change immutable values in
+   an existing run. If the dependency environment or matching skill version is
+   unavailable, report the resume audit as blocked during discovery. Restore
+   the same skill version/runtime rather than asking for a separate source
+   checkout, and do not launch GPU work before the audit.
+
+Ask one consolidated question for unresolved required inputs. `max_iterations`
+is required unless a time budget was supplied. Estimate conservatively:
+baseline setup and pool embedding can take tens of minutes, and one 8-GPU
+iteration is commonly about 30 minutes at the bundled 10k/1-epoch settings;
+hardware, pool size, and accumulated data can change this substantially.
+
+## Defaults
+
+| Field | Default |
+|---|---|
+| metric | `Rank-1`, query type `medium`, operator `>=`, no target |
+| training epochs | `1` per iteration |
+| GPU shape | `num_gpus=1`, `gpu_ids=0` |
+| mining | budget `10000`, top-N `25`, cosine distance |
+| history selection | enabled, replay fraction `0.20` |
+| continual behavior | dataset `true`, model `false` |
+| visualization | contact sheets `true`, embedding plot `true` |
+| Hugging Face token forwarding | disabled; enable only when the approved model/environment requires it |
+| PyTorch image | `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` | <!-- versions-key: images.tao_toolkit.pyt -->
+| data-services image | `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services` | <!-- versions-key: images.tao_toolkit.data_services -->
+| monitoring | attached, poll every `5 minutes` |
+
+An ungated run evaluates every allowed iteration and completes with
+`max_iterations`. Never invent a KPI target.
+
+## Approval summary
+
+Show this one compact summary and stop for explicit approval. It is the sole
+approval boundary for the planned run; do not split platform, image, setup, or
+launch confirmation into separate prompts.
+
+```text
+IAA DEFT pre-flight
+
+Workflow
+  skill: tao-run-deft-iaa 0.3.3 (source=SKILL.md frontmatter)
+  platform: local Docker (source=fixed by workflow)
+  workspace: <absolute path> (source=<user | default>)
+  monitoring: attached=true; interval=5 minutes (source=default)
+
+Run
+  results: <absolute path> (new | resume; source=<user | discovery | default>)
+  stop: metric=<value> (source=<user | template | default>);
+        query=<value> (source=<user | template | default>);
+        operator=<value> (source=<user | template | default>);
+        target=<value | no target> (source=<user | default>);
+        max_iterations=<N> (source=<user | derived from approved time budget>)
+  train: epochs=<N> (source=<user | template | default>);
+         num_gpus=<N> (source=<user | default>);
+         gpu_ids=<list> (source=<user | default>)
+  mining: budget=<N> (source=<user | template | default>);
+          topn=<N> (source=<user | template | default>);
+          metric=<name> (source=<user | template | default>);
+          history=<bool> (source=<user | template | default>);
+          replay=<f> (source=<user | template | default>)
+  continual: dataset=<bool> (source=<user | template | default>);
+             model=<bool> (source=<user | template | default>)
+  visualization: sheets=<bool> (source=<user | template | default>);
+                 embeddings=<bool> (source=<user | template | default>)
+
+Inputs
+  archive root: <absolute path> (type=<archive-only | archive-with-extracted-data>;
+                source=<user | discovery: checked-root reason>)
+  images archive: <absolute path and size> (source=<user | discovery: checked-root reason>)
+  metadata archive: <absolute path and size> (source=<user | discovery: checked-root reason>)
+  SHA256SUMS: <absolute path | absent> (source=<user | discovery>)
+  dataset root: <absolute intended path> (source=<user | default>)
+  IAA runtime: bundled with skill (source=fixed by workflow);
+               integrity=<verified | mismatch>
+  credentials: NGC_KEY=<set | not needed | missing>;
+               HF_TOKEN=<set | optional/unset | missing>
+  token forwarding: requires_hf_token=<bool> (source=<user | default>)
+  PyTorch image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+                 (source=versions.yaml; status=<local | pull after approval>)
+  data-services image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+                       (source=versions.yaml; status=<local | pull after approval>)
+  GPUs: <selected IDs> (source=<user | default>);
+        memory=<free/total discovery result>
+
+Planned writes/actions
+  <login/pulls if needed>; CUDA probe; <venv install if needed>;
+  config/state creation; archive extraction/rebuild; baseline and at most N iterations
+
+Estimate: <baseline + bounded-loop estimate and assumptions>
+```
+
+Label every configurable parameter source, including defaulted parameters; do
+not limit source labels to overrides. Use `user`, `template`, `default`,
+`discovery: <checked-root reason>`, `fixed by workflow`, `versions.yaml`, or
+`derived from approved time budget` as applicable. If the user changes a row
+after approval, show only the changed rows and wait for approval again.
+
+## Approved initialization
+
+For a new run, perform the following in order.
+
+1. If an image pull is needed, require `NGC_KEY` in the launching process,
+   login without placing it in argv or output, then pull only the pinned images:
+
+   ```bash
+   (
+     if [ -z "${NGC_KEY:-}" ]; then
+       echo "export NGC_KEY in the launching shell before the approved image pull" >&2
+       exit 2
+     fi
+     printf '%s' "$NGC_KEY" | docker login nvcr.io \
+       --username '$oauthtoken' --password-stdin >/dev/null
+   )
+   docker pull nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+   docker pull nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+   ```
+
+   Never print, persist, or place the credential value in argv.
+
+2. Prove that the PyTorch image can execute CUDA on the selected host:
+
+   ```bash
+   : "${GPU_IDS:?approved comma-separated GPU ids are required}"
+   DOCKER_GPU_REQUEST="\"device=${GPU_IDS}\""
+   docker run --rm --gpus "$DOCKER_GPU_REQUEST" \
+     nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt python3 -c 'import torch; torch.zeros(1).cuda()'  # versions-key: images.tao_toolkit.pyt
+   ```
+
+   `GPU_IDS` is the exact approved `gpu_ids` list (for example `0` or `0,2`).
+   CUDA initialization or unsupported-architecture failure is a hard stop.
+3. Reuse a complete workspace venv if the runtime probe passes. Otherwise
+   create it and install only the bundled runtime's third-party dependencies:
+
+   ```bash
+   python3 -m venv "$WORKSPACE/.venv"
+   "$WORKSPACE/.venv/bin/pip" install \
+     pandas numpy matplotlib pyarrow pillow pyyaml scikit-learn
+   "$WORKSPACE/.venv/bin/pip" install torch \
+     --index-url https://download.pytorch.org/whl/cpu
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     -c 'import iaa_deft; print("bundled IAA runtime: OK")'
+   ```
+
+   Never install into the system interpreter. If package installation was not
+   in the approved actions, obtain approval first.
+4. Materialize an immutable run config and `approval.json` from the bundled
+   templates. Pass every approved override explicitly; this command writes
+   only `${RESULTS_DIR}/config/` and refuses an initialized run:
+
+   ```bash
+   PREP_OPTIONAL_ARGS=()
+   if [ -n "${CHECKSUMS_FILE:-}" ]; then
+     PREP_OPTIONAL_ARGS+=(--checksums-file "$CHECKSUMS_FILE")
+   fi
+   if [ -n "${METRIC_TARGET:-}" ]; then
+     PREP_OPTIONAL_ARGS+=(--metric-target "$METRIC_TARGET")
+   fi
+   if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+     PREP_OPTIONAL_ARGS+=(--requires-hf-token)
+   fi
+
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/prepare_deft_config.py" \
+       --workspace "$WORKSPACE" --results-dir "$RESULTS_DIR" \
+       --dataset-root "$DATASET_ROOT" \
+       --images-archive "$IMAGES_ARCHIVE" \
+       --metadata-archive "$METADATA_ARCHIVE" \
+       "${PREP_OPTIONAL_ARGS[@]}" \
+       --max-iterations "$MAX_ITERATIONS" \
+       --training-epochs "$TRAINING_EPOCHS" \
+       --num-gpus "$NUM_GPUS" --gpu-ids "$GPU_IDS" \
+       --mining-topn "$MINING_TOPN" --knn-metric "$KNN_METRIC" \
+       --target-query-count "$TARGET_QUERY_COUNT" \
+       --history-aware "$HISTORY_AWARE" --replay-fraction "$REPLAY_FRACTION" \
+       --continual-dataset "$CONTINUAL_DATASET" \
+       --continual-model "$CONTINUAL_MODEL" \
+       --visualize "$VISUALIZE" \
+       --visualize-embeddings "$VISUALIZE_EMBEDDINGS" \
+       --metric-name "$METRIC_NAME" --metric-query-type "$QUERY_TYPE" \
+       --metric-op "$METRIC_OP"
+   ```
+
+5. Initialize state once. Omit checksum, target, and token flags when they are
+   not approved:
+
+   ```bash
+   INIT_OPTIONAL_ARGS=()
+   if [ -n "${CHECKSUMS_FILE:-}" ]; then
+     INIT_OPTIONAL_ARGS+=(--checksums-file "$CHECKSUMS_FILE")
+   fi
+   if [ -n "${METRIC_TARGET:-}" ]; then
+     INIT_OPTIONAL_ARGS+=(--metric-target "$METRIC_TARGET")
+   fi
+   if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+     INIT_OPTIONAL_ARGS+=(--requires-hf-token)
+   fi
+
+   IAA_PYT_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+   IAA_DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+
+   "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+     "$SKILL_ROOT/scripts/init_deft_state.py" \
+       --results-dir "$RESULTS_DIR" --workspace "$WORKSPACE" \
+       --dataset-root "$DATASET_ROOT" \
+       --images-archive "$IMAGES_ARCHIVE" \
+       --metadata-archive "$METADATA_ARCHIVE" \
+       "${INIT_OPTIONAL_ARGS[@]}" \
+       --max-iterations "$MAX_ITERATIONS" \
+       --metric-name "$METRIC_NAME" --metric-query-type "$QUERY_TYPE" \
+       --metric-op "$METRIC_OP" \
+       --platform docker \
+       --pyt-image "$IAA_PYT_IMAGE" \
+       --ds-image "$IAA_DS_IMAGE" \
+       --deft-config "$RESULTS_DIR/config/deft_config.yaml" \
+       --tao-spec "$RESULTS_DIR/config/tao_spec.yaml"
+   ```
+
+6. Run the audit. Its only legal first action for a new run is
+   `baseline/dataset_setup`. If initialization or audit fails, do not
+   reinitialize the same directory; diagnose the invalid input and start a new
+   run directory.
+
+## Resume
+
+For an existing run, do not repeat image/config/state setup merely because a
+new shell lacks variables. `deft_python.sh` takes the workspace explicitly and
+the container wrapper reads workspace, images, mounts, and config paths from
+state. Run the audit, read its one stage reference, and follow `next_action`.
+If the user's requested values differ from immutable state, explain the
+difference and start a separately approved run rather than mutating history.

--- a/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
@@ -1,0 +1,209 @@
+# Scripts, Stage Ownership, and Recovery
+
+Despite this file's compatibility-preserving name, the IAA workflow does not
+need a reporter agent or stage subagents. One agent runs a small linear flow
+through deterministic scripts.
+
+## Contents
+
+- [Script interfaces](#script-interfaces)
+- [Stage ownership](#stage-ownership)
+- [Container launch contract](#container-launch-contract)
+- [Bundled adapter contract](#bundled-adapter-contract)
+- [Path invariants](#path-invariants)
+- [Bounded recovery](#bounded-recovery)
+
+## Script interfaces
+
+| Script | Role | Runtime |
+|---|---|---|
+| `deft_python.sh` | select a Python per call and cap BLAS/OpenMP threads | shell |
+| `prepare_deft_config.py` | copy templates into a run and apply approved values | IAA runtime |
+| `init_deft_state.py` | validate config/metric inputs and create schema-v3 state once | IAA runtime |
+| `audit_deft_run.py` | read-only state, transition, evidence, and artifact audit | IAA runtime (parquet/YAML validation) |
+| `run_deft_container.py` | launch one pinned TAO container and atomically record log/status/fresh outputs | control Python |
+| `run_iaa_stage.py` | expose bundled IAA host operations as named subcommands | IAA runtime |
+| `iaa_deft/` | bundled IAA gap, mining, selection, visualization, config, and checkpoint implementation | imported only through `run_iaa_stage.py` |
+| `commit_stage.py` | validate and atomically commit one stage | IAA runtime for parquet checks |
+| `recover_commit.py` | roll back a journaled state/log commit interrupted by process death | IAA runtime (runs the audit) |
+| `parse_iaa_metrics.py` | parse one exact CSV row/column into iteration-bound JSON | control Python |
+| `render_deft_report.py` | audit and atomically render a deterministic HTML report | IAA runtime (its audit validates parquet) |
+| `metric_contract.py`, `command_contract.py`, `checkpoint_contract.py`, `record_metric_result.py`, `log_stage.py` | internal validation/commit helpers | never invoke directly |
+
+Use the control plane for container launch and metric parsing:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/<control-script>.py" ...
+```
+
+Add `--runtime` for config preparation, initialization, audit, bundled IAA
+adapters, stage commit/recovery, and reporting:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/<runtime-script>.py" ...
+```
+
+Every path argument must be absolute. Workflow paths and decisions may not
+depend on a prior `cd` or hidden env-file load. Credential-requiring commands
+consume only variables inherited from the launching process; no wrapper opens
+or sources a credentials file, and no value is written to argv, status, state,
+or logs.
+
+## Stage ownership
+
+| State stage | Producer | Adapter or launch | Read first |
+|---|---|---|---|
+| `dataset_setup` | archive `rebuild.py` plus bundled IAA data utilities | `run_iaa_stage.py dataset-materialize` | `data-layout.md` |
+| `pool_embed` | TAO data services | `run_deft_container.py` | `mining.md` |
+| `evaluate` | TAO CLIP plus bound parser | `run_iaa_stage.py eval-config`, container wrapper, parser | `clip-train-eval.md`, `metric-contract.md` |
+| `gap_analysis` | bundled IAA gap analysis | `run_iaa_stage.py gap-analysis` | `gap-analysis.md` |
+| `data_mining` | TAO text embedding/k-NN plus bundled IAA data utilities | two container launches, then `mining-postprocess` | `mining.md` |
+| `history_select` | bundled IAA history selection | `run_iaa_stage.py history-select` | `mining.md` |
+| `visualize` | bundled IAA visualization plus optional TAO image embedding | `visualize-prepare`, container launches, `visualize-finish` | `visualization.md` |
+| `train` | bundled config/checkpoint helpers plus TAO CLIP | `train-config`, container launch, `publish-checkpoint` | `clip-train-eval.md` |
+| `loop_stop` / report | bundled control scripts | commit, audit, renderer | `pipeline-and-state.md` |
+
+The canonical workflow executes plain `clip train`, so there is no AutoML branch.
+Never add `automl_policy`, `workflow`, or another orchestration key to a TAO
+YAML schema.
+
+## Container launch contract
+
+Always launch TAO through the wrapper, not an assembled `docker run`. It reads
+the image and standard mounts from state, forwards the existing `HF_TOKEN`
+only with the explicit option below and without exposing its value, mounts the
+compatibility patch, writes the full log, and records exact command status.
+
+The following is a launch shape, not a literal copy/paste command; each stage
+reference supplies the exact stable name, outputs, command, and independently
+reconstructs credential arguments from immutable approval:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/run_deft_container.py" \
+    --results-dir "$RESULTS_DIR" --image <pyt|ds> \
+    --stage-dir "$STAGE_DIR" --name <stable-stage-name> \
+    "${HF_ARGS[@]}" \
+    --fresh-output "$ABSOLUTE_EXPECTED_FILE" \
+    -- <container command and arguments>
+```
+
+Repeat `--fresh-output` for every exact file whose freshness proves the
+launch. The wrapper deletes only those non-symlink, results-scoped files before
+launch, verifies they were recreated after launch, and records the exact argv
+plus its digest. Pass its generated `<name>.status.json` to
+`commit_stage.py`. A zero Docker exit without fresh, valid output is failure;
+a file without successful matching command status is not resumable evidence.
+
+The wrapper uses a deterministic Docker name, CID file, and nonblocking launch
+lock. If its process dies while Docker continues, a later call inspects that
+container read-only and refuses to overlap it. Wait for the named container to
+exit; never kill it automatically. `HF_TOKEN` is not forwarded unless the
+approved command needs it and `--pass-hf-token` is supplied explicitly.
+Docker and host-adapter statuses also carry a stable `attempt` value. Attempt
+1 is the initial call, attempt 2 is the single evidence-based correction, and
+either wrapper refuses attempt 3. Keep the documented stable command names;
+changing a name does not create a valid new retry budget.
+
+Required stable names are `pool_embed`, `target_embed`, `knn`,
+`viz_weak_embed`, `viz_mined_embed`, `viz_previous_embed`, `train`, and
+`evaluate`. Logs and statuses live in the matching `--stage-dir`.
+
+## Bundled adapter contract
+
+`run_iaa_stage.py` is the only supported entry to bundled IAA host operations:
+
+```text
+dataset-materialize  create eval/val/pool splits and source_pool.parquet
+gap-analysis         analyze the prior evaluation into iter_N/gaps
+mining-postprocess   summarize k-NN and create uncapped/capped candidates
+history-select       apply novel/replay budget and leakage check
+visualize-prepare    contact sheets and image-embedding input parquets
+visualize-finish     t-SNE from completed image embeddings
+train-config         generate an iteration train YAML
+publish-checkpoint   choose the best checkpoint and normalize it
+eval-config          generate baseline or iteration eval YAML
+iteration-summary    bind an iteration's gap/mining/checkpoint summary
+```
+
+Each command takes `--results-dir` and `--deft-config`; iteration commands also
+take `--iter-num`, except `eval-config`, which takes `--iter-label`. Gap
+analysis derives the iteration budget from immutable state. Do not recreate
+these calls with inline Python.
+
+## Path invariants
+
+- Baseline state label `baseline` maps to `${RESULTS_DIR}/zs`.
+- State label `iterN` maps to `${RESULTS_DIR}/iter_N`.
+- Split files are exactly under `iaa_splits/`; source pool/embeddings are
+  exactly under `embeddings/source/`.
+- The wrapper mounts `${RESULTS_DIR}` as `/results`, the dataset parent as
+  `/data` and at its absolute host path, the immutable config as `/specs`, and
+  workspace cache as `/cache`.
+- Container YAML and commands use `/results`, `/data`, and `/specs`; state and
+  commit arguments use absolute host paths.
+- Iteration evidence must come from that iteration. Never satisfy iterN with a
+  prior iteration's checkpoint, parquet, status, or summary.
+
+## Bounded recovery
+
+After any nonzero command, inspect the last meaningful error block in its log.
+Do not guess a different CLI. One corrected retry is allowed only when evidence
+supports the correction.
+
+### Interrupted canonical commit
+
+If the audit reports `.deft_commit_transaction.json`, run no workload stage.
+Restore the saved canonical state/log pair once:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/recover_commit.py" --results-dir "$RESULTS_DIR"
+```
+
+The recovery validates journal ownership, restores both files atomically, and
+accepts only a valid nonterminal `IN_PROGRESS` or `FAILED` audit. Then run the
+normal audit and follow its single `next_action`. Never edit or delete the
+journal by hand.
+
+### History write preceded commit
+
+`history-select` records iteration N in `mining_selection_history.json` before
+the outer stage transaction. If a process dies in that narrow window, state
+still reports the stage uncommitted while the history entry and selection
+outputs exist. Run:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/run_iaa_stage.py" history-select \
+    --results-dir "$RESULTS_DIR" \
+    --deft-config "$RESULTS_DIR/config/deft_config.yaml" \
+    --iter-num "$N" --resume
+```
+
+Then run the audit and commit normally. The adapter verifies the saved
+selection and leakage. If resume rejects the history or artifacts, hard-stop;
+never remove/edit a history entry.
+
+### GPU contention
+
+Immediately before train, inspect selected GPU occupancy. If a launch fails
+with OOM and occupancy changed after approval, wait for the selected GPUs to
+be free and retry the same approved command once. Changing GPU IDs/count is a
+parameter change and requires an updated approval summary. A second OOM on
+otherwise free GPUs is terminal.
+
+### Registry/network interruption
+
+Retry a pull or public model download once only after connectivity or registry
+state demonstrably changes. Never downgrade an image/model or switch sources
+speculatively.
+
+### Non-retryable failures
+
+Checksum/rebuild failure, unsupported CUDA architecture, missing or malformed
+split evidence, empty/schema-invalid mining output, eval leakage, cross-label
+metric evidence, stale output, config hash mismatch, and state/log corruption
+are hard stops. Preserve logs and provide the auditor's recovery statement.

--- a/skills/applications/tao-run-deft-iaa/references/visualization.md
+++ b/skills/applications/tao-run-deft-iaa/references/visualization.md
@@ -1,0 +1,150 @@
+# Visualization
+
+Visualization is one ordered stage with two independently configured outputs:
+contact sheets (`visualize`) and an embedding t-SNE
+(`visualize_embeddings`). It is the only skippable stage.
+
+## Contents
+
+- [Prepare host artifacts](#prepare-host-artifacts)
+- [Embed image sets](#embed-image-sets)
+- [Finish and commit](#finish-and-commit)
+
+If both approved flags are false, commit the stage with `--skip` and no
+artifacts. If either is true, a failure is not silently downgraded to a skip.
+
+## Prepare host artifacts
+
+```bash
+ITER_DIR="$RESULTS_DIR/iter_$N"
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/run_iaa_stage.py" visualize-prepare \
+    --results-dir "$RESULTS_DIR" \
+    --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N"
+```
+
+When contact sheets are enabled, this must populate
+`iter_N/visualization/samples/`. When embedding visualization is enabled, it
+creates exact input parquets for weak and mined images, plus a previous-data
+pool only when prior continual training data exists.
+
+## Embed image sets
+
+Skip this section when `visualize_embeddings=false`. Otherwise launch weak and
+mined embedding commands, each with its exact output marked fresh:
+
+```bash
+HF_ARGS=()
+if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+  HF_ARGS=(--pass-hf-token)
+fi
+WEAK_DIR="$ITER_DIR/embeddings/viz_weak"
+WEAK_OUT="$WEAK_DIR/embeddings.parquet"
+MINED_EMBED_DIR="$ITER_DIR/embeddings/augmented"
+MINED_EMBED_OUT="$MINED_EMBED_DIR/mined_embeddings.parquet"
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/run_deft_container.py" \
+    --results-dir "$RESULTS_DIR" --image ds \
+    --stage-dir "$WEAK_DIR" --name viz_weak_embed \
+    "${HF_ARGS[@]}" \
+    --fresh-output "$WEAK_OUT" -- \
+    embedding image_embeddings -e /specs/image_embed_spec.yaml \
+    input_parquet=/results/iter_$N/embeddings/viz_weak/input.parquet \
+    output_parquet=/results/iter_$N/embeddings/viz_weak/embeddings.parquet
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/run_deft_container.py" \
+    --results-dir "$RESULTS_DIR" --image ds \
+    --stage-dir "$MINED_EMBED_DIR" --name viz_mined_embed \
+    "${HF_ARGS[@]}" \
+    --fresh-output "$MINED_EMBED_OUT" -- \
+    embedding image_embeddings -e /specs/image_embed_spec.yaml \
+    input_parquet=/results/iter_$N/mining/mined_unique_images.parquet \
+    output_parquet=/results/iter_$N/embeddings/augmented/mined_embeddings.parquet
+```
+
+If `iter_N/embeddings/previous/prev_pool.parquet` exists and is non-empty,
+also run:
+
+```bash
+PREV_DIR="$ITER_DIR/embeddings/previous"
+PREV_OUT="$PREV_DIR/embeddings.parquet"
+HF_ARGS=()
+if [ "${REQUIRES_HF_TOKEN:-false}" = true ]; then
+  HF_ARGS=(--pass-hf-token)
+fi
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" \
+  "$SKILL_ROOT/scripts/run_deft_container.py" \
+    --results-dir "$RESULTS_DIR" --image ds \
+    --stage-dir "$PREV_DIR" --name viz_previous_embed \
+    "${HF_ARGS[@]}" \
+    --fresh-output "$PREV_OUT" -- \
+    embedding image_embeddings -e /specs/image_embed_spec.yaml \
+    input_parquet=/results/iter_$N/embeddings/previous/prev_pool.parquet \
+    output_parquet=/results/iter_$N/embeddings/previous/embeddings.parquet
+```
+
+Do not synthesize an empty previous-data input; absence at iteration 1 without
+a seed training set is the normal branch.
+
+## Finish and commit
+
+When `VISUALIZE_EMBEDDINGS=true`, run t-SNE only after all required embedding
+launches succeed. Do not run this adapter for contact-sheets-only mode:
+
+```bash
+if [ "$VISUALIZE_EMBEDDINGS" = true ]; then
+  "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+    "$SKILL_ROOT/scripts/run_iaa_stage.py" visualize-finish \
+      --results-dir "$RESULTS_DIR" \
+      --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N"
+fi
+```
+
+Always run this host step through `deft_python.sh`; its thread caps prevent
+many-core OpenBLAS failures during scikit-learn t-SNE.
+
+Build commit arguments only for enabled/configured outputs. Repeat
+`--visualize-command-status` for weak, mined, and—when run—previous embedding
+statuses:
+
+```bash
+VIS_ARGS=()
+VIS_ARGS+=(--visualize-prepare-status \
+  "$ITER_DIR/visualization/visualize-prepare.host.status.json")
+if [ "$VISUALIZE" = true ]; then
+  VIS_ARGS+=(--samples-dir "$ITER_DIR/visualization/samples")
+fi
+if [ "$VISUALIZE_EMBEDDINGS" = true ]; then
+  VIS_ARGS+=(--tsne-plot "$ITER_DIR/visualization/tsne_plot.png")
+  VIS_ARGS+=(--visualize-finish-status \
+    "$ITER_DIR/visualization/visualize-finish.host.status.json")
+  VIS_ARGS+=(--visualize-command-status "$WEAK_DIR/viz_weak_embed.status.json")
+  VIS_ARGS+=(--visualize-command-status "$MINED_EMBED_DIR/viz_mined_embed.status.json")
+  if [ -n "${PREV_OUT:-}" ]; then
+    VIS_ARGS+=(--visualize-command-status "$PREV_DIR/viz_previous_embed.status.json")
+  fi
+fi
+
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "iter$N" --stage visualize \
+    "${VIS_ARGS[@]}" --summary "iter$N approved visualizations completed"
+```
+
+When both flags are false, use instead:
+
+```bash
+"$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
+  "$SKILL_ROOT/scripts/commit_stage.py" \
+    --results-dir "$RESULTS_DIR" --iter-label "iter$N" \
+    --stage visualize --skip \
+    --summary "visualization disabled in approved config"
+```
+
+Empty contact sheets, missing t-SNE, nonzero embedding status, or stale image
+embeddings are stage failures. Apply the normal one-correction limit; do not
+change the approved visualization flags to make the audit pass.

--- a/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
@@ -1,0 +1,2762 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audit IAA DEFT disk state and report the only safe resume/completion status.
+
+This is deliberately read-only. It cross-checks ``deft_state.json``,
+``loop_log.jsonl``, every artifact path recorded in iteration state, the
+mined-list / eval-split leakage invariant, and ``mining_selection_history.json``
+coherence. Agents run it on startup, after compaction, before each stage, and
+before claiming that the loop or an iteration completed. ``commit_stage.py``
+runs it after every commit and rolls back on INVALID.
+
+Exit codes:
+  0: structurally valid (IN_PROGRESS, FAILED, or COMPLETE)
+  1: inconsistent/invalid, non-terminal with --require-terminal, or
+     unsuccessful with --require-complete
+  2: input file could not be loaded
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import pathlib
+import re
+import sys
+from typing import Any
+
+import yaml
+
+from checkpoint_contract import validate_best_checkpoint
+from command_contract import (
+    command_sha256,
+    expected_container_command,
+    expected_hf_forwarding,
+    expected_image_kind,
+)
+from metric_contract import (
+    compare,
+    pick_best,
+    validate_contract,
+)
+from parse_iaa_metrics import build_result
+
+
+WORKFLOW = "tao-run-deft-iaa"
+SCHEMA_VERSION = "3"
+VALID_ITERATION_STATUSES = {"pending", "in_progress", "complete", "failed"}
+VALID_LOG_STATUSES = {"ok", "error", "skip"}
+SKIPPABLE_STAGES = {"visualize"}
+VALID_STAGES = {
+    "dataset_setup",
+    "pool_embed",
+    "evaluate",
+    "gap_analysis",
+    "data_mining",
+    "history_select",
+    "visualize",
+    "train",
+    "loop_stop",
+}
+VALID_COMPLETED_STAGES = VALID_STAGES - {"loop_stop"}
+LOOP_STOP_REASONS = ("kpi_met", "max_iterations", "hard_stop")
+COMPLETION_REASONS = ("kpi_met", "max_iterations")
+VERIFY_MARKER = "VERIFY: PASS"
+CHECKSUM_MARKER = "CHECKSUM_VERIFY: PASS"
+EVAL_SUCCESS_MARKER = "Evaluate finished successfully"
+TRAIN_SUCCESS_MARKER = "Train finished successfully."
+RUN_SPEC_NAMES = (
+    "deft_config.yaml",
+    "tao_spec.yaml",
+    "text_embed_spec.yaml",
+    "image_embed_spec.yaml",
+    "mining_spec.yaml",
+    "approval.json",
+)
+PINNED_PYT_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"  # versions-key: images.tao_toolkit.pyt
+PINNED_DS_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services"  # versions-key: images.tao_toolkit.data_services
+
+# Artifact fields recorded by commit_stage._apply_success, grouped by the
+# containment scope commit_stage enforced at commit time.
+RESULTS_SCOPED_FILE_FIELDS = {
+    "source_pool_parquet",
+    "pool_embeddings_parquet",
+    "gaps_parquet",
+    "target_embeddings_parquet",
+    "mined_parquet",
+    "candidate_pairs",
+    "mined_image_list",
+    "mined_pairs",
+    "mined_manifest",
+    "cumulative_names",
+    "tsne_plot",
+    "mining_history",
+    "caption_history",
+    "pool_embed_command_status",
+    "verify_log",
+    "checksum_verify_log",
+    "dataset_materialize_status",
+    "gap_analysis_status",
+}
+PHASE_SCOPED_FILE_FIELDS = {
+    "metrics_aggregate_csv",
+    "eval_status_json",
+    "best_ckpt_path",
+    "best_ckpt_metadata",
+    "best_ckpt_source",
+    "iteration_summary",
+    "target_embed_command_status",
+    "knn_command_status",
+    "eval_command_status",
+    "train_command_status",
+    "train_tao_status_json",
+    "visualize_prepare_status",
+    "visualize_finish_status",
+    "pretrained_state",
+    "train_config",
+    "eval_config",
+    "eval_config_status",
+    "iteration_summary_status",
+    "mining_postprocess_status",
+    "history_select_status",
+    "train_config_status",
+    "publish_checkpoint_status",
+}
+UNSCOPED_FILE_FIELDS: set[str] = set()
+RESULTS_SCOPED_DIR_FIELDS = {"iaa_splits_dir", "samples_dir"}
+PATH_FIELDS = (
+    RESULTS_SCOPED_FILE_FIELDS
+    | PHASE_SCOPED_FILE_FIELDS
+    | UNSCOPED_FILE_FIELDS
+    | RESULTS_SCOPED_DIR_FIELDS
+)
+MARKER_FIELDS = {
+    "verify_log": VERIFY_MARKER,
+    "checksum_verify_log": CHECKSUM_MARKER,
+    "eval_status_json": EVAL_SUCCESS_MARKER,
+    "train_tao_status_json": TRAIN_SUCCESS_MARKER,
+}
+FIELD_STAGE = {
+    "iaa_splits_dir": "dataset_setup",
+    "source_pool_parquet": "dataset_setup",
+    "verify_log": "dataset_setup",
+    "checksum_verify_log": "dataset_setup",
+    "dataset_materialize_status": "dataset_setup",
+    "pool_embeddings_parquet": "pool_embed",
+    "pool_embed_command_status": "pool_embed",
+    "metrics_aggregate_csv": "evaluate",
+    "eval_status_json": "evaluate",
+    "metric_result": "evaluate",
+    "eval_command_status": "evaluate",
+    "iteration_summary": "evaluate",
+    "eval_config": "evaluate",
+    "eval_config_status": "evaluate",
+    "iteration_summary_status": "evaluate",
+    "gaps_parquet": "gap_analysis",
+    "caption_history": "gap_analysis",
+    "gap_analysis_status": "gap_analysis",
+    "target_embeddings_parquet": "data_mining",
+    "mined_parquet": "data_mining",
+    "candidate_pairs": "data_mining",
+    "target_embed_command_status": "data_mining",
+    "knn_command_status": "data_mining",
+    "mining_postprocess_status": "data_mining",
+    "mined_image_list": "history_select",
+    "mined_pairs": "history_select",
+    "mined_manifest": "history_select",
+    "cumulative_names": "history_select",
+    "mining_history": "history_select",
+    "history_select_status": "history_select",
+    "samples_dir": "visualize",
+    "tsne_plot": "visualize",
+    "visualize_skipped": "visualize",
+    "visualize_prepare_status": "visualize",
+    "visualize_finish_status": "visualize",
+    "best_ckpt_path": "train",
+    "best_ckpt_metadata": "train",
+    "best_ckpt_source": "train",
+    "publish_mode": "train",
+    "pretrained_state": "train",
+    "train_config": "train",
+    "train_command_status": "train",
+    "train_tao_status_json": "train",
+    "train_config_status": "train",
+    "publish_checkpoint_status": "train",
+}
+# Proof fields required in state for a successful (status=ok) log event. A
+# status=skip visualize event requires visualize_skipped=true instead.
+STAGE_REQUIRED_FIELDS = {
+    "dataset_setup": (
+        "iaa_splits_dir",
+        "source_pool_parquet",
+        "verify_log",
+        "dataset_materialize_status",
+    ),
+    "pool_embed": ("pool_embeddings_parquet", "pool_embed_command_status"),
+    "evaluate": (
+        "metrics_aggregate_csv",
+        "eval_status_json",
+        "metric_result",
+        "eval_command_status",
+        "eval_config",
+        "eval_config_status",
+    ),
+    "gap_analysis": ("gaps_parquet", "caption_history", "gap_analysis_status"),
+    "data_mining": (
+        "target_embeddings_parquet",
+        "mined_parquet",
+        "candidate_pairs",
+        "target_embed_command_status",
+        "knn_command_status",
+        "mining_postprocess_status",
+    ),
+    "history_select": (
+        "mined_image_list",
+        "mined_pairs",
+        "mined_manifest",
+        "cumulative_names",
+        "history_select_status",
+    ),
+    "visualize": (),
+    "train": (
+        "best_ckpt_path",
+        "best_ckpt_metadata",
+        "best_ckpt_source",
+        "publish_mode",
+        "pretrained_state",
+        "train_config",
+        "train_command_status",
+        "train_tao_status_json",
+        "train_config_status",
+        "publish_checkpoint_status",
+    ),
+}
+# "Read first" column of the Stage Reference Modules table in
+# references/scripts-and-agents.md.
+STAGE_REFERENCES = {
+    "dataset_setup": ("references/data-layout.md",),
+    "pool_embed": ("references/mining.md",),
+    "evaluate": ("references/clip-train-eval.md", "references/metric-contract.md"),
+    "gap_analysis": ("references/gap-analysis.md",),
+    "data_mining": ("references/mining.md",),
+    "history_select": ("references/mining.md",),
+    "visualize": ("references/visualization.md",),
+    "train": ("references/clip-train-eval.md",),
+    "loop_stop": ("references/pipeline-and-state.md",),
+}
+PIPELINE_REFERENCE = ("references/pipeline-and-state.md",)
+RECOVERY_REFERENCE = "references/scripts-and-agents.md"
+
+
+def _skill_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parent.parent
+
+
+def _render_references(names: tuple[str, ...]) -> str:
+    root = _skill_root()
+    return ", ".join(str(root / name) for name in names)
+
+
+def _load_state(path: pathlib.Path) -> dict[str, Any]:
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError("deft_state.json root must be an object")
+    return data
+
+
+def _load_log(path: pathlib.Path, errors: list[str]) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for lineno, raw in enumerate(path.read_text().splitlines(), 1):
+        if not raw.strip():
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            errors.append(f"loop_log.jsonl:{lineno}: invalid JSON: {exc}")
+            continue
+        if not isinstance(entry, dict):
+            errors.append(f"loop_log.jsonl:{lineno}: entry must be an object")
+            continue
+        entries.append(entry)
+    return entries
+
+
+def _iteration_sort_key(label: str) -> tuple[int, int]:
+    if label == "baseline":
+        return (0, 0)
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    return (1, int(match.group(1))) if match else (2, 0)
+
+
+def _phase_dir(results_dir: pathlib.Path, label: str) -> pathlib.Path | None:
+    """Map an iteration label to its iaa_deft results directory.
+
+    baseline artifacts live under zs/ (zero-shot); iterN artifacts live under
+    iter_<N>/ — note the underscore. Mirrors commit_stage._phase_dir.
+    """
+    if label == "baseline":
+        return results_dir / "zs"
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    return results_dir / f"iter_{match.group(1)}" if match else None
+
+
+def _is_finite_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _gate_from_state(
+    state: dict[str, Any], errors: list[str]
+) -> dict[str, Any] | None:
+    """Return the one canonical metric contract or record why it is invalid."""
+    contract = state.get("metric_contract")
+    if contract is None:
+        errors.append("state.metric_contract is required")
+        return None
+    try:
+        normalized = validate_contract(contract)
+    except ValueError as exc:
+        errors.append(f"invalid state.metric_contract: {exc}")
+        return None
+    return {
+        key: normalized[key]
+        for key in ("metric_name", "query_type", "op", "target")
+    }
+
+
+def _gate_passes(gate: dict[str, Any], value: Any) -> bool:
+    """A null-target gate never passes: the loop runs to max_iterations."""
+    if gate.get("target") is None:
+        return False
+    return compare(float(value), gate["op"], float(gate["target"]))
+
+
+def _render_target(gate: dict[str, Any]) -> str:
+    if gate.get("target") is None:
+        return "none (run to max_iterations)"
+    return f"{gate['op']} {gate['target']:g}"
+
+
+def _expected_next(
+    entry: dict[str, Any], state: dict[str, Any]
+) -> set[tuple[str, str]]:
+    """Legal successor events, including KPI and iteration branch predicates."""
+    label = str(entry.get("iteration"))
+    stage = str(entry.get("stage"))
+    if entry.get("status") == "error":
+        return {(label, "loop_stop")}
+    if stage == "loop_stop":
+        return set()
+    if label == "baseline":
+        if stage == "dataset_setup":
+            return {("baseline", "pool_embed")}
+        if stage == "pool_embed":
+            return {("baseline", "evaluate")}
+        if stage == "evaluate":
+            info = state.get("iterations", {}).get("baseline", {})
+            result = info.get("metric_result") if isinstance(info, dict) else None
+            return (
+                {("baseline", "loop_stop")}
+                if isinstance(result, dict) and result.get("passed") is True
+                else {("baseline", "gap_analysis")}
+            )
+        if stage == "gap_analysis":
+            return {("iter1", "data_mining")}
+        return set()
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    if not match:
+        return set()
+    number = int(match.group(1))
+    if stage == "data_mining":
+        return {(label, "history_select")}
+    if stage == "history_select":
+        return {(label, "visualize")}
+    if stage == "visualize":
+        return {(label, "train")}
+    if stage == "train":
+        return {(label, "evaluate")}
+    if stage == "evaluate":
+        info = state.get("iterations", {}).get(label, {})
+        result = info.get("metric_result") if isinstance(info, dict) else None
+        passed = isinstance(result, dict) and result.get("passed") is True
+        raw_maximum = state.get("max_iterations")
+        if not isinstance(raw_maximum, int) or isinstance(raw_maximum, bool):
+            return set()
+        maximum = raw_maximum
+        return (
+            {(label, "loop_stop")}
+            if passed or number >= maximum
+            else {(label, "gap_analysis")}
+        )
+    if stage == "gap_analysis":
+        raw_maximum = state.get("max_iterations")
+        if not isinstance(raw_maximum, int) or isinstance(raw_maximum, bool):
+            return set()
+        maximum = raw_maximum
+        return (
+            {(f"iter{number + 1}", "data_mining")}
+            if number < maximum
+            else set()
+        )
+    return set()
+
+
+def _basenames(path: pathlib.Path, field: str, errors: list[str]) -> set[str]:
+    try:
+        text = path.read_text(errors="replace")
+    except OSError as exc:
+        errors.append(f"{field} cannot be read: {exc}")
+        return set()
+    return {
+        pathlib.Path(line.strip()).name
+        for line in text.splitlines()
+        if line.strip()
+    }
+
+
+def _expected_artifact_path(
+    field: str,
+    label: str,
+    results_dir: pathlib.Path,
+    config: dict[str, Any],
+) -> pathlib.Path | None:
+    phase = _phase_dir(results_dir, label)
+    if phase is None:
+        return None
+    fixed = {
+        "iaa_splits_dir": results_dir / "iaa_splits",
+        "source_pool_parquet": results_dir / "embeddings" / "source" / "source_pool.parquet",
+        "verify_log": results_dir / "dataset_setup" / "rebuild_verify.log",
+        "checksum_verify_log": results_dir / "dataset_setup" / "checksum_verify.log",
+        "dataset_materialize_status": results_dir / "dataset_setup" / "dataset-materialize.host.status.json",
+        "pool_embeddings_parquet": results_dir / "embeddings" / "source" / "embeddings.parquet",
+        "pool_embed_command_status": results_dir / "embeddings" / "source" / "pool_embed.status.json",
+        "metrics_aggregate_csv": phase / "evaluate" / "nvidia_iaa_metrics_aggregate.csv",
+        "eval_status_json": phase / "evaluate" / "status.json",
+        "eval_command_status": phase / "evaluate" / "evaluate.status.json",
+        "iteration_summary": phase / "iteration_summary.json",
+        "eval_config": phase / "specs" / "eval_config.yaml",
+        "eval_config_status": phase / "specs" / "eval-config.host.status.json",
+        "iteration_summary_status": phase / "iteration-summary.host.status.json",
+        "target_embeddings_parquet": phase / "embeddings" / "target" / "embeddings.parquet",
+        "target_embed_command_status": phase / "embeddings" / "target" / "target_embed.status.json",
+        "mined_parquet": phase / "mining" / "mined_samples.parquet",
+        "knn_command_status": phase / "mining" / "knn.status.json",
+        "mined_image_list": phase / "mining" / "mined_image_list.txt",
+        "mined_pairs": phase / "mining" / "mined_pairs.json",
+        "mined_manifest": phase / "mining" / "mined_dataset.json",
+        "cumulative_names": phase / "mining" / "cumulative_mined_unique_names.json",
+        "mining_history": results_dir / "mining_selection_history.json",
+        "caption_history": results_dir / "caption_selection_history.json",
+        "samples_dir": phase / "visualization" / "samples",
+        "tsne_plot": phase / "visualization" / "tsne_plot.png",
+        "visualize_prepare_status": phase / "visualization" / "visualize-prepare.host.status.json",
+        "visualize_finish_status": phase / "visualization" / "visualize-finish.host.status.json",
+        "best_ckpt_path": phase / "train" / "best" / "clip_best_val_t2i_mAP.pth",
+        "best_ckpt_metadata": phase / "train" / "best" / "clip_best_val_t2i_mAP.json",
+        "train_tao_status_json": phase / "train" / "status.json",
+        "train_command_status": phase / "train" / "train.status.json",
+        "pretrained_state": phase / "pretrained" / "model_state.pth",
+        "train_config": phase / "specs" / "train_config.yaml",
+        "mining_postprocess_status": phase / "mining" / "mining-postprocess.host.status.json",
+        "history_select_status": phase / "mining" / "history-select.host.status.json",
+        "train_config_status": phase / "specs" / "train-config.host.status.json",
+        "publish_checkpoint_status": phase / "train" / "publish-checkpoint.host.status.json",
+    }
+    if field == "gaps_parquet":
+        feed = 1 if label == "baseline" else int(label[4:]) + 1
+        return results_dir / f"iter_{feed}" / "gaps" / "kpi_gaps.parquet"
+    if field == "gap_analysis_status":
+        feed = 1 if label == "baseline" else int(label[4:]) + 1
+        return results_dir / f"iter_{feed}" / "gaps" / "gap-analysis.host.status.json"
+    if field == "candidate_pairs":
+        candidate = phase / "mining"
+        if config.get("history_aware"):
+            candidate = candidate / "history_candidates"
+        return candidate / "mined_pairs.json"
+    return fixed.get(field)
+
+
+def _validate_json_shape(
+    path: pathlib.Path,
+    field: str,
+    errors: list[str],
+    expected_type: type,
+) -> Any | None:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"{field} must contain valid JSON: {path}: {exc}")
+        return None
+    if not isinstance(payload, expected_type) or not payload:
+        errors.append(
+            f"{field} JSON must be a non-empty {expected_type.__name__}: {path}"
+        )
+        return None
+    return payload
+
+
+def _validate_parquet(
+    path: pathlib.Path,
+    field: str,
+    errors: list[str],
+    required_columns: set[str],
+) -> None:
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        errors.append(
+            f"{field} validation requires pyarrow in the selected interpreter"
+        )
+        return
+    try:
+        parquet = pq.ParquetFile(path)
+        rows = parquet.metadata.num_rows
+        columns = set(parquet.schema_arrow.names)
+    except Exception as exc:
+        errors.append(f"{field} is not a readable parquet: {path}: {exc}")
+        return
+    if rows < 1:
+        errors.append(f"{field} parquet has zero rows: {path}")
+    missing = sorted(required_columns - columns)
+    if missing:
+        errors.append(f"{field} parquet is missing columns {missing}: {path}")
+
+
+def _validate_png(path: pathlib.Path, field: str, errors: list[str]) -> None:
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(8)
+    except OSError as exc:
+        errors.append(f"{field} cannot be read: {path}: {exc}")
+        return
+    if header != b"\x89PNG\r\n\x1a\n":
+        errors.append(f"{field} must be a PNG image: {path}")
+
+
+def _validate_image_dir(path: pathlib.Path, field: str, errors: list[str]) -> None:
+    try:
+        images = sorted(
+            item
+            for item in path.rglob("*")
+            if item.is_file() and item.suffix.lower() in {".png", ".jpg", ".jpeg"}
+        )
+    except OSError as exc:
+        errors.append(f"{field} cannot be listed: {path}: {exc}")
+        return
+    links = [item for item in path.rglob("*") if item.is_symlink()]
+    if links:
+        errors.append(f"{field} must not contain symlinks: {links[0]}")
+        return
+    for image in images:
+        try:
+            with image.open("rb") as handle:
+                header = handle.read(8)
+        except OSError:
+            continue
+        if header == b"\x89PNG\r\n\x1a\n" or header[:3] == b"\xff\xd8\xff":
+            return
+    errors.append(
+        f"{field} must contain at least one non-empty PNG or JPEG image: {path}"
+    )
+
+
+def _config_section(
+    root: dict[str, Any], key: str, field: str, errors: list[str]
+) -> dict[str, Any]:
+    value = root.get(key)
+    if not isinstance(value, dict):
+        errors.append(f"{field}.{key} must be an object")
+        return {}
+    return value
+
+
+def _python_tree_sha256(root: pathlib.Path) -> str:
+    files = sorted(path for path in root.rglob("*.py") if "__pycache__" not in path.parts)
+    if not files:
+        raise ValueError(f"no Python files under {root}")
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _results_root_for_scope(scope: pathlib.Path) -> pathlib.Path:
+    """Find the canonical run root while retaining phase-scoped status checks."""
+    resolved = scope.resolve()
+    for candidate in (resolved, *resolved.parents):
+        if (candidate / "deft_state.json").is_file():
+            return candidate
+    return resolved
+
+
+def _validate_command_status(
+    path: pathlib.Path,
+    field: str,
+    errors: list[str],
+    scope: pathlib.Path,
+    required_name: str | None = None,
+    required_command: list[str] | None = None,
+    required_image_kind: str | None = None,
+    required_image: str | None = None,
+    required_hf_forwarding: bool | None = None,
+) -> dict[str, Any] | None:
+    payload = _validate_json_shape(path, field, errors, dict)
+    if payload is None:
+        return None
+    if payload.get("schema_version") != "1":
+        errors.append(f"{field}.schema_version must be '1'")
+    if not isinstance(payload.get("name"), str) or not payload.get("name", "").strip():
+        errors.append(f"{field}.name must be a non-empty string")
+    elif required_name is not None and payload.get("name") != required_name:
+        errors.append(
+            f"{field}.name must be {required_name!r}, got {payload.get('name')!r}"
+        )
+    if required_command is not None:
+        if payload.get("kind") != "container":
+            errors.append(f"{field}.kind must be 'container'")
+        if payload.get("command") != required_command:
+            errors.append(f"{field} does not record the approved command argv")
+        if payload.get("command_sha256") != command_sha256(required_command):
+            errors.append(f"{field}.command_sha256 does not match approved argv")
+        if payload.get("docker_exit_code") != 0:
+            errors.append(f"{field}.docker_exit_code must be zero")
+        if payload.get("artifact_error") is not None:
+            errors.append(f"{field}.artifact_error must be null")
+        if payload.get("image_kind") != required_image_kind:
+            errors.append(
+                f"{field}.image_kind must be {required_image_kind!r}, "
+                f"got {payload.get('image_kind')!r}"
+            )
+        if payload.get("image") != required_image:
+            errors.append(
+                f"{field}.image must be {required_image!r}, "
+                f"got {payload.get('image')!r}"
+            )
+        if payload.get("passed_hf_token") is not required_hf_forwarding:
+            errors.append(
+                f"{field}.passed_hf_token must be {required_hf_forwarding!r}"
+            )
+    attempt = payload.get("attempt")
+    if (
+        not isinstance(attempt, int)
+        or isinstance(attempt, bool)
+        or not 1 <= attempt <= 2
+    ):
+        errors.append(f"{field}.attempt must be an integer in [1, 2]")
+    if (
+        payload.get("workflow") != WORKFLOW
+        or payload.get("status") != "ok"
+        or payload.get("exit_code") != 0
+    ):
+        errors.append(f"{field} does not record a successful IAA DEFT command: {path}")
+    started_ns = payload.get("started_ns")
+    if not isinstance(started_ns, int) or isinstance(started_ns, bool) or started_ns < 1:
+        errors.append(f"{field}.started_ns must be a positive integer")
+    if not isinstance(payload.get("finished_at"), str) or not payload.get("finished_at", "").strip():
+        errors.append(f"{field}.finished_at must be a non-empty timestamp string")
+    fresh_outputs = payload.get("fresh_outputs")
+    results_root = _results_root_for_scope(scope)
+    if not isinstance(fresh_outputs, list) or not fresh_outputs:
+        errors.append(f"{field}.fresh_outputs must be a non-empty list")
+    else:
+        for item in fresh_outputs:
+            if not isinstance(item, str):
+                errors.append(f"{field}.fresh_outputs entries must be absolute paths")
+                continue
+            raw_output = pathlib.Path(item).expanduser()
+            absolute_output = pathlib.Path(os.path.abspath(raw_output))
+            if not raw_output.is_absolute() or raw_output != absolute_output:
+                errors.append(
+                    f"{field}.fresh_outputs entry must be a normalized "
+                    f"absolute path: {item}"
+                )
+                continue
+            try:
+                absolute_output.resolve().relative_to(results_root)
+            except ValueError:
+                errors.append(
+                    f"{field}.fresh_outputs entry must resolve under "
+                    f"{results_root}: {item}"
+                )
+    log_path = pathlib.Path(str(payload.get("log_path", ""))).expanduser()
+    if (
+        not log_path.is_absolute()
+        or not log_path.is_file()
+        or log_path.stat().st_size == 0
+        or log_path.is_symlink()
+        or log_path.resolve() != log_path
+    ):
+        errors.append(
+            f"{field}.log_path does not exist, is empty, or is unsafe: {log_path}"
+        )
+    try:
+        path.resolve().relative_to(scope.resolve())
+        log_path.resolve().relative_to(scope.resolve())
+    except ValueError:
+        errors.append(f"{field} and its log must be under {scope}")
+    return payload
+
+
+def _history_iteration_numbers(
+    payload: dict[str, Any], errors: list[str]
+) -> list[int]:
+    iterations = payload.get("iterations")
+    if isinstance(iterations, dict):
+        raw_items = list(iterations.keys())
+    elif isinstance(iterations, list):
+        raw_items = [
+            item.get("iteration") if isinstance(item, dict) else item
+            for item in iterations
+        ]
+    else:
+        errors.append(
+            "mining_selection_history.json must contain an 'iterations' "
+            "object or list"
+        )
+        return []
+    numbers: list[int] = []
+    for raw in raw_items:
+        try:
+            number = int(raw)
+        except (TypeError, ValueError):
+            errors.append(
+                f"mining_selection_history.json has a non-integer iteration "
+                f"entry: {raw!r}"
+            )
+            continue
+        if number < 1:
+            errors.append(
+                f"mining_selection_history.json has an out-of-range iteration "
+                f"entry: {number}"
+            )
+            continue
+        numbers.append(number)
+    return numbers
+
+
+def _next_action(
+    state: dict[str, Any],
+    entries: list[dict[str, Any]],
+    iterations: dict[str, Any],
+    status: str,
+    terminal: bool,
+) -> tuple[str, tuple[str, ...] | None]:
+    if status == "INVALID":
+        return "repair disk-state inconsistencies before running another stage", None
+    if status == "COMPLETE":
+        return (
+            "render the deterministic loop-end report, then present the "
+            "best-iteration evidence",
+            PIPELINE_REFERENCE,
+        )
+    if status == "FAILED":
+        if terminal:
+            return (
+                "surface the logged hard stop; do not retry automatically",
+                PIPELINE_REFERENCE,
+            )
+        label = str(entries[-1].get("iteration"))
+        return f"{label}/loop_stop", STAGE_REFERENCES["loop_stop"]
+    if not entries:
+        return "baseline/dataset_setup", STAGE_REFERENCES["dataset_setup"]
+
+    last = entries[-1]
+    label = str(last.get("iteration"))
+    stage = str(last.get("stage"))
+    max_iterations = state.get("max_iterations")
+    valid_max = isinstance(max_iterations, int) and not isinstance(
+        max_iterations, bool
+    )
+    if stage == "dataset_setup":
+        nxt = ("baseline", "pool_embed")
+    elif stage == "pool_embed":
+        nxt = ("baseline", "evaluate")
+    elif stage == "evaluate":
+        info = iterations.get(label, {})
+        result = info.get("metric_result") if isinstance(info, dict) else None
+        passed = isinstance(result, dict) and result.get("passed") is True
+        match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+        reached_max = bool(
+            match and valid_max and int(match.group(1)) >= max_iterations
+        )
+        nxt = (
+            (label, "loop_stop")
+            if passed or reached_max
+            else (label, "gap_analysis")
+        )
+    elif stage == "gap_analysis":
+        if label == "baseline":
+            nxt = ("iter1", "data_mining")
+        else:
+            number = int(label[4:])
+            if valid_max and number >= max_iterations:
+                nxt = (label, "loop_stop")
+            else:
+                nxt = (f"iter{number + 1}", "data_mining")
+    elif stage == "data_mining":
+        nxt = (label, "history_select")
+    elif stage == "history_select":
+        nxt = (label, "visualize")
+    elif stage == "visualize":
+        nxt = (label, "train")
+    elif stage == "train":
+        nxt = (label, "evaluate")
+    else:
+        return (
+            "inspect references/pipeline-and-state.md before continuing",
+            PIPELINE_REFERENCE,
+        )
+    return f"{nxt[0]}/{nxt[1]}", STAGE_REFERENCES[nxt[1]]
+
+
+def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str, Any]:
+    results_dir = results_dir.expanduser().resolve()
+    state_path = results_dir / "deft_state.json"
+    log_path = results_dir / "loop_log.jsonl"
+    state = _load_state(state_path)
+    errors: list[str] = []
+    warnings: list[str] = []
+    entries = _load_log(log_path, errors)
+    transaction_path = results_dir / ".deft_commit_transaction.json"
+    if transaction_path.exists():
+        errors.append(
+            f"interrupted stage transaction found: {transaction_path}; run "
+            f"{pathlib.Path(__file__).resolve().parent / 'recover_commit.py'} "
+            f"--results-dir {results_dir} before any other mutation"
+        )
+
+    if state.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"state.schema_version must be {SCHEMA_VERSION!r}, "
+            f"got {state.get('schema_version')!r}"
+        )
+    if state.get("workflow") != WORKFLOW:
+        errors.append(
+            f"state.workflow must be {WORKFLOW!r}, got {state.get('workflow')!r}"
+        )
+    started_at = state.get("started_at")
+    if not isinstance(started_at, str) or not started_at.strip():
+        errors.append("state.started_at must be a non-empty timestamp string")
+
+    recorded_results = pathlib.Path(str(state.get("results_dir", ""))).expanduser()
+    if not recorded_results.is_absolute():
+        errors.append("state.results_dir must be an absolute path")
+    elif recorded_results.resolve() != results_dir:
+        errors.append(
+            f"state.results_dir={recorded_results.resolve()} does not match "
+            f"{results_dir}"
+        )
+
+    for name in ("max_iterations", "current_iteration"):
+        value = state.get(name)
+        if not isinstance(value, int) or isinstance(value, bool):
+            errors.append(f"state.{name} must be an integer")
+    max_iterations = state.get("max_iterations")
+    valid_max = isinstance(max_iterations, int) and not isinstance(
+        max_iterations, bool
+    )
+    current_iteration = state.get("current_iteration")
+    valid_current = isinstance(current_iteration, int) and not isinstance(
+        current_iteration, bool
+    )
+    if valid_max and max_iterations < 1:
+        errors.append("state.max_iterations must be >= 1")
+    if valid_current and current_iteration < 0:
+        errors.append("state.current_iteration must be >= 0")
+    if valid_max and valid_current and current_iteration > max_iterations:
+        errors.append("state.current_iteration must not exceed max_iterations")
+
+    gate = _gate_from_state(state, errors)
+    gate_met = state.get("gate_met")
+    if not isinstance(gate_met, bool):
+        errors.append("state.gate_met must be a boolean")
+
+    config = state.get("config")
+    layout: dict[str, Any] = {}
+    dataset_committed = any(
+        entry.get("iteration") == "baseline"
+        and entry.get("stage") == "dataset_setup"
+        and entry.get("status") == "ok"
+        for entry in entries
+    )
+    if not isinstance(config, dict):
+        errors.append("state.config must be an object")
+        config = {}
+    else:
+        for field in ("workspace",):
+            value = config.get(field)
+            if not value:
+                errors.append(f"state.config.{field} is required")
+                continue
+            path = pathlib.Path(str(value)).expanduser()
+            if not path.is_absolute():
+                errors.append(f"state.config.{field} must be absolute: {value}")
+            elif not path.is_dir():
+                errors.append(
+                    f"state.config.{field} is not an existing directory: {value}"
+                )
+        workspace_path = pathlib.Path(str(config.get("workspace", ""))).expanduser()
+        iaa_runtime_path = pathlib.Path(__file__).resolve().parent / "iaa_deft"
+        try:
+            runtime_digest = _python_tree_sha256(iaa_runtime_path)
+        except (OSError, ValueError) as exc:
+            errors.append(f"bundled IAA runtime cannot be hashed: {exc}")
+        else:
+            if config.get("iaa_deft_bundle_sha256") != runtime_digest:
+                errors.append("bundled IAA runtime changed after initialization")
+        if workspace_path.is_absolute() and workspace_path.is_dir():
+            workspace_path = workspace_path.resolve()
+            if workspace_path == pathlib.Path(workspace_path.anchor):
+                errors.append("state.config.workspace must not be a filesystem root")
+            else:
+                try:
+                    relative_results = results_dir.resolve().relative_to(workspace_path)
+                except ValueError:
+                    errors.append("state.results_dir must be under state.config.workspace")
+                else:
+                    if relative_results == pathlib.Path("."):
+                        errors.append("state.results_dir must not equal state.config.workspace")
+        dataset_value = config.get("dataset_root")
+        if not dataset_value:
+            errors.append("state.config.dataset_root is required")
+        else:
+            dataset_path = pathlib.Path(str(dataset_value)).expanduser()
+            if not dataset_path.is_absolute():
+                errors.append(
+                    f"state.config.dataset_root must be absolute: {dataset_value}"
+                )
+            elif dataset_path.exists() and not dataset_path.is_dir():
+                errors.append(
+                    f"state.config.dataset_root is not a directory: {dataset_value}"
+                )
+            elif dataset_committed:
+                for name in ("images", "captions"):
+                    if not (dataset_path / name).is_dir():
+                        errors.append(
+                            f"committed dataset root is missing {name}/: {dataset_path}"
+                        )
+                for name in ("train_pairs.json", "val_pairs.json"):
+                    candidate = dataset_path / name
+                    if not candidate.is_file() or candidate.stat().st_size == 0:
+                        errors.append(
+                            f"committed dataset root is missing non-empty {name}: "
+                            f"{dataset_path}"
+                        )
+            if workspace_path.is_absolute() and workspace_path.is_dir():
+                try:
+                    relative_dataset = dataset_path.resolve().relative_to(
+                        workspace_path.resolve()
+                    )
+                except ValueError:
+                    errors.append(
+                        "state.config.dataset_root must be under state.config.workspace"
+                    )
+                else:
+                    if relative_dataset == pathlib.Path("."):
+                        errors.append(
+                            "state.config.dataset_root must not equal state.config.workspace"
+                        )
+                if (
+                    results_dir.resolve() in dataset_path.resolve().parents
+                    or dataset_path.resolve() in results_dir.resolve().parents
+                ):
+                    errors.append(
+                        "state.results_dir and state.config.dataset_root must not "
+                        "contain one another"
+                    )
+                if dataset_path.resolve().parent == workspace_path.resolve():
+                    errors.append(
+                        "state.config.dataset_root must be nested below a "
+                        "workspace data directory"
+                    )
+        for field in ("images_archive", "metadata_archive"):
+            value = config.get(field)
+            path = pathlib.Path(str(value or "")).expanduser()
+            if not value or not path.is_absolute() or not path.is_file() or path.stat().st_size == 0:
+                errors.append(
+                    f"state.config.{field} must be an existing absolute non-empty file: {value}"
+                )
+        checksum_value = config.get("checksums_file")
+        if checksum_value is not None:
+            checksum_path = pathlib.Path(str(checksum_value)).expanduser()
+            if (
+                not checksum_path.is_absolute()
+                or not checksum_path.is_file()
+                or checksum_path.stat().st_size == 0
+            ):
+                errors.append(
+                    "state.config.checksums_file must be null or an existing "
+                    f"absolute non-empty file: {checksum_value}"
+                )
+            else:
+                checksum_digest = hashlib.sha256(checksum_path.read_bytes()).hexdigest()
+                if config.get("checksums_file_sha256") != checksum_digest:
+                    errors.append(
+                        "state.config.checksums_file changed after initialization"
+                    )
+        elif config.get("checksums_file_sha256") is not None:
+            errors.append(
+                "state.config.checksums_file_sha256 must be null when no manifest is approved"
+            )
+        config_dir_value = config.get("config_dir")
+        config_dir_path: pathlib.Path | None = None
+        expected_config_dir = pathlib.Path(os.path.abspath(results_dir / "config"))
+        if not config_dir_value or not pathlib.Path(str(config_dir_value)).is_absolute():
+            errors.append("state.config.config_dir must be an absolute path")
+        else:
+            raw_config_dir = pathlib.Path(str(config_dir_value)).expanduser()
+            config_dir_path = pathlib.Path(os.path.abspath(raw_config_dir))
+            if config_dir_path != raw_config_dir:
+                errors.append("state.config.config_dir must be a normalized absolute path")
+            if config_dir_path.resolve() != config_dir_path:
+                errors.append("state.config.config_dir must not traverse a symlink")
+            if config_dir_path != expected_config_dir:
+                errors.append(
+                    f"state.config.config_dir must be {expected_config_dir}, "
+                    f"got {config_dir_path}"
+                )
+            if not config_dir_path.is_dir():
+                errors.append(f"state.config.config_dir does not exist: {config_dir_path}")
+
+        expected_hashes = config.get("spec_sha256")
+        if not isinstance(expected_hashes, dict) or set(expected_hashes) != set(RUN_SPEC_NAMES):
+            errors.append(
+                "state.config.spec_sha256 must bind all immutable run config files"
+            )
+            expected_hashes = {}
+        if config_dir_path is not None:
+            for name in RUN_SPEC_NAMES:
+                path = config_dir_path / name
+                if not path.is_file() or path.stat().st_size == 0:
+                    errors.append(f"approved run spec is missing or empty: {path}")
+                    continue
+                if path.resolve() != path:
+                    errors.append(f"approved run spec must not be a symlink: {path}")
+                    continue
+                digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                if expected_hashes.get(name) != digest:
+                    errors.append(
+                        f"state.config spec changed after approval: {path}"
+                    )
+            for field, name in (
+                ("deft_config", "deft_config.yaml"),
+                ("tao_spec", "tao_spec.yaml"),
+            ):
+                value = config.get(field)
+                expected_path = config_dir_path / name
+                if not value or not pathlib.Path(str(value)).is_absolute():
+                    errors.append(f"state.config.{field} must be an absolute path")
+                elif pathlib.Path(os.path.abspath(str(value))) != expected_path:
+                    errors.append(
+                        f"state.config.{field} must be {expected_path}"
+                    )
+                legacy_digest = config.get(f"{field}_sha256")
+                if legacy_digest != expected_hashes.get(name):
+                    errors.append(
+                        f"state.config.{field}_sha256 disagrees with spec_sha256"
+                    )
+
+            approval_path = config_dir_path / "approval.json"
+            approval_value = config.get("approval_manifest")
+            if (
+                not approval_value
+                or pathlib.Path(os.path.abspath(str(approval_value))) != approval_path
+            ):
+                errors.append(
+                    f"state.config.approval_manifest must be {approval_path}"
+                )
+            if approval_path.is_file():
+                try:
+                    approval = json.loads(approval_path.read_text())
+                except (OSError, json.JSONDecodeError) as exc:
+                    errors.append(f"approval manifest is invalid JSON: {exc}")
+                else:
+                    expected_approval = {
+                        "schema_version": "2",
+                        "workflow": WORKFLOW,
+                        "workspace": str(pathlib.Path(str(config.get("workspace", ""))).resolve()),
+                        "results_dir": str(results_dir.resolve()),
+                        "dataset_root": str(pathlib.Path(str(config.get("dataset_root", ""))).resolve()),
+                        "iaa_deft_bundle_sha256": config.get("iaa_deft_bundle_sha256"),
+                        "images_archive": str(pathlib.Path(str(config.get("images_archive", ""))).resolve()),
+                        "metadata_archive": str(pathlib.Path(str(config.get("metadata_archive", ""))).resolve()),
+                        "checksums_file": (
+                            str(pathlib.Path(str(config.get("checksums_file"))).resolve())
+                            if config.get("checksums_file") is not None
+                            else None
+                        ),
+                        "requires_hf_token": config.get("requires_hf_token"),
+                        "max_iterations": max_iterations,
+                        "metric_contract": gate,
+                        "pyt_image": config.get("pyt_image"),
+                        "ds_image": config.get("ds_image"),
+                    }
+                    if approval != expected_approval:
+                        errors.append(
+                            "state immutable approval fields disagree with approval.json"
+                        )
+
+            deft_path = config_dir_path / "deft_config.yaml"
+            tao_path = config_dir_path / "tao_spec.yaml"
+            if deft_path.is_file() and tao_path.is_file():
+                try:
+                    deft_payload = yaml.safe_load(deft_path.read_text())
+                    tao_payload = yaml.safe_load(tao_path.read_text())
+                except (OSError, yaml.YAMLError) as exc:
+                    errors.append(f"approved run config is not readable YAML: {exc}")
+                else:
+                    if not isinstance(deft_payload, dict) or not isinstance(tao_payload, dict):
+                        errors.append("approved DEFT and TAO config roots must be objects")
+                    else:
+                        experiment = _config_section(
+                            deft_payload, "experiment", "deft_config", errors
+                        )
+                        iteration = _config_section(
+                            deft_payload, "iteration", "deft_config", errors
+                        )
+                        training = _config_section(
+                            deft_payload, "training", "deft_config", errors
+                        )
+                        mining = _config_section(
+                            deft_payload, "mining", "deft_config", errors
+                        )
+                        history = _config_section(
+                            mining, "history_aware", "deft_config.mining", errors
+                        )
+                        gap_config = _config_section(
+                            deft_payload, "gap_analysis", "deft_config", errors
+                        )
+                        iaa = _config_section(
+                            deft_payload, "iaa", "deft_config", errors
+                        )
+                        tao_train = _config_section(
+                            tao_payload, "train", "tao_spec", errors
+                        )
+                        tao_evaluate = _config_section(
+                            tao_payload, "evaluate", "tao_spec", errors
+                        )
+                        derived = {
+                            "training_epochs": tao_train.get("num_epochs"),
+                            "num_gpus": tao_train.get("num_gpus"),
+                            "gpu_ids": tao_train.get("gpu_ids"),
+                            "history_aware": history.get("enabled"),
+                            "replay_fraction": history.get("replay_fraction"),
+                            "mining_topn": mining.get("topn"),
+                            "knn_metric": mining.get("knn_metric"),
+                            "target_query_count": gap_config.get("target_query_count"),
+                            "continual_dataset": training.get("continual_dataset"),
+                            "continual_model": training.get("continual_model"),
+                            "visualize": experiment.get("visualize"),
+                            "visualize_embeddings": experiment.get("visualize_embeddings"),
+                        }
+                        for field, expected_value in derived.items():
+                            if config.get(field) != expected_value:
+                                errors.append(
+                                    f"state.config.{field}={config.get(field)!r} "
+                                    f"disagrees with approved config {expected_value!r}"
+                                )
+                        if iteration.get("start") != 1 or iteration.get("end") != max_iterations:
+                            errors.append(
+                                "approved deft_config iteration range must be 1..max_iterations"
+                            )
+                        results_value = pathlib.Path(
+                            str(experiment.get("results_path", ""))
+                        ).expanduser()
+                        if results_value.resolve() != results_dir.resolve():
+                            errors.append(
+                                "approved deft_config experiment.results_path "
+                                "does not match state results_dir"
+                            )
+                        for key in ("train_config", "eval_config"):
+                            value = pathlib.Path(str(experiment.get(key, ""))).expanduser()
+                            if value.resolve() != tao_path.resolve():
+                                errors.append(
+                                    f"approved deft_config experiment.{key} must be {tao_path}"
+                                )
+                        if (
+                            tao_evaluate.get("num_gpus") != tao_train.get("num_gpus")
+                            or tao_evaluate.get("gpu_ids") != tao_train.get("gpu_ids")
+                        ):
+                            errors.append("approved TAO train/evaluate GPU shapes must match")
+                        if gate is not None and gap_config.get("metric_name") != gate["metric_name"]:
+                            errors.append(
+                                "approved gap metric does not match the immutable metric contract"
+                            )
+                        dataset_base = pathlib.Path(str(config.get("dataset_root", ""))).resolve()
+                        expected_iaa_paths = {
+                            "pool_pairs_source_file": dataset_base / "train_pairs.json",
+                            "eval_pairs_source_file": dataset_base / "val_pairs.json",
+                            "train_image_dir": dataset_base / "images",
+                            "train_caption_dir": dataset_base / "captions",
+                            "source_image_dir": dataset_base / "images",
+                            "source_caption_dir": dataset_base / "captions",
+                            "eval_image_dir": dataset_base / "images",
+                            "eval_caption_dir": dataset_base / "captions",
+                        }
+                        for field, expected_path in expected_iaa_paths.items():
+                            actual_path = pathlib.Path(str(iaa.get(field, ""))).expanduser()
+                            if actual_path.resolve() != expected_path.resolve():
+                                errors.append(
+                                    f"approved deft_config iaa.{field} must be {expected_path}"
+                                )
+        for field in ("platform", "pyt_image", "ds_image"):
+            value = config.get(field)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"state.config.{field} must be a non-empty string")
+        if config.get("platform") != "docker":
+            errors.append("state.config.platform must be 'docker' for this workflow")
+        if config.get("pyt_image") != PINNED_PYT_IMAGE:
+            errors.append("state.config.pyt_image must be the pinned IAA PyTorch image")
+        if config.get("ds_image") != PINNED_DS_IMAGE:
+            errors.append("state.config.ds_image must be the pinned IAA data-services image")
+        for field in ("training_epochs", "num_gpus", "mining_topn", "target_query_count"):
+            value = config.get(field)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                errors.append(f"state.config.{field} must be an integer >= 1")
+        gpu_ids = config.get("gpu_ids")
+        if not isinstance(gpu_ids, list) or len(gpu_ids) != config.get("num_gpus"):
+            errors.append("state.config.gpu_ids must match state.config.num_gpus")
+        for field in (
+            "history_aware",
+            "continual_dataset",
+            "continual_model",
+            "visualize",
+            "visualize_embeddings",
+        ):
+            if not isinstance(config.get(field), bool):
+                errors.append(f"state.config.{field} must be a boolean")
+        if not isinstance(config.get("requires_hf_token"), bool):
+            errors.append("state.config.requires_hf_token must be a boolean")
+        replay = config.get("replay_fraction")
+        if not _is_finite_number(replay) or not 0.0 <= replay <= 1.0:
+            errors.append("state.config.replay_fraction must be in [0, 1]")
+        if config.get("knn_metric") not in {"cosine", "euclidean"}:
+            errors.append("state.config.knn_metric must be cosine or euclidean")
+        raw_layout = config.get("layout")
+        if not isinstance(raw_layout, dict):
+            errors.append("state.config.layout must be an object")
+        else:
+            layout = raw_layout
+            expected_layout = {
+                "baseline_dir": results_dir / "zs",
+                "iteration_dir_template": results_dir / "iter_{N}",
+                "iaa_splits_dir": results_dir / "iaa_splits",
+                "source_embeddings_dir": results_dir / "embeddings" / "source",
+                "caption_selection_history": results_dir / "caption_selection_history.json",
+                "mining_selection_history": results_dir / "mining_selection_history.json",
+            }
+            for field, expected_path in expected_layout.items():
+                value = layout.get(field)
+                if not value:
+                    errors.append(f"state.config.layout.{field} is required")
+                elif not pathlib.Path(str(value)).expanduser().is_absolute():
+                    errors.append(
+                        f"state.config.layout.{field} must be absolute: {value}"
+                    )
+                else:
+                    actual_path = pathlib.Path(str(value)).expanduser()
+                    actual_absolute = pathlib.Path(os.path.abspath(actual_path))
+                    expected_absolute = pathlib.Path(os.path.abspath(expected_path))
+                    if actual_path != actual_absolute or actual_absolute != expected_absolute:
+                        errors.append(
+                            f"state.config.layout.{field} must be {expected_absolute}"
+                        )
+                    elif actual_absolute.resolve() != actual_absolute:
+                        errors.append(
+                            f"state.config.layout.{field} must not traverse a symlink"
+                        )
+
+    iterations = state.get("iterations")
+    if not isinstance(iterations, dict):
+        errors.append("state.iterations must be an object")
+        iterations = {}
+
+    # ---- loop_log.jsonl structural validation ------------------------------
+    seen_keys: set[tuple[str, str]] = set()
+    successful_keys: set[tuple[str, str]] = set()
+    last_successful_stage: dict[str, str] = {}
+    error_labels: set[str] = set()
+    labels_with_events: set[str] = set()
+    expected_seq = 0
+    for index, entry in enumerate(entries, 1):
+        seq = entry.get("seq")
+        if seq != expected_seq:
+            errors.append(
+                f"loop_log entry {index} has seq={seq!r}; expected {expected_seq}"
+            )
+            expected_seq = (
+                seq + 1
+                if isinstance(seq, int) and not isinstance(seq, bool)
+                else expected_seq + 1
+            )
+        else:
+            expected_seq += 1
+        label = entry.get("iteration")
+        stage = entry.get("stage")
+        log_status = entry.get("status")
+        if label != "baseline" and not (
+            isinstance(label, str) and re.fullmatch(r"iter[1-9][0-9]*", label)
+        ):
+            errors.append(f"loop_log seq={seq}: invalid iteration label {label!r}")
+        if stage not in VALID_STAGES:
+            errors.append(f"loop_log seq={seq}: invalid stage {stage!r}")
+        if log_status not in VALID_LOG_STATUSES:
+            errors.append(f"loop_log seq={seq}: invalid status {log_status!r}")
+        elif log_status == "skip" and stage not in SKIPPABLE_STAGES:
+            errors.append(
+                f"loop_log seq={seq}: status 'skip' is valid only for "
+                f"{sorted(SKIPPABLE_STAGES)}, got stage {stage!r}"
+            )
+        ts = entry.get("ts")
+        if not isinstance(ts, str) or not ts.strip():
+            errors.append(f"loop_log seq={seq}: ts must be a non-empty string")
+        if not isinstance(entry.get("summary"), str) or not entry["summary"].strip():
+            errors.append(f"loop_log seq={seq}: summary must be non-empty")
+        duration = entry.get("duration_s")
+        if duration is not None and (
+            not _is_finite_number(duration) or duration < 0
+        ):
+            errors.append(
+                f"loop_log seq={seq}: duration_s must be null or a "
+                f"non-negative finite number"
+            )
+        tokens = entry.get("tokens")
+        if tokens is not None and (
+            not isinstance(tokens, int) or isinstance(tokens, bool) or tokens < 0
+        ):
+            errors.append(
+                f"loop_log seq={seq}: tokens must be null or a non-negative integer"
+            )
+
+        key = (str(label), str(stage))
+        if key in seen_keys:
+            errors.append(
+                f"loop_log contains duplicate stage event {key}; one event per "
+                f"stage is required"
+            )
+        seen_keys.add(key)
+        labels_with_events.add(str(label))
+        if log_status in ("ok", "skip") and stage != "loop_stop":
+            successful_keys.add(key)
+            last_successful_stage[str(label)] = str(stage)
+        if log_status == "error":
+            error_labels.add(str(label))
+        if index == 1 and key != ("baseline", "dataset_setup"):
+            errors.append(
+                f"loop_log seq={seq}: first stage must be baseline/dataset_setup, "
+                f"got {label}/{stage}"
+            )
+        elif index > 1:
+            previous = entries[index - 2]
+            allowed = _expected_next(previous, state)
+            if key not in allowed:
+                rendered = ", ".join(f"{i}/{s}" for i, s in sorted(allowed))
+                errors.append(
+                    f"loop_log seq={seq}: illegal transition "
+                    f"{previous.get('iteration')}/{previous.get('stage')} -> "
+                    f"{label}/{stage}; expected one of "
+                    f"[{rendered or 'end-of-log'}]"
+                )
+
+    iter_numbers_in_log = sorted(
+        {
+            int(match.group(1))
+            for entry in entries
+            if (
+                match := re.fullmatch(
+                    r"iter([1-9][0-9]*)", str(entry.get("iteration"))
+                )
+            )
+        }
+    )
+    expected_current = max(iter_numbers_in_log, default=0)
+    if valid_current and current_iteration != expected_current:
+        errors.append(
+            f"state.current_iteration={current_iteration} does not match the "
+            f"highest iteration committed in loop_log ({expected_current})"
+        )
+    if valid_max:
+        for number in iter_numbers_in_log:
+            if number > max_iterations:
+                errors.append(
+                    f"loop_log contains iter{number} events beyond "
+                    f"max_iterations={max_iterations}"
+                )
+
+    # ---- per-iteration state validation ------------------------------------
+    passed_labels: set[str] = set()
+    metric_candidates: list[tuple[str, dict[str, Any]]] = []
+    for label in sorted(iterations, key=_iteration_sort_key):
+        info = iterations[label]
+        if label != "baseline" and not re.fullmatch(r"iter[1-9][0-9]*", label):
+            errors.append(f"state.iterations has invalid key {label!r}")
+        if not isinstance(info, dict):
+            errors.append(f"state.iterations.{label} must be an object")
+            continue
+        iter_status = info.get("status")
+        if iter_status not in VALID_ITERATION_STATUSES:
+            errors.append(
+                f"state.iterations.{label}.status={iter_status!r} is invalid"
+            )
+        elif iter_status == "failed" and label not in error_labels:
+            errors.append(
+                f"state.iterations.{label}.status is 'failed' but loop_log has "
+                f"no error event for it"
+            )
+        elif iter_status == "pending" and label in labels_with_events:
+            errors.append(
+                f"state.iterations.{label}.status is 'pending' despite "
+                f"committed log events"
+            )
+        if label not in labels_with_events and not (
+            label == "baseline" and iter_status == "pending"
+        ):
+            errors.append(
+                f"state.iterations.{label} exists but loop_log has no events "
+                f"for it"
+            )
+
+        completed = info.get("stage_completed")
+        if completed is not None and completed not in VALID_COMPLETED_STAGES:
+            errors.append(
+                f"state.iterations.{label}.stage_completed={completed!r} is "
+                f"invalid; use one of {sorted(VALID_COMPLETED_STAGES)}"
+            )
+        elif completed is not None and (label, str(completed)) not in successful_keys:
+            errors.append(
+                f"state says {label}/{completed} completed but loop_log has no "
+                f"matching successful event"
+            )
+        expected_completed = last_successful_stage.get(label)
+        if expected_completed is not None and completed != expected_completed:
+            errors.append(
+                f"state.iterations.{label}.stage_completed={completed!r} is "
+                f"stale; last successful log stage is {expected_completed!r}"
+            )
+
+        phase_root = _phase_dir(results_dir, label)
+        for field, value in info.items():
+            if field in PATH_FIELDS and value:
+                path = pathlib.Path(str(value)).expanduser()
+                if not path.is_absolute():
+                    errors.append(
+                        f"state.iterations.{label}.{field} must be absolute: "
+                        f"{value}"
+                    )
+                else:
+                    absolute = pathlib.Path(os.path.abspath(path))
+                    if absolute != path:
+                        errors.append(
+                            f"state.iterations.{label}.{field} must be a normalized "
+                            f"absolute path: {value}"
+                        )
+                    elif field != "best_ckpt_path" and path.resolve() != absolute:
+                        errors.append(
+                            f"state.iterations.{label}.{field} must not traverse "
+                            f"a symlink: {value}"
+                        )
+                if path.is_absolute() and field in RESULTS_SCOPED_DIR_FIELDS:
+                    if not path.is_dir():
+                        errors.append(
+                            f"state.iterations.{label}.{field} does not exist "
+                            f"or is not a directory: {value}"
+                        )
+                    else:
+                        try:
+                            populated = any(path.iterdir())
+                        except OSError as exc:
+                            populated = False
+                            errors.append(
+                                f"state.iterations.{label}.{field} cannot be "
+                                f"listed: {exc}"
+                            )
+                        if not populated:
+                            errors.append(
+                                f"state.iterations.{label}.{field} is empty: "
+                                f"{value}"
+                            )
+                elif path.is_absolute() and not path.exists():
+                    errors.append(
+                        f"state.iterations.{label}.{field} does not exist: "
+                        f"{value}"
+                    )
+                elif path.is_absolute() and not path.is_file():
+                    errors.append(
+                        f"state.iterations.{label}.{field} is not a file: "
+                        f"{value}"
+                    )
+                elif path.is_absolute() and path.stat().st_size == 0:
+                    errors.append(
+                        f"state.iterations.{label}.{field} is empty: {value}"
+                    )
+                elif path.is_absolute():
+                    marker = MARKER_FIELDS.get(field)
+                    if marker:
+                        try:
+                            text = path.read_text(errors="replace")
+                        except OSError as exc:
+                            errors.append(
+                                f"state.iterations.{label}.{field} cannot be "
+                                f"read: {exc}"
+                            )
+                        else:
+                            if marker not in text:
+                                errors.append(
+                                    f"state.iterations.{label}.{field} must "
+                                    f"contain {marker!r}: {value}"
+                                )
+                if path.is_absolute():
+                    scope: pathlib.Path | None = None
+                    if field in RESULTS_SCOPED_FILE_FIELDS or (
+                        field in RESULTS_SCOPED_DIR_FIELDS
+                    ):
+                        scope = results_dir
+                    elif field in PHASE_SCOPED_FILE_FIELDS:
+                        scope = phase_root
+                    if scope is not None:
+                        try:
+                            path.resolve().relative_to(scope.resolve())
+                        except ValueError:
+                            errors.append(
+                                f"state.iterations.{label}.{field} must be "
+                                f"under {scope}: {value}"
+                            )
+            stage = FIELD_STAGE.get(field)
+            if (
+                stage
+                and value is not None
+                and (label, stage) not in successful_keys
+            ):
+                errors.append(
+                    f"state.iterations.{label}.{field} is set but loop_log "
+                    f"lacks a successful {label}/{stage}"
+                )
+
+        for field in PATH_FIELDS:
+            value = info.get(field)
+            if not value:
+                continue
+            expected_path = _expected_artifact_path(
+                field, label, results_dir, config
+            )
+            if expected_path is not None:
+                actual_path = pathlib.Path(str(value)).expanduser()
+                actual_absolute = pathlib.Path(os.path.abspath(actual_path))
+                expected_absolute = pathlib.Path(os.path.abspath(expected_path))
+                if actual_absolute != expected_absolute:
+                    errors.append(
+                        f"state.iterations.{label}.{field} must be "
+                        f"{expected_absolute}, got {actual_absolute}"
+                    )
+
+        parquet_contracts = {
+            "source_pool_parquet": {"filepath", "text"},
+            "pool_embeddings_parquet": {"filepath", "embedding"},
+            "gaps_parquet": {"filepath", "text", "weak_attribute"},
+            "target_embeddings_parquet": {"filepath", "embedding"},
+            "mined_parquet": {"filepath"},
+        }
+        for field, columns in parquet_contracts.items():
+            value = info.get(field)
+            if value and pathlib.Path(str(value)).is_file():
+                _validate_parquet(
+                    pathlib.Path(str(value)),
+                    f"state.iterations.{label}.{field}",
+                    errors,
+                    columns,
+                )
+
+        json_contracts = {
+            "caption_history": dict,
+            "candidate_pairs": list,
+            "mined_pairs": list,
+            "mined_manifest": dict,
+            "cumulative_names": list,
+            "iteration_summary": dict,
+        }
+        for field, expected_type in json_contracts.items():
+            value = info.get(field)
+            if value and pathlib.Path(str(value)).is_file():
+                _validate_json_shape(
+                    pathlib.Path(str(value)),
+                    f"state.iterations.{label}.{field}",
+                    errors,
+                    expected_type,
+                )
+
+        samples_value = info.get("samples_dir")
+        if samples_value and pathlib.Path(str(samples_value)).is_dir():
+            _validate_image_dir(
+                pathlib.Path(str(samples_value)),
+                f"state.iterations.{label}.samples_dir",
+                errors,
+            )
+        tsne_value = info.get("tsne_plot")
+        if tsne_value and pathlib.Path(str(tsne_value)).is_file():
+            _validate_png(
+                pathlib.Path(str(tsne_value)),
+                f"state.iterations.{label}.tsne_plot",
+                errors,
+            )
+
+        if (label, "dataset_setup") in successful_keys:
+            splits = pathlib.Path(str(info.get("iaa_splits_dir", "")))
+            for name in ("eval_list.txt", "val_list.txt", "aug_pool_list.txt"):
+                candidate = splits / name
+                if not candidate.is_file() or candidate.stat().st_size == 0:
+                    errors.append(f"committed IAA split is missing or empty: {candidate}")
+            for name in ("eval_pairs.json", "aug_pool_pairs.json"):
+                candidate = splits / name
+                if candidate.is_file():
+                    _validate_json_shape(
+                        candidate, f"IAA split {name}", errors, list
+                    )
+                else:
+                    errors.append(f"committed IAA split is missing: {candidate}")
+
+        status_scopes = {
+            "pool_embed_command_status": results_dir,
+            "dataset_materialize_status": results_dir,
+            "gap_analysis_status": results_dir,
+        }
+        if phase_root is not None:
+            status_scopes.update(
+                {
+                    "target_embed_command_status": phase_root,
+                    "knn_command_status": phase_root,
+                    "eval_command_status": phase_root,
+                    "train_command_status": phase_root,
+                    "eval_config_status": phase_root,
+                    "iteration_summary_status": phase_root,
+                    "mining_postprocess_status": phase_root,
+                    "history_select_status": phase_root,
+                    "train_config_status": phase_root,
+                    "publish_checkpoint_status": phase_root,
+                }
+            )
+        status_outputs = {
+            "pool_embed_command_status": ("pool_embeddings_parquet",),
+            "dataset_materialize_status": ("source_pool_parquet",),
+            "gap_analysis_status": ("gaps_parquet",),
+            "target_embed_command_status": ("target_embeddings_parquet",),
+            "knn_command_status": ("mined_parquet",),
+            "eval_command_status": ("metrics_aggregate_csv", "eval_status_json"),
+            "train_command_status": ("train_tao_status_json",),
+            "eval_config_status": ("eval_config",),
+            "iteration_summary_status": ("iteration_summary",),
+            "mining_postprocess_status": ("candidate_pairs",),
+            "history_select_status": (
+                "mined_image_list",
+                "mined_pairs",
+                "mined_manifest",
+                "cumulative_names",
+                "mining_history",
+            ),
+            "train_config_status": ("train_config",),
+            "publish_checkpoint_status": (
+                "pretrained_state",
+                "best_ckpt_metadata",
+            ),
+        }
+        status_names = {
+            "pool_embed_command_status": "pool_embed",
+            "dataset_materialize_status": "dataset-materialize",
+            "gap_analysis_status": "gap-analysis",
+            "target_embed_command_status": "target_embed",
+            "knn_command_status": "knn",
+            "eval_command_status": "evaluate",
+            "train_command_status": "train",
+            "eval_config_status": "eval-config",
+            "iteration_summary_status": "iteration-summary",
+            "mining_postprocess_status": "mining-postprocess",
+            "history_select_status": "history-select",
+            "train_config_status": "train-config",
+            "publish_checkpoint_status": "publish-checkpoint",
+        }
+        for field, scope in status_scopes.items():
+            value = info.get(field)
+            if not value or not pathlib.Path(str(value)).is_file():
+                continue
+            required_command = None
+            required_kind = None
+            required_image = None
+            required_hf = None
+            if field in {
+                "pool_embed_command_status",
+                "target_embed_command_status",
+                "knn_command_status",
+                "eval_command_status",
+                "train_command_status",
+            }:
+                try:
+                    required_command = expected_container_command(
+                        status_names[field], label, config
+                    )
+                    required_kind = expected_image_kind(status_names[field])
+                    required_image = config.get(f"{required_kind}_image")
+                    required_hf = expected_hf_forwarding(status_names[field], config)
+                except ValueError as exc:
+                    errors.append(
+                        f"state.iterations.{label}.{field} command contract: {exc}"
+                    )
+            payload = _validate_command_status(
+                pathlib.Path(str(value)),
+                f"state.iterations.{label}.{field}",
+                errors,
+                scope,
+                required_name=status_names[field],
+                required_command=required_command,
+                required_image_kind=required_kind,
+                required_image=required_image,
+                required_hf_forwarding=required_hf,
+            )
+            output_fields = status_outputs[field]
+            if payload is not None:
+                fresh = {
+                    str(pathlib.Path(str(item)).resolve())
+                    for item in payload.get("fresh_outputs", [])
+                }
+                started_ns = payload.get("started_ns")
+                output_paths: list[tuple[str, pathlib.Path]] = []
+                for output_field in output_fields:
+                    output_value = info.get(output_field)
+                    if not output_value:
+                        continue
+                    output_paths.append(
+                        (output_field, pathlib.Path(str(output_value)).resolve())
+                    )
+                if field == "dataset_materialize_status":
+                    split_root = pathlib.Path(str(info.get("iaa_splits_dir", "")))
+                    output_paths.extend(
+                        (f"iaa_splits_dir/{name}", (split_root / name).resolve())
+                        for name in (
+                            "eval_list.txt",
+                            "eval_pairs.json",
+                            "val_list.txt",
+                            "aug_pool_list.txt",
+                            "aug_pool_pairs.json",
+                        )
+                    )
+                if field == "history_select_status" and not isinstance(
+                    payload.get("resume"), bool
+                ):
+                    errors.append(
+                        f"state.iterations.{label}.{field}.resume must be a boolean"
+                    )
+                for output_field, output_path in output_paths:
+                    if str(output_path) not in fresh:
+                        errors.append(
+                            f"state.iterations.{label}.{field} does not bind fresh "
+                            f"output {output_path}"
+                        )
+                    if (
+                        isinstance(started_ns, int)
+                        and output_path.is_file()
+                        and output_path.stat().st_mtime_ns < started_ns
+                        and not (
+                            field == "history_select_status"
+                            and payload.get("resume") is True
+                        )
+                    ):
+                        errors.append(
+                            f"state.iterations.{label}.{output_field} predates {field}"
+                        )
+
+        if (label, "train") in successful_keys and phase_root is not None:
+            train_command_value = info.get("train_command_status")
+            try:
+                train_payload = json.loads(
+                    pathlib.Path(str(train_command_value)).read_text()
+                )
+                if not isinstance(train_payload, dict):
+                    raise ValueError("train command status root must be an object")
+                started_ns = train_payload.get("started_ns")
+                provenance = validate_best_checkpoint(
+                    pathlib.Path(str(info.get("best_ckpt_path", ""))),
+                    phase_root / "train",
+                    started_ns=started_ns,
+                )
+            except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+                errors.append(
+                    f"state.iterations.{label} best checkpoint provenance is invalid: {exc}"
+                )
+            else:
+                for field in (
+                    "best_ckpt_path",
+                    "best_ckpt_metadata",
+                    "best_ckpt_source",
+                    "publish_mode",
+                ):
+                    if info.get(field) != provenance[field]:
+                        errors.append(
+                            f"state.iterations.{label}.{field} disagrees with "
+                            "checkpoint publication evidence"
+                        )
+                publish_value = info.get("publish_checkpoint_status")
+                try:
+                    publish_payload = json.loads(
+                        pathlib.Path(str(publish_value)).read_text()
+                    )
+                    if not isinstance(publish_payload, dict):
+                        raise ValueError(
+                            "publish checkpoint status root must be an object"
+                        )
+                except (OSError, ValueError, json.JSONDecodeError, TypeError) as exc:
+                    errors.append(
+                        f"state.iterations.{label}.publish_checkpoint_status "
+                        f"cannot be checked against best checkpoint: {exc}"
+                    )
+                else:
+                    publish_outputs = publish_payload.get("fresh_outputs")
+                    if not isinstance(publish_outputs, list):
+                        publish_outputs = []
+                    publish_fresh = {
+                        str(
+                            pathlib.Path(
+                                os.path.abspath(pathlib.Path(str(item)).expanduser())
+                            )
+                        )
+                        for item in publish_outputs
+                        if isinstance(item, str)
+                    }
+                    if provenance["best_ckpt_path"] not in publish_fresh:
+                        errors.append(
+                            f"state.iterations.{label}.publish_checkpoint_status "
+                            "does not bind the canonical best checkpoint"
+                        )
+
+        visual_statuses = info.get("visualize_command_statuses")
+        if visual_statuses is not None and phase_root is not None:
+            if not isinstance(visual_statuses, list) or not visual_statuses:
+                errors.append(
+                    f"state.iterations.{label}.visualize_command_statuses must "
+                    "be a non-empty list"
+                )
+            else:
+                expected_visual_outputs = [
+                    phase_root / "embeddings" / "viz_weak" / "embeddings.parquet",
+                    phase_root / "embeddings" / "augmented" / "mined_embeddings.parquet",
+                ]
+                previous_input = (
+                    phase_root / "embeddings" / "previous" / "prev_pool.parquet"
+                )
+                if previous_input.is_file() and previous_input.stat().st_size > 0:
+                    expected_visual_outputs.append(
+                        phase_root / "embeddings" / "previous" / "embeddings.parquet"
+                    )
+                if len(visual_statuses) != len(expected_visual_outputs):
+                    errors.append(
+                        f"state.iterations.{label}.visualize_command_statuses "
+                        f"has {len(visual_statuses)} item(s), expected "
+                        f"{len(expected_visual_outputs)}"
+                    )
+                for index, value in enumerate(visual_statuses):
+                    path = pathlib.Path(str(value))
+                    if not path.is_file():
+                        errors.append(
+                            f"state.iterations.{label}.visualize_command_statuses"
+                            f"[{index}] does not exist: {path}"
+                        )
+                    else:
+                        if index >= len(expected_visual_outputs):
+                            continue
+                        command_name = (
+                            "viz_weak_embed"
+                            if index == 0
+                            else "viz_mined_embed"
+                            if index == 1
+                            else "viz_previous_embed"
+                        )
+                        expected_status = (
+                            expected_visual_outputs[index].parent
+                            / f"{command_name}.status.json"
+                        )
+                        if pathlib.Path(os.path.abspath(path)) != expected_status:
+                            errors.append(
+                                f"state.iterations.{label}.visualize_command_statuses"
+                                f"[{index}] must be {expected_status}, got {path}"
+                            )
+                        payload = _validate_command_status(
+                            path,
+                            f"state.iterations.{label}.visualize_command_statuses[{index}]",
+                            errors,
+                            phase_root,
+                            required_name=command_name,
+                            required_command=expected_container_command(
+                                command_name, label, config
+                            ),
+                            required_image_kind=expected_image_kind(command_name),
+                            required_image=config["ds_image"],
+                            required_hf_forwarding=expected_hf_forwarding(
+                                command_name, config
+                            ),
+                        )
+                        output = expected_visual_outputs[index]
+                        _validate_parquet(
+                            output,
+                            f"state.iterations.{label}.visualization_embedding[{index}]",
+                            errors,
+                            {"filepath", "embedding"},
+                        )
+                        if payload is not None:
+                            fresh = {
+                                str(pathlib.Path(str(item)).resolve())
+                                for item in payload.get("fresh_outputs", [])
+                            }
+                            if str(output.resolve()) not in fresh:
+                                errors.append(
+                                    f"state.iterations.{label}.visualize_command_statuses"
+                                    f"[{index}] does not bind fresh output {output.resolve()}"
+                                )
+                            started_ns = payload.get("started_ns")
+                            if (
+                                isinstance(started_ns, int)
+                                and output.is_file()
+                                and output.stat().st_mtime_ns < started_ns
+                            ):
+                                errors.append(
+                                    f"state.iterations.{label}.visualization_embedding"
+                                    f"[{index}] predates its command status"
+                                )
+
+        if phase_root is not None and info.get("visualize_prepare_status"):
+            prepare_path = pathlib.Path(str(info["visualize_prepare_status"]))
+            prepare_payload = _validate_command_status(
+                prepare_path,
+                f"state.iterations.{label}.visualize_prepare_status",
+                errors,
+                phase_root,
+                required_name="visualize-prepare",
+            )
+            prepare_outputs: list[pathlib.Path] = []
+            if config.get("visualize") and info.get("samples_dir"):
+                prepare_outputs.append(pathlib.Path(str(info["samples_dir"])))
+            if config.get("visualize_embeddings"):
+                weak_input = phase_root / "embeddings" / "viz_weak" / "input.parquet"
+                mined_input = phase_root / "mining" / "mined_unique_images.parquet"
+                _validate_parquet(
+                    weak_input,
+                    f"state.iterations.{label}.visualization_weak_input",
+                    errors,
+                    {"filepath"},
+                )
+                _validate_parquet(
+                    mined_input,
+                    f"state.iterations.{label}.visualization_mined_input",
+                    errors,
+                    {"filepath"},
+                )
+                prepare_outputs.extend([weak_input, mined_input])
+                previous_input = (
+                    phase_root / "embeddings" / "previous" / "prev_pool.parquet"
+                )
+                if previous_input.is_file() and previous_input.stat().st_size > 0:
+                    _validate_parquet(
+                        previous_input,
+                        f"state.iterations.{label}.visualization_previous_input",
+                        errors,
+                        {"filepath"},
+                    )
+                    prepare_outputs.append(previous_input)
+            if prepare_payload is not None:
+                fresh = {
+                    str(pathlib.Path(str(item)).resolve())
+                    for item in prepare_payload.get("fresh_outputs", [])
+                }
+                started_ns = prepare_payload.get("started_ns")
+                for output in prepare_outputs:
+                    if str(output.resolve()) not in fresh:
+                        errors.append(
+                            f"state.iterations.{label}.visualize_prepare_status "
+                            f"does not bind fresh output {output.resolve()}"
+                        )
+                    if (
+                        isinstance(started_ns, int)
+                        and output.exists()
+                        and output.stat().st_mtime_ns < started_ns
+                    ):
+                        errors.append(
+                            f"state.iterations.{label} visualization input/output "
+                            f"predates visualize_prepare_status: {output}"
+                        )
+
+        if phase_root is not None and info.get("visualize_finish_status"):
+            finish_path = pathlib.Path(str(info["visualize_finish_status"]))
+            finish_payload = _validate_command_status(
+                finish_path,
+                f"state.iterations.{label}.visualize_finish_status",
+                errors,
+                phase_root,
+                required_name="visualize-finish",
+            )
+            tsne = pathlib.Path(str(info.get("tsne_plot", ""))).expanduser()
+            if finish_payload is not None and tsne.is_file():
+                fresh = {
+                    str(pathlib.Path(str(item)).resolve())
+                    for item in finish_payload.get("fresh_outputs", [])
+                }
+                if str(tsne.resolve()) not in fresh:
+                    errors.append(
+                        f"state.iterations.{label}.visualize_finish_status does "
+                        f"not bind fresh output {tsne.resolve()}"
+                    )
+                started_ns = finish_payload.get("started_ns")
+                if (
+                    isinstance(started_ns, int)
+                    and tsne.stat().st_mtime_ns < started_ns
+                ):
+                    errors.append(
+                        f"state.iterations.{label}.tsne_plot predates "
+                        "visualize_finish_status"
+                    )
+
+        raw_result = info.get("metric_result")
+        if raw_result is not None:
+            if not isinstance(raw_result, dict):
+                errors.append(
+                    f"state.iterations.{label}.metric_result must be an object"
+                )
+            else:
+                value = raw_result.get("value")
+                valid_value = _is_finite_number(value)
+                if not valid_value:
+                    errors.append(
+                        f"state.iterations.{label}.metric_result.value must be "
+                        f"a finite number"
+                    )
+                if gate is not None:
+                    if (
+                        str(raw_result.get("metric_name", "")).strip().lower()
+                        != gate["metric_name"].lower()
+                    ):
+                        errors.append(
+                            f"state.iterations.{label}.metric_result."
+                            f"metric_name={raw_result.get('metric_name')!r} "
+                            f"does not match the gate metric "
+                            f"{gate['metric_name']!r}"
+                        )
+                    if (
+                        str(raw_result.get("query_type", "")).strip().lower()
+                        != gate["query_type"].lower()
+                    ):
+                        errors.append(
+                            f"state.iterations.{label}.metric_result."
+                            f"query_type={raw_result.get('query_type')!r} does "
+                            f"not match the gate query type "
+                            f"{gate['query_type']!r}"
+                        )
+                passed = raw_result.get("passed")
+                if not isinstance(passed, bool):
+                    errors.append(
+                        f"state.iterations.{label}.metric_result.passed must "
+                        f"be a boolean"
+                    )
+                elif gate is not None and valid_value:
+                    recomputed = _gate_passes(gate, value)
+                    if passed != recomputed:
+                        errors.append(
+                            f"state.iterations.{label}.metric_result.passed="
+                            f"{passed} disagrees with the metric gate "
+                            f"comparison ({recomputed})"
+                        )
+                if passed is True:
+                    passed_labels.add(label)
+                evidence = raw_result.get("evidence_path")
+                if not evidence:
+                    errors.append(
+                        f"state.iterations.{label}.metric_result.evidence_path "
+                        f"is required"
+                    )
+                else:
+                    evidence_path = pathlib.Path(str(evidence)).expanduser()
+                    if not evidence_path.is_absolute():
+                        errors.append(
+                            f"state.iterations.{label}.metric_result."
+                            f"evidence_path must be absolute"
+                        )
+                    elif pathlib.Path(os.path.abspath(evidence_path)) != evidence_path:
+                        errors.append(
+                            f"state.iterations.{label}.metric_result.evidence_path "
+                            "must be a normalized absolute path"
+                        )
+                    elif evidence_path.resolve() != evidence_path:
+                        errors.append(
+                            f"state.iterations.{label}.metric_result.evidence_path "
+                            "must not traverse a symlink"
+                        )
+                    elif not evidence_path.is_file():
+                        errors.append(
+                            f"state.iterations.{label}.metric_result."
+                            f"evidence_path does not exist: {evidence}"
+                        )
+                    elif evidence_path.stat().st_size == 0:
+                        errors.append(
+                            f"state.iterations.{label}.metric_result."
+                            f"evidence_path is empty: {evidence}"
+                        )
+                    elif gate is not None and phase_root is not None:
+                        expected_evidence = phase_root / "evaluate" / "metric_result.json"
+                        if evidence_path != pathlib.Path(os.path.abspath(expected_evidence)):
+                            errors.append(
+                                f"state.iterations.{label}.metric_result.evidence_path "
+                                f"must be {expected_evidence}"
+                            )
+                        try:
+                            raw_evidence = json.loads(evidence_path.read_text())
+                        except (OSError, json.JSONDecodeError) as exc:
+                            errors.append(
+                                f"state.iterations.{label}.metric_result evidence "
+                                f"is invalid JSON: {exc}"
+                            )
+                        else:
+                            if not isinstance(raw_evidence, dict):
+                                errors.append(
+                                    f"state.iterations.{label}.metric_result "
+                                    "evidence root must be an object"
+                                )
+                                raw_evidence = {}
+                            metrics_path = phase_root / "evaluate" / "nvidia_iaa_metrics_aggregate.csv"
+                            if raw_evidence.get("iter_label") != label:
+                                errors.append(
+                                    f"metric evidence iter_label={raw_evidence.get('iter_label')!r} "
+                                    f"does not match {label!r}"
+                                )
+                            source = pathlib.Path(
+                                str(raw_evidence.get("source_csv", ""))
+                            ).expanduser()
+                            if source.resolve() != metrics_path.resolve():
+                                errors.append(
+                                    f"metric evidence source_csv must be {metrics_path}"
+                                )
+                            elif metrics_path.is_file():
+                                try:
+                                    recomputed = build_result(
+                                        argparse.Namespace(
+                                            metrics_csv=metrics_path,
+                                            metric_name=gate["metric_name"],
+                                            query_type=gate["query_type"],
+                                            op=gate["op"],
+                                            target=gate["target"],
+                                            iter_label=label,
+                                        )
+                                    )
+                                except (OSError, ValueError) as exc:
+                                    errors.append(
+                                        f"metric evidence cannot be recomputed for {label}: {exc}"
+                                    )
+                                else:
+                                    if not math.isclose(
+                                        float(value),
+                                        float(recomputed["value"]),
+                                        rel_tol=1e-12,
+                                        abs_tol=1e-12,
+                                    ):
+                                        errors.append(
+                                            f"state.iterations.{label}.metric_result.value "
+                                            "disagrees with its source CSV"
+                                        )
+                                    for source_name, payload in (
+                                        ("metric evidence", raw_evidence),
+                                        (f"state.iterations.{label}.metric_result", raw_result),
+                                    ):
+                                        for field in (
+                                            "schema_version",
+                                            "workflow",
+                                            "iter_label",
+                                            "metric_name",
+                                            "query_type",
+                                            "op",
+                                            "passed",
+                                            "row",
+                                        ):
+                                            if payload.get(field) != recomputed.get(field):
+                                                errors.append(
+                                                    f"{source_name}.{field} disagrees with "
+                                                    "the canonical CSV-derived result"
+                                                )
+                                        payload_target = payload.get("target")
+                                        expected_target = recomputed.get("target")
+                                        if (payload_target is None) != (expected_target is None):
+                                            errors.append(
+                                                f"{source_name}.target disagrees with the "
+                                                "metric contract"
+                                            )
+                                        elif payload_target is not None and (
+                                            not _is_finite_number(payload_target)
+                                            or not math.isclose(
+                                                float(payload_target),
+                                                float(expected_target),
+                                                rel_tol=1e-12,
+                                                abs_tol=1e-12,
+                                            )
+                                        ):
+                                            errors.append(
+                                                f"{source_name}.target disagrees with the "
+                                                "metric contract"
+                                            )
+                                        payload_value = payload.get("value")
+                                        if (
+                                            not _is_finite_number(payload_value)
+                                            or not math.isclose(
+                                                float(payload_value),
+                                                float(recomputed["value"]),
+                                                rel_tol=1e-12,
+                                                abs_tol=1e-12,
+                                            )
+                                        ):
+                                            errors.append(
+                                                f"{source_name}.value disagrees with the "
+                                                "canonical CSV-derived result"
+                                            )
+                if valid_value:
+                    metric_candidates.append((label, raw_result))
+
+        if iter_status == "complete":
+            if not isinstance(raw_result, dict):
+                errors.append(
+                    f"complete iteration {label} is missing metric_result for "
+                    f"the configured gate metric"
+                )
+            if (label, "evaluate") not in successful_keys:
+                errors.append(
+                    f"complete iteration {label} has no committed evaluate event"
+                )
+            if completed not in {"evaluate", "gap_analysis"}:
+                errors.append(
+                    f"complete iteration {label} must end at evaluate or "
+                    f"gap_analysis, got {completed!r}"
+                )
+
+    # ---- log -> state proof validation --------------------------------------
+    for entry in entries:
+        label = str(entry.get("iteration"))
+        stage = str(entry.get("stage"))
+        log_status = entry.get("status")
+        if stage == "loop_stop":
+            continue
+        info = iterations.get(label)
+        if not isinstance(info, dict):
+            errors.append(
+                f"loop_log commits {label}/{stage} but "
+                f"state.iterations.{label} is missing"
+            )
+            continue
+        if log_status == "error":
+            if info.get("status") != "failed":
+                errors.append(
+                    f"loop_log records {label}/{stage} error but "
+                    f"state.iterations.{label}.status is not 'failed'"
+                )
+            continue
+        if log_status == "skip":
+            if info.get("visualize_skipped") is not True:
+                errors.append(
+                    f"loop_log records {label}/visualize skip but state lacks "
+                    f"visualize_skipped=true"
+                )
+            if config.get("visualize") or config.get("visualize_embeddings"):
+                errors.append(
+                    f"loop_log skips {label}/visualize although an approved "
+                    "visualization flag is enabled"
+                )
+            continue
+        if log_status != "ok":
+            continue
+        required = STAGE_REQUIRED_FIELDS.get(stage)
+        if required:
+            missing = [field for field in required if not info.get(field)]
+            if missing:
+                errors.append(
+                    f"loop_log commits {label}/{stage} but state lacks "
+                    f"required proof: {'+'.join(missing)}"
+                )
+        if stage == "evaluate" and label != "baseline" and not info.get(
+            "iteration_summary"
+        ):
+            errors.append(
+                f"loop_log commits {label}/evaluate but state lacks "
+                "iteration_summary"
+            )
+        if stage == "evaluate" and label != "baseline" and not info.get(
+            "iteration_summary_status"
+        ):
+            errors.append(
+                f"loop_log commits {label}/evaluate but state lacks "
+                "iteration_summary_status"
+            )
+        if (
+            stage == "dataset_setup"
+            and config.get("checksums_file")
+            and not info.get("checksum_verify_log")
+        ):
+            errors.append(
+                "loop_log commits baseline/dataset_setup with an approved checksum "
+                "manifest but state lacks checksum_verify_log"
+            )
+        if stage == "history_select" and config.get("history_aware") and not info.get(
+            "mining_history"
+        ):
+            errors.append(
+                f"loop_log commits {label}/history_select but state lacks "
+                "mining_history"
+            )
+        if stage == "visualize":
+            visual_missing: list[str] = ["visualize_prepare_status"] if not info.get(
+                "visualize_prepare_status"
+            ) else []
+            if config.get("visualize") and not info.get("samples_dir"):
+                visual_missing.append("samples_dir")
+            if config.get("visualize_embeddings"):
+                if not info.get("tsne_plot"):
+                    visual_missing.append("tsne_plot")
+                if not info.get("visualize_command_statuses"):
+                    visual_missing.append("visualize_command_statuses")
+                if not info.get("visualize_finish_status"):
+                    visual_missing.append("visualize_finish_status")
+            if visual_missing:
+                errors.append(
+                    f"loop_log commits {label}/visualize but state lacks "
+                    + "+".join(visual_missing)
+                )
+        if stage == "evaluate" and label not in error_labels:
+            if info.get("status") != "complete":
+                errors.append(
+                    f"loop_log commits {label}/evaluate but "
+                    f"state.iterations.{label}.status is not 'complete'"
+                )
+
+    # ---- gate_met coherence --------------------------------------------------
+    if isinstance(gate_met, bool):
+        if gate_met and not passed_labels:
+            errors.append(
+                "state.gate_met is true but no recorded metric_result has "
+                "passed=true"
+            )
+        elif not gate_met and passed_labels:
+            errors.append(
+                f"state.gate_met is false but {sorted(passed_labels)} recorded "
+                f"passed=true"
+            )
+
+    # ---- loop_stop coherence --------------------------------------------------
+    ok_stop_events = [
+        entry
+        for entry in entries
+        if str(entry.get("stage")) == "loop_stop" and entry.get("status") == "ok"
+    ]
+    reason = state.get("loop_stop_reason")
+    if ok_stop_events:
+        if reason not in LOOP_STOP_REASONS:
+            errors.append(
+                f"loop_log has a successful loop_stop but "
+                f"state.loop_stop_reason={reason!r} is not one of "
+                f"{list(LOOP_STOP_REASONS)}"
+            )
+        elif reason == "kpi_met" and gate_met is not True:
+            errors.append(
+                "loop_stop reason kpi_met requires gate_met=true in state"
+            )
+        elif reason == "max_iterations" and valid_max and valid_current:
+            if current_iteration < max_iterations:
+                errors.append(
+                    f"loop_stop reason max_iterations requires "
+                    f"current_iteration >= max_iterations "
+                    f"({current_iteration} < {max_iterations})"
+                )
+    elif reason is not None:
+        errors.append(
+            "state.loop_stop_reason is set but loop_log has no successful "
+            "loop_stop event"
+        )
+
+    # ---- gaps parquet feed for started iterations ----------------------------
+    for number in iter_numbers_in_log:
+        label = f"iter{number}"
+        feeder = "baseline" if number == 1 else f"iter{number - 1}"
+        if (feeder, "gap_analysis") not in successful_keys:
+            errors.append(
+                f"{label} has started but loop_log lacks a committed "
+                f"{feeder}/gap_analysis to feed it"
+            )
+        feeder_info = iterations.get(feeder)
+        gaps = (
+            feeder_info.get("gaps_parquet")
+            if isinstance(feeder_info, dict)
+            else None
+        )
+        if not gaps:
+            errors.append(
+                f"{label} has started but state.iterations.{feeder}."
+                f"gaps_parquet is not recorded"
+            )
+        else:
+            gaps_path = pathlib.Path(str(gaps)).expanduser()
+            if not gaps_path.is_file() or gaps_path.stat().st_size == 0:
+                errors.append(
+                    f"{label} depends on a missing or empty gaps parquet: {gaps}"
+                )
+
+    # ---- leakage guard: mined lists must not intersect the eval split --------
+    baseline_info = iterations.get("baseline")
+    splits_value = (
+        baseline_info.get("iaa_splits_dir")
+        if isinstance(baseline_info, dict)
+        else None
+    ) or layout.get("iaa_splits_dir")
+    eval_list_path: pathlib.Path | None = None
+    if splits_value:
+        candidate = pathlib.Path(str(splits_value)).expanduser() / "eval_list.txt"
+        if candidate.is_file():
+            eval_list_path = candidate
+    if eval_list_path is not None:
+        eval_names = _basenames(eval_list_path, str(eval_list_path), errors)
+        for label in sorted(iterations, key=_iteration_sort_key):
+            info = iterations[label]
+            if not isinstance(info, dict):
+                continue
+            if (label, "history_select") not in successful_keys:
+                continue
+            mined_value = info.get("mined_image_list")
+            if not mined_value:
+                continue  # missing proof reported above
+            mined_path = pathlib.Path(str(mined_value)).expanduser()
+            if not mined_path.is_file():
+                continue  # missing artifact reported above
+            overlap = sorted(
+                _basenames(
+                    mined_path,
+                    f"state.iterations.{label}.mined_image_list",
+                    errors,
+                )
+                & eval_names
+            )
+            if overlap:
+                sample = ", ".join(overlap[:3])
+                errors.append(
+                    f"state.iterations.{label}.mined_image_list leaks "
+                    f"{len(overlap)} eval-split image(s) into training "
+                    f"(e.g. {sample}); mined lists must have zero basename "
+                    f"overlap with {eval_list_path}"
+                )
+    elif any(key[1] == "history_select" for key in successful_keys):
+        errors.append(
+            "history_select is committed but iaa_splits/eval_list.txt is "
+            "missing; leakage cannot be validated"
+        )
+
+    # ---- caption_selection_history.json coherence ----------------------------
+    caption_path = results_dir / "caption_selection_history.json"
+    committed_gap_feeds: set[int] = set()
+    for gap_label, gap_stage in successful_keys:
+        if gap_stage != "gap_analysis":
+            continue
+        if gap_label == "baseline":
+            committed_gap_feeds.add(1)
+            continue
+        gap_match = re.fullmatch(r"iter([1-9][0-9]*)", gap_label)
+        if gap_match:
+            committed_gap_feeds.add(int(gap_match.group(1)) + 1)
+    if caption_path.is_file():
+        try:
+            caption_payload = json.loads(caption_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"caption_selection_history.json is not readable JSON: {exc}")
+        else:
+            if not isinstance(caption_payload, dict):
+                errors.append("caption_selection_history.json root must be an object")
+            else:
+                raw_entries = caption_payload.get("entries")
+                if not isinstance(raw_entries, list):
+                    errors.append("caption_selection_history.json entries must be a list")
+                    caption_numbers: set[int] = set()
+                else:
+                    caption_numbers = {
+                        item.get("iter")
+                        for item in raw_entries
+                        if isinstance(item, dict)
+                        and isinstance(item.get("iter"), int)
+                        and not isinstance(item.get("iter"), bool)
+                        and item.get("iter") >= 1
+                    }
+                    malformed = [
+                        item for item in raw_entries
+                        if not isinstance(item, dict)
+                        or not isinstance(item.get("iter"), int)
+                        or isinstance(item.get("iter"), bool)
+                        or item.get("iter") < 1
+                    ]
+                    if malformed:
+                        errors.append(
+                            "caption_selection_history.json has entries with invalid iter values"
+                        )
+                for number in sorted(committed_gap_feeds - caption_numbers):
+                    errors.append(
+                        f"gap analysis feeding iter{number} is committed but caption "
+                        "history has no matching entry"
+                    )
+                extra_caption = caption_numbers - committed_gap_feeds
+                expected_in_flight: set[int] = set()
+                if entries:
+                    for next_label, next_stage in _expected_next(entries[-1], state):
+                        if next_stage == "gap_analysis":
+                            expected_in_flight.add(
+                                1 if next_label == "baseline" else int(next_label[4:]) + 1
+                            )
+                for number in sorted(extra_caption):
+                    message = (
+                        f"caption_selection_history.json records feed iteration {number} "
+                        "before its gap_analysis commit; rerun the idempotent gap adapter "
+                        "once, then commit"
+                    )
+                    if number in expected_in_flight and not require_complete:
+                        warnings.append(message)
+                    else:
+                        errors.append(message)
+                last_iter = caption_payload.get("last_iter")
+                if caption_numbers and last_iter != max(caption_numbers):
+                    errors.append(
+                        "caption_selection_history.json last_iter does not match its entries"
+                    )
+    elif committed_gap_feeds:
+        errors.append(
+            "gap_analysis is committed but caption_selection_history.json is missing"
+        )
+
+    # ---- mining_selection_history.json coherence -----------------------------
+    history_value = layout.get("mining_selection_history") or str(
+        results_dir / "mining_selection_history.json"
+    )
+    history_path = pathlib.Path(str(history_value)).expanduser()
+    committed_select = {
+        int(match.group(1))
+        for key in successful_keys
+        if key[1] == "history_select"
+        and (match := re.fullmatch(r"iter([1-9][0-9]*)", key[0]))
+    }
+    if history_path.is_file():
+        try:
+            history_payload = json.loads(history_path.read_text())
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            errors.append(
+                f"mining_selection_history.json is not readable JSON: {exc}"
+            )
+        else:
+            if not isinstance(history_payload, dict):
+                errors.append("mining_selection_history.json root must be an object")
+            else:
+                history_numbers = set(
+                    _history_iteration_numbers(history_payload, errors)
+                )
+                started = set(iter_numbers_in_log)
+                in_flight = max(started, default=0)
+                for number in sorted(history_numbers):
+                    if number in committed_select:
+                        continue
+                    if number in started and number == in_flight:
+                        message = (
+                            f"mining_selection_history.json records iteration "
+                            f"{number} but iter{number}/history_select is not "
+                            f"committed; a prior attempt crashed mid-stage — "
+                            f"follow the sanctioned recovery in "
+                            f"{RECOVERY_REFERENCE} before rerunning "
+                            f"history_select"
+                        )
+                        if require_complete:
+                            errors.append(message)
+                        else:
+                            warnings.append(message)
+                    else:
+                        errors.append(
+                            f"mining_selection_history.json records iteration "
+                            f"{number} with no committed "
+                            f"iter{number}/history_select and it is not the "
+                            f"in-flight iteration"
+                        )
+                for number in sorted(committed_select - history_numbers):
+                    errors.append(
+                        f"iter{number}/history_select is committed but "
+                        f"mining_selection_history.json has no iteration "
+                        f"{number} entry"
+                    )
+    elif config.get("history_aware") and committed_select:
+        errors.append(
+            f"history-aware selections are committed but history ledger is "
+            f"missing: {history_path}"
+        )
+
+    # ---- terminal / status classification -------------------------------------
+    last = entries[-1] if entries else None
+    terminal = bool(last and str(last.get("stage")) == "loop_stop")
+    error_entries = [entry for entry in entries if entry.get("status") == "error"]
+    if (
+        terminal
+        and last.get("status") == "ok"
+        and reason in COMPLETION_REASONS
+        and not error_entries
+    ):
+        incomplete = sorted(
+            label
+            for label, info in iterations.items()
+            if isinstance(info, dict) and info.get("status") != "complete"
+        )
+        if incomplete:
+            errors.append(
+                f"loop_stop reason {reason} requires every iteration to be "
+                f"complete; not complete: {incomplete}"
+            )
+    if errors:
+        status = "INVALID"
+    elif terminal and (
+        error_entries or last.get("status") != "ok" or reason == "hard_stop"
+    ):
+        status = "FAILED"
+        warnings.append("run ended after a hard stop; do not claim KPI completion")
+    elif terminal:
+        status = "COMPLETE"
+    elif last and last.get("status") == "error":
+        status = "FAILED"
+        warnings.append(
+            "last committed stage is a hard stop; commit loop_stop and do not "
+            "auto-retry"
+        )
+    else:
+        status = "IN_PROGRESS"
+
+    best_label: str | None = None
+    best_result: dict[str, Any] | None = None
+    if gate is not None and metric_candidates:
+        candidates = [
+            (label, iterations[label], result)
+            for label, result in metric_candidates
+            if isinstance(iterations.get(label), dict)
+        ]
+        best_label, _, best_result = pick_best(candidates, gate)
+
+    next_action, reference_names = _next_action(
+        state, entries, iterations, status, terminal
+    )
+    required_reference = (
+        _render_references(reference_names) if reference_names else None
+    )
+    if reference_names:
+        for name in reference_names:
+            if not (_skill_root() / name).is_file():
+                warnings.append(
+                    f"stage reference {name} is missing under {_skill_root()}; "
+                    f"stop rather than substituting generic commands"
+                )
+
+    return {
+        "status": status,
+        "terminal": terminal,
+        "results_dir": str(results_dir),
+        "workflow": state.get("workflow"),
+        "max_iterations": state.get("max_iterations"),
+        "current_iteration": state.get("current_iteration"),
+        "gate_met": state.get("gate_met"),
+        "loop_stop_reason": state.get("loop_stop_reason"),
+        "metric_gate": gate,
+        "log_entries": len(entries),
+        "last_committed": last,
+        "best_iteration": best_label,
+        "best_metric_result": best_result,
+        "next_action": next_action,
+        "required_reference": required_reference,
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def _print_text(report: dict[str, Any]) -> None:
+    print(f"DEFT_RUN_STATUS={report['status']}")
+    print(f"results_dir={report['results_dir']}")
+    print(
+        f"iteration={report['current_iteration']}/{report['max_iterations']} "
+        f"log_entries={report['log_entries']} gate_met={report['gate_met']}"
+    )
+    if report["last_committed"]:
+        last = report["last_committed"]
+        print(
+            "last_committed="
+            f"seq:{last.get('seq')} {last.get('iteration')}/{last.get('stage')} "
+            f"status:{last.get('status')}"
+        )
+    else:
+        print("last_committed=none")
+    gate = report["metric_gate"]
+    if report["best_iteration"] is not None and gate is not None:
+        result = report["best_metric_result"]
+        print(
+            f"best={report['best_iteration']} "
+            f"metric={gate['metric_name']}({gate['query_type']}) "
+            f"value={float(result['value']):.6g} target={_render_target(gate)}"
+        )
+    print(f"next_action={report['next_action']}")
+    if report["required_reference"]:
+        print(f"read_before_action={report['required_reference']}")
+    for warning in report["warnings"]:
+        print(f"WARNING: {warning}")
+    for error in report["errors"]:
+        print(f"ERROR: {error}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument(
+        "--require-terminal",
+        action="store_true",
+        help="fail unless the last committed event is loop_stop (failed runs allowed)",
+    )
+    parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help=(
+            "fail unless a successful loop_stop with reason kpi_met or "
+            "max_iterations exists and every iteration is complete"
+        ),
+    )
+    args = parser.parse_args(argv)
+    try:
+        report = audit(args.results_dir, require_complete=args.require_complete)
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        KeyError,
+        AttributeError,
+        ArithmeticError,
+        json.JSONDecodeError,
+        yaml.YAMLError,
+    ) as exc:
+        print(f"audit_deft_run: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_text(report)
+    if report["status"] == "INVALID":
+        return 1
+    if args.require_terminal and not report["terminal"]:
+        return 1
+    if args.require_complete and report["status"] != "COMPLETE":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/checkpoint_contract.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/checkpoint_contract.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate canonical IAA best-checkpoint publication evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+from typing import Any
+
+
+BEST_RELPATH = pathlib.Path("best/clip_best_val_t2i_mAP.pth")
+METADATA_RELPATH = pathlib.Path("best/clip_best_val_t2i_mAP.json")
+
+
+def _absolute_lexical(path: pathlib.Path | str, name: str) -> pathlib.Path:
+    raw = pathlib.Path(path).expanduser()
+    if not raw.is_absolute():
+        raise ValueError(f"{name} must be absolute: {raw}")
+    absolute = pathlib.Path(os.path.abspath(raw))
+    if absolute != raw:
+        raise ValueError(f"{name} must be a normalized absolute path: {raw}")
+    return absolute
+
+
+def _raw_checkpoint(path: pathlib.Path, train_root: pathlib.Path, name: str) -> pathlib.Path:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise ValueError(f"{name} must be an existing non-empty file: {path}")
+    if path.is_symlink() or path.resolve() != path:
+        raise ValueError(f"{name} must not be or traverse a symlink: {path}")
+    try:
+        relative = path.relative_to(train_root)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be strictly within {train_root}: {path}") from exc
+    if not relative.parts or relative.parts[0] == "best":
+        raise ValueError(f"{name} must be a raw checkpoint outside best/: {path}")
+    if path.suffix.lower() not in {".pth", ".ckpt", ".safetensors"}:
+        raise ValueError(f"{name} has an unsupported checkpoint suffix: {path}")
+    return path
+
+
+def validate_best_checkpoint(
+    best_path: pathlib.Path | str,
+    train_root: pathlib.Path | str,
+    *,
+    started_ns: int,
+) -> dict[str, Any]:
+    """Validate the canonical publication and return normalized provenance.
+
+    The IAA runtime normally creates a relative symlink at the canonical best
+    path, with hardlink/copy fallbacks. Only that one lexical symlink is
+    allowed; its target must be a direct, regular raw checkpoint in the same
+    iteration's train directory and must belong to the current Docker attempt.
+    """
+    if not isinstance(started_ns, int) or isinstance(started_ns, bool) or started_ns < 1:
+        raise ValueError("train started_ns must be a positive integer")
+    train = _absolute_lexical(train_root, "train root")
+    if not train.is_dir() or train.resolve() != train:
+        raise ValueError(f"train root must be an existing non-symlink directory: {train}")
+    best = _absolute_lexical(best_path, "best checkpoint")
+    expected = train / BEST_RELPATH
+    if best != expected:
+        raise ValueError(f"best checkpoint must be {expected}, got {best}")
+    if best.parent.resolve() != best.parent:
+        raise ValueError(f"best checkpoint parent must not traverse a symlink: {best.parent}")
+    if not os.path.lexists(best) or not best.is_file() or best.stat().st_size == 0:
+        raise ValueError(f"best checkpoint is missing, empty, or dangling: {best}")
+
+    metadata_path = train / METADATA_RELPATH
+    if (
+        not metadata_path.is_file()
+        or metadata_path.stat().st_size == 0
+        or metadata_path.is_symlink()
+        or metadata_path.resolve() != metadata_path
+    ):
+        raise ValueError(f"best checkpoint metadata must be a non-symlink file: {metadata_path}")
+    try:
+        metadata = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"best checkpoint metadata is invalid JSON: {metadata_path}: {exc}") from exc
+    if not isinstance(metadata, dict):
+        raise ValueError(f"best checkpoint metadata root must be an object: {metadata_path}")
+
+    source_value = metadata.get("selected_checkpoint")
+    if not isinstance(source_value, str) or not source_value:
+        raise ValueError("best checkpoint metadata.selected_checkpoint is required")
+    source = _raw_checkpoint(
+        _absolute_lexical(source_value, "selected checkpoint"),
+        train,
+        "selected checkpoint",
+    )
+    if source.stat().st_mtime_ns < started_ns:
+        raise ValueError(
+            f"selected checkpoint predates the current train attempt: {source}"
+        )
+    if metadata.get("published_checkpoint") != str(best):
+        raise ValueError(
+            f"best checkpoint metadata.published_checkpoint must be {best}"
+        )
+    if metadata.get("metric_name") != "val/t2i_mAP":
+        raise ValueError("best checkpoint metadata.metric_name must be 'val/t2i_mAP'")
+    mode = metadata.get("publish_mode")
+    if mode not in {"symlink", "hardlink", "copy"}:
+        raise ValueError("best checkpoint metadata.publish_mode is invalid")
+
+    if best.is_symlink():
+        if mode != "symlink":
+            raise ValueError("symlink checkpoint must record publish_mode='symlink'")
+        raw_target = pathlib.Path(os.readlink(best))
+        lexical_target = (
+            raw_target
+            if raw_target.is_absolute()
+            else pathlib.Path(os.path.abspath(best.parent / raw_target))
+        )
+        if lexical_target != source:
+            raise ValueError(
+                f"best checkpoint symlink must directly name selected checkpoint {source}"
+            )
+        if lexical_target.is_symlink() or lexical_target.resolve() != lexical_target:
+            raise ValueError("best checkpoint symlink target must not be a symlink chain")
+        if best.resolve() != source:
+            raise ValueError("best checkpoint symlink resolves to the wrong source")
+    else:
+        if best.resolve() != best:
+            raise ValueError(f"best checkpoint must not traverse a symlink: {best}")
+        if mode == "symlink":
+            raise ValueError("regular checkpoint cannot record publish_mode='symlink'")
+        if mode == "hardlink" and best.stat().st_ino != source.stat().st_ino:
+            raise ValueError("hardlink checkpoint does not share the selected source inode")
+        if best.stat().st_size != source.stat().st_size:
+            raise ValueError("published checkpoint size differs from selected source")
+
+    return {
+        "best_ckpt_path": str(best),
+        "best_ckpt_metadata": str(metadata_path),
+        "best_ckpt_source": str(source),
+        "publish_mode": mode,
+    }

--- a/skills/applications/tao-run-deft-iaa/scripts/command_contract.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/command_contract.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact Docker argv contracts for the IAA DEFT workflow."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import pathlib
+from typing import Any
+
+
+_MODEL_COMMANDS = {
+    "pool_embed",
+    "target_embed",
+    "viz_weak_embed",
+    "viz_mined_embed",
+    "viz_previous_embed",
+    "train",
+    "evaluate",
+}
+
+
+def command_sha256(command: list[str]) -> str:
+    """Return a stable digest for an argv vector (without shell parsing)."""
+    encoded = json.dumps(
+        command, ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _iteration_number(label: str) -> int:
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    if not match:
+        raise ValueError(f"container command requires iterN, got {label!r}")
+    return int(match.group(1))
+
+
+def expected_container_command(
+    name: str, label: str, config: dict[str, Any]
+) -> list[str]:
+    """Build the one allowed argv vector for a named workflow launch."""
+    if name == "pool_embed":
+        if label != "baseline":
+            raise ValueError("pool_embed is valid only for baseline")
+        return [
+            "embedding",
+            "text_embeddings",
+            "-e",
+            "/specs/text_embed_spec.yaml",
+            "input_parquet=/results/embeddings/source/source_pool.parquet",
+            "output_parquet=/results/embeddings/source/embeddings.parquet",
+        ]
+
+    if name == "evaluate":
+        phase = "zs" if label == "baseline" else f"iter_{_iteration_number(label)}"
+        return ["clip", "evaluate", "-e", f"/results/{phase}/specs/eval_config.yaml"]
+
+    number = _iteration_number(label)
+    if name == "target_embed":
+        return [
+            "embedding",
+            "text_embeddings",
+            "-e",
+            "/specs/text_embed_spec.yaml",
+            f"input_parquet=/results/iter_{number}/gaps/kpi_gaps.parquet",
+            f"output_parquet=/results/iter_{number}/embeddings/target/embeddings.parquet",
+        ]
+    if name == "knn":
+        return [
+            "tmm",
+            "nearest_neighbors",
+            "-e",
+            "/specs/mining_spec.yaml",
+            "source_parquet=/results/embeddings/source/embeddings.parquet",
+            f"target_parquet=/results/iter_{number}/embeddings/target/embeddings.parquet",
+            f"output_parquet=/results/iter_{number}/mining/mined_samples.parquet",
+            f"topn={config.get('mining_topn')}",
+            f"knn_metric={config.get('knn_metric')}",
+        ]
+    if name == "train":
+        return ["clip", "train", "-e", f"/results/iter_{number}/specs/train_config.yaml"]
+    if name == "viz_weak_embed":
+        return [
+            "embedding",
+            "image_embeddings",
+            "-e",
+            "/specs/image_embed_spec.yaml",
+            f"input_parquet=/results/iter_{number}/embeddings/viz_weak/input.parquet",
+            f"output_parquet=/results/iter_{number}/embeddings/viz_weak/embeddings.parquet",
+        ]
+    if name == "viz_mined_embed":
+        return [
+            "embedding",
+            "image_embeddings",
+            "-e",
+            "/specs/image_embed_spec.yaml",
+            f"input_parquet=/results/iter_{number}/mining/mined_unique_images.parquet",
+            f"output_parquet=/results/iter_{number}/embeddings/augmented/mined_embeddings.parquet",
+        ]
+    if name == "viz_previous_embed":
+        return [
+            "embedding",
+            "image_embeddings",
+            "-e",
+            "/specs/image_embed_spec.yaml",
+            f"input_parquet=/results/iter_{number}/embeddings/previous/prev_pool.parquet",
+            f"output_parquet=/results/iter_{number}/embeddings/previous/embeddings.parquet",
+        ]
+    raise ValueError(f"unsupported IAA DEFT container command name: {name!r}")
+
+
+def expected_image_kind(name: str) -> str:
+    if name in {"train", "evaluate"}:
+        return "pyt"
+    if name in {
+        "pool_embed",
+        "target_embed",
+        "knn",
+        "viz_weak_embed",
+        "viz_mined_embed",
+        "viz_previous_embed",
+    }:
+        return "ds"
+    raise ValueError(f"unsupported IAA DEFT container command name: {name!r}")
+
+
+def expected_hf_forwarding(name: str, config: dict[str, Any]) -> bool:
+    """Only model-loading stages receive the approved token environment."""
+    return bool(config.get("requires_hf_token")) and name in _MODEL_COMMANDS
+
+
+def expected_stage_directory(
+    name: str, label: str, results_dir: pathlib.Path
+) -> pathlib.Path:
+    """Return the exact host directory that owns a container status."""
+    if name == "pool_embed":
+        if label != "baseline":
+            raise ValueError("pool_embed is valid only for baseline")
+        return results_dir / "embeddings" / "source"
+    phase = (
+        results_dir / "zs"
+        if label == "baseline"
+        else results_dir / f"iter_{_iteration_number(label)}"
+    )
+    if name == "evaluate":
+        return phase / "evaluate"
+    _iteration_number(label)
+    suffixes = {
+        "target_embed": pathlib.Path("embeddings/target"),
+        "knn": pathlib.Path("mining"),
+        "viz_weak_embed": pathlib.Path("embeddings/viz_weak"),
+        "viz_mined_embed": pathlib.Path("embeddings/augmented"),
+        "viz_previous_embed": pathlib.Path("embeddings/previous"),
+        "train": pathlib.Path("train"),
+    }
+    suffix = suffixes.get(name)
+    if suffix is None:
+        raise ValueError(f"unsupported IAA DEFT container command name: {name!r}")
+    return phase / suffix
+
+
+def expected_fresh_outputs(
+    name: str, label: str, results_dir: pathlib.Path
+) -> list[pathlib.Path]:
+    """Return the exact files whose recreation proves a container stage."""
+    if name == "pool_embed":
+        return [results_dir / "embeddings" / "source" / "embeddings.parquet"]
+    phase = (
+        results_dir / "zs"
+        if label == "baseline"
+        else results_dir / f"iter_{_iteration_number(label)}"
+    )
+    if name == "evaluate":
+        return [
+            phase / "evaluate" / "nvidia_iaa_metrics_aggregate.csv",
+            phase / "evaluate" / "status.json",
+        ]
+    number = _iteration_number(label)
+    fixed = {
+        "target_embed": phase / "embeddings" / "target" / "embeddings.parquet",
+        "knn": phase / "mining" / "mined_samples.parquet",
+        "viz_weak_embed": phase / "embeddings" / "viz_weak" / "embeddings.parquet",
+        "viz_mined_embed": phase / "embeddings" / "augmented" / "mined_embeddings.parquet",
+        "viz_previous_embed": phase / "embeddings" / "previous" / "embeddings.parquet",
+        "train": phase / "train" / "status.json",
+    }
+    if name not in fixed:
+        raise ValueError(
+            f"unsupported IAA DEFT container command name for iter{number}: {name!r}"
+        )
+    return [fixed[name]]

--- a/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
@@ -1,0 +1,1390 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Journal and commit one IAA DEFT stage to state and loop_log.
+
+Use this instead of inline Python, jq, or hand-authored JSON. For evaluate,
+this command validates and records the metric result before adding the ordered
+log event, then runs the sibling audit script and rolls both files back if the
+audit reports INVALID.
+
+Stage machine (per iteration label):
+
+    baseline: dataset_setup -> pool_embed -> evaluate -> gap_analysis (optional
+        terminal; feeds iter1)
+    iterN:    data_mining -> history_select -> visualize (or --skip) -> train
+        -> evaluate -> gap_analysis (optional terminal; feeds iterN+1)
+    loop_stop: committed once at run level with --reason
+        (kpi_met | max_iterations | hard_stop)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+from checkpoint_contract import validate_best_checkpoint
+from command_contract import (
+    command_sha256,
+    expected_container_command,
+    expected_hf_forwarding,
+    expected_image_kind,
+)
+from log_stage import append_stage, next_seq
+
+try:
+    from record_metric_result import commit as commit_metric_result
+except ImportError:  # the sibling recorder ships with the skill
+    commit_metric_result = None
+
+STAGES = (
+    "dataset_setup",
+    "pool_embed",
+    "evaluate",
+    "gap_analysis",
+    "data_mining",
+    "history_select",
+    "visualize",
+    "train",
+    "loop_stop",
+)
+SKIPPABLE_STAGES = ("visualize",)
+_LOOP_STOP_REASONS = ("kpi_met", "max_iterations", "hard_stop")
+_EVAL_SUCCESS_MARKER = "Evaluate finished successfully"
+_TRAIN_SUCCESS_MARKER = "Train finished successfully."
+_VERIFY_MARKER = "VERIFY: PASS"
+_CHECKSUM_MARKER = "CHECKSUM_VERIFY: PASS"
+
+
+def _atomic_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_text(path: pathlib.Path, text: str) -> None:
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(text)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _required_file(path: pathlib.Path | None, name: str) -> str:
+    if path is None:
+        raise ValueError(f"{name} is required")
+    expanded = pathlib.Path(os.path.abspath(path.expanduser()))
+    if not expanded.is_absolute():
+        raise ValueError(f"{name} must be absolute: {path}")
+    if not expanded.is_file() or expanded.stat().st_size == 0:
+        raise ValueError(f"{name} must be an existing non-empty file: {path}")
+    if expanded.resolve() != expanded:
+        raise ValueError(f"{name} must not traverse a symlink: {expanded}")
+    return str(expanded)
+
+
+def _required_dir(path: pathlib.Path | None, name: str) -> str:
+    if path is None:
+        raise ValueError(f"{name} is required")
+    expanded = pathlib.Path(os.path.abspath(path.expanduser()))
+    if not expanded.is_absolute():
+        raise ValueError(f"{name} must be absolute: {path}")
+    if not expanded.is_dir() or not any(expanded.iterdir()):
+        raise ValueError(f"{name} must be an existing non-empty directory: {path}")
+    if expanded.resolve() != expanded:
+        raise ValueError(f"{name} must not traverse a symlink: {expanded}")
+    return str(expanded)
+
+
+def _required_png(path: pathlib.Path | None, name: str) -> str:
+    resolved = pathlib.Path(_required_file(path, name))
+    with resolved.open("rb") as handle:
+        header = handle.read(8)
+    if header != b"\x89PNG\r\n\x1a\n":
+        raise ValueError(f"{name} must be a PNG image: {resolved}")
+    return str(resolved.resolve())
+
+
+def _required_image_dir(path: pathlib.Path | None, name: str) -> str:
+    resolved = pathlib.Path(_required_dir(path, name))
+    links = [item for item in resolved.rglob("*") if item.is_symlink()]
+    if links:
+        raise ValueError(f"{name} must not contain symlinks: {links[0]}")
+    images = sorted(
+        item
+        for item in resolved.rglob("*")
+        if item.is_file() and item.suffix.lower() in {".png", ".jpg", ".jpeg"}
+    )
+    valid = False
+    for image in images:
+        with image.open("rb") as handle:
+            header = handle.read(8)
+        if header == b"\x89PNG\r\n\x1a\n" or header[:3] == b"\xff\xd8\xff":
+            valid = True
+            break
+    if not valid:
+        raise ValueError(
+            f"{name} must contain at least one non-empty PNG or JPEG image: {resolved}"
+        )
+    return str(resolved.resolve())
+
+
+def _require_exact(path: str, expected: pathlib.Path, name: str) -> str:
+    absolute = pathlib.Path(os.path.abspath(path))
+    expected_absolute = pathlib.Path(os.path.abspath(expected))
+    if absolute != expected_absolute:
+        raise ValueError(f"{name} must be {expected_absolute}, got {absolute}")
+    if absolute.resolve() != absolute:
+        raise ValueError(f"{name} must not traverse a symlink: {absolute}")
+    return str(absolute)
+
+
+def _required_json(
+    path: pathlib.Path | None,
+    name: str,
+    *,
+    root_type: type,
+    nonempty: bool = True,
+) -> tuple[str, Any]:
+    resolved = pathlib.Path(_required_file(path, name))
+    try:
+        payload = json.loads(resolved.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{name} must contain valid JSON: {resolved}: {exc}") from exc
+    if not isinstance(payload, root_type):
+        raise ValueError(f"{name} JSON root must be {root_type.__name__}: {resolved}")
+    if nonempty and not payload:
+        raise ValueError(f"{name} JSON must not be empty: {resolved}")
+    return str(resolved), payload
+
+
+def _required_parquet(
+    path: pathlib.Path | None,
+    name: str,
+    *,
+    required_columns: set[str],
+) -> str:
+    resolved = pathlib.Path(_required_file(path, name))
+    try:
+        import pyarrow.parquet as pq
+    except ImportError as exc:
+        raise ValueError(
+            f"{name} validation requires pyarrow; run commit_stage.py with the "
+            "approved runtime interpreter"
+        ) from exc
+    try:
+        parquet = pq.ParquetFile(resolved)
+        rows = parquet.metadata.num_rows
+        columns = set(parquet.schema_arrow.names)
+    except Exception as exc:
+        raise ValueError(f"{name} is not a readable parquet: {resolved}: {exc}") from exc
+    if rows < 1:
+        raise ValueError(f"{name} must contain at least one row: {resolved}")
+    missing = sorted(required_columns - columns)
+    if missing:
+        raise ValueError(f"{name} is missing parquet columns {missing}: {resolved}")
+    return str(resolved)
+
+
+def _required_command_status(
+    path: pathlib.Path | None,
+    name: str,
+    *,
+    scope: pathlib.Path,
+    required_output: pathlib.Path | None = None,
+    required_outputs: list[pathlib.Path] | None = None,
+    required_name: str | None = None,
+    allow_stale_resume: bool = False,
+    required_command: list[str] | None = None,
+    required_image_kind: str | None = None,
+    required_image: str | None = None,
+    required_hf_forwarding: bool | None = None,
+) -> str:
+    resolved_text, payload = _required_json(path, name, root_type=dict)
+    resolved = pathlib.Path(resolved_text)
+    _require_within(str(resolved), scope, name)
+    if (
+        payload.get("schema_version") != "1"
+        or payload.get("workflow") != "tao-run-deft-iaa"
+        or payload.get("status") != "ok"
+        or payload.get("exit_code") != 0
+        or not isinstance(payload.get("name"), str)
+        or not payload.get("name", "").strip()
+        or not isinstance(payload.get("finished_at"), str)
+        or not payload.get("finished_at", "").strip()
+    ):
+        raise ValueError(f"{name} must record a successful IAA DEFT command: {resolved}")
+    if required_name is not None and payload.get("name") != required_name:
+        raise ValueError(
+            f"{name}.name must be {required_name!r}, got {payload.get('name')!r}"
+        )
+    if required_command is not None:
+        if payload.get("kind") != "container":
+            raise ValueError(f"{name}.kind must be 'container'")
+        if payload.get("command") != required_command:
+            raise ValueError(f"{name} does not record the approved command argv")
+        if payload.get("command_sha256") != command_sha256(required_command):
+            raise ValueError(f"{name}.command_sha256 does not match its approved argv")
+        if payload.get("docker_exit_code") != 0 or payload.get("artifact_error") is not None:
+            raise ValueError(f"{name} does not prove Docker and artifact success")
+        if payload.get("image_kind") != required_image_kind:
+            raise ValueError(
+                f"{name}.image_kind must be {required_image_kind!r}, "
+                f"got {payload.get('image_kind')!r}"
+            )
+        if payload.get("image") != required_image:
+            raise ValueError(
+                f"{name}.image must be {required_image!r}, got {payload.get('image')!r}"
+            )
+        if payload.get("passed_hf_token") is not required_hf_forwarding:
+            raise ValueError(
+                f"{name}.passed_hf_token must be {required_hf_forwarding!r}"
+            )
+    attempt = payload.get("attempt")
+    if (
+        not isinstance(attempt, int)
+        or isinstance(attempt, bool)
+        or not 1 <= attempt <= 2
+    ):
+        raise ValueError(f"{name}.attempt must be an integer in [1, 2]")
+    log_path = pathlib.Path(str(payload.get("log_path", ""))).expanduser()
+    if (
+        not log_path.is_absolute()
+        or not log_path.is_file()
+        or log_path.stat().st_size == 0
+        or log_path.is_symlink()
+        or log_path.resolve() != log_path
+    ):
+        raise ValueError(f"{name} references a missing, empty, or unsafe log: {log_path}")
+    _require_within(str(log_path.resolve()), scope, f"{name}.log_path")
+    if not isinstance(payload.get("fresh_outputs"), list) or not payload["fresh_outputs"]:
+        raise ValueError(f"{name}.fresh_outputs must be a non-empty list")
+    results_root = _results_root_for_scope(scope)
+    for item in payload["fresh_outputs"]:
+        if not isinstance(item, str):
+            raise ValueError(f"{name}.fresh_outputs entries must be absolute paths")
+        raw_output = pathlib.Path(item).expanduser()
+        absolute_output = pathlib.Path(os.path.abspath(raw_output))
+        if not raw_output.is_absolute() or raw_output != absolute_output:
+            raise ValueError(
+                f"{name}.fresh_outputs entry must be a normalized absolute path: {item}"
+            )
+        _require_within(
+            str(absolute_output.resolve()), results_root, f"{name}.fresh_outputs"
+        )
+    outputs = list(required_outputs or [])
+    if required_output is not None:
+        outputs.append(required_output)
+    if outputs:
+        fresh = {
+            str(pathlib.Path(str(item)).resolve())
+            for item in payload.get("fresh_outputs", [])
+        }
+        started_ns = payload.get("started_ns")
+        if not isinstance(started_ns, int) or isinstance(started_ns, bool) or started_ns < 1:
+            raise ValueError(f"{name}.started_ns must be a positive integer")
+        for output in outputs:
+            if str(output.resolve()) not in fresh:
+                raise ValueError(
+                    f"{name} does not bind required fresh output {output.resolve()}"
+                )
+            if (
+                output.stat().st_mtime_ns < started_ns
+                and not (allow_stale_resume and payload.get("resume") is True)
+            ):
+                raise ValueError(
+                    f"{output} is older than the command recorded by {name}"
+                )
+    return str(resolved)
+
+
+def _require_within(path: str, root: pathlib.Path, name: str) -> str:
+    resolved = pathlib.Path(path).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"{name} must be under {root}: {resolved}") from exc
+    return str(resolved)
+
+
+def _results_root_for_scope(scope: pathlib.Path) -> pathlib.Path:
+    """Find the canonical run root while retaining phase-scoped status checks."""
+    resolved = scope.resolve()
+    for candidate in (resolved, *resolved.parents):
+        if (candidate / "deft_state.json").is_file():
+            return candidate
+    return resolved
+
+
+def _require_marker(path: str, marker: str, name: str) -> str:
+    try:
+        text = pathlib.Path(path).read_text(errors="replace")
+    except OSError as exc:
+        raise ValueError(f"{name} cannot be read: {path}: {exc}") from exc
+    if marker not in text:
+        raise ValueError(f"{name} must contain {marker!r}: {path}")
+    return path
+
+
+def _phase_dir(results_dir: pathlib.Path, iter_label: str) -> pathlib.Path:
+    """Map an iteration label to its iaa_deft results directory.
+
+    baseline artifacts live under zs/ (zero-shot); iterN artifacts live under
+    iter_<N>/ — note the underscore.
+    """
+    if iter_label == "baseline":
+        return results_dir / "zs"
+    match = re.fullmatch(r"iter([1-9][0-9]*)", iter_label)
+    if not match:
+        raise ValueError(f"unrecognized iteration label: {iter_label}")
+    return results_dir / f"iter_{match.group(1)}"
+
+
+def _load_log(path: pathlib.Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line_number, raw in enumerate(path.read_text().splitlines(), 1):
+        if not raw.strip():
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"loop_log line {line_number} is invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(entry, dict):
+            raise ValueError(f"loop_log line {line_number} must be an object")
+        entries.append(entry)
+    return entries
+
+
+def _expected_next(
+    entry: dict[str, Any], state: dict[str, Any]
+) -> set[tuple[str, str]]:
+    label = str(entry.get("iteration"))
+    stage = str(entry.get("stage"))
+    if entry.get("status") == "error":
+        return {(label, "loop_stop")}
+    if stage == "loop_stop":
+        return set()
+    if label == "baseline":
+        if stage == "dataset_setup":
+            return {("baseline", "pool_embed")}
+        if stage == "pool_embed":
+            return {("baseline", "evaluate")}
+        if stage == "evaluate":
+            info = state.get("iterations", {}).get("baseline", {})
+            result = info.get("metric_result") if isinstance(info, dict) else None
+            return (
+                {("baseline", "loop_stop")}
+                if isinstance(result, dict) and result.get("passed") is True
+                else {("baseline", "gap_analysis")}
+            )
+        if stage == "gap_analysis":
+            return {("iter1", "data_mining")}
+        return set()
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    if not match:
+        return set()
+    number = int(match.group(1))
+    if stage == "data_mining":
+        return {(label, "history_select")}
+    if stage == "history_select":
+        return {(label, "visualize")}
+    if stage == "visualize":
+        return {(label, "train")}
+    if stage == "train":
+        return {(label, "evaluate")}
+    if stage == "evaluate":
+        info = state.get("iterations", {}).get(label, {})
+        result = info.get("metric_result") if isinstance(info, dict) else None
+        passed = isinstance(result, dict) and result.get("passed") is True
+        maximum = int(state.get("max_iterations", 0))
+        return (
+            {(label, "loop_stop")}
+            if passed or number >= maximum
+            else {(label, "gap_analysis")}
+        )
+    if stage == "gap_analysis":
+        maximum = int(state.get("max_iterations", 0))
+        return (
+            {(f"iter{number + 1}", "data_mining")}
+            if number < maximum
+            else set()
+        )
+    return set()
+
+
+def _validate_transition(
+    entries: list[dict[str, Any]], state: dict[str, Any], iter_label: str, stage: str
+) -> None:
+    key = (iter_label, stage)
+    if any((entry.get("iteration"), entry.get("stage")) == key for entry in entries):
+        raise ValueError(f"stage already committed: {iter_label}/{stage}")
+    if not entries:
+        if key != ("baseline", "dataset_setup"):
+            raise ValueError("first stage must be baseline/dataset_setup")
+        return
+    allowed = _expected_next(entries[-1], state)
+    if key not in allowed:
+        rendered = ", ".join(f"{label}/{name}" for label, name in sorted(allowed))
+        previous = entries[-1]
+        raise ValueError(
+            f"illegal transition {previous.get('iteration')}/{previous.get('stage')} -> "
+            f"{iter_label}/{stage}; expected one of [{rendered or 'end-of-log'}]"
+        )
+
+
+def _validate_loop_stop(state: dict[str, Any], args: argparse.Namespace) -> None:
+    if args.reason is None:
+        raise ValueError(
+            "--reason is required for loop_stop "
+            f"(one of {', '.join(_LOOP_STOP_REASONS)})"
+        )
+    if args.reason == "kpi_met" and state.get("gate_met") is not True:
+        raise ValueError(
+            "loop_stop reason kpi_met requires gate_met=true in state; no "
+            "recorded evaluate result has passed the metric gate"
+        )
+    if args.reason == "max_iterations":
+        current = int(state.get("current_iteration", 0))
+        maximum = int(state.get("max_iterations", 0))
+        if current < maximum:
+            raise ValueError(
+                "loop_stop reason max_iterations requires "
+                f"current_iteration >= max_iterations ({current} < {maximum})"
+            )
+
+
+def _apply_success(
+    state: dict[str, Any],
+    phase: dict[str, Any],
+    stage: str,
+    args: argparse.Namespace,
+    results_dir: pathlib.Path,
+    iter_label: str,
+) -> None:
+    phase_root = _phase_dir(results_dir, iter_label)
+    config = state.get("config", {})
+    if stage == "visualize":
+        configured = bool(config.get("visualize") or config.get("visualize_embeddings"))
+        if args.skip and configured:
+            raise ValueError(
+                "visualize may be skipped only when both approved visualization flags are false"
+            )
+        if not args.skip and not configured:
+            raise ValueError(
+                "visualize must use --skip when both approved visualization flags are false"
+            )
+    if stage == "dataset_setup":
+        splits = pathlib.Path(
+            _require_exact(
+                _required_dir(args.iaa_splits_dir, "--iaa-splits-dir"),
+                results_dir / "iaa_splits",
+                "--iaa-splits-dir",
+            )
+        )
+        split_outputs: list[pathlib.Path] = []
+        for name, root_type in (
+            ("eval_pairs.json", list),
+            ("aug_pool_pairs.json", list),
+        ):
+            _required_json(splits / name, f"--iaa-splits-dir/{name}", root_type=root_type)
+            split_outputs.append(splits / name)
+        for name in ("eval_list.txt", "val_list.txt", "aug_pool_list.txt"):
+            _required_file(splits / name, f"--iaa-splits-dir/{name}")
+            split_outputs.append(splits / name)
+        source_pool = pathlib.Path(
+            _required_parquet(
+                args.source_pool_parquet,
+                "--source-pool-parquet",
+                required_columns={"filepath", "text"},
+            )
+        )
+        _require_exact(
+            str(source_pool),
+            results_dir / "embeddings" / "source" / "source_pool.parquet",
+            "--source-pool-parquet",
+        )
+        verify_log = _require_marker(
+            _required_file(args.verify_log, "--verify-log"),
+            _VERIFY_MARKER,
+            "--verify-log",
+        )
+        _require_exact(
+            verify_log,
+            results_dir / "dataset_setup" / "rebuild_verify.log",
+            "--verify-log",
+        )
+        dataset_status = _required_command_status(
+            args.dataset_materialize_status,
+            "--dataset-materialize-status",
+            scope=results_dir,
+            required_outputs=[*split_outputs, source_pool],
+            required_name="dataset-materialize",
+        )
+        phase["dataset_materialize_status"] = _require_exact(
+            dataset_status,
+            results_dir / "dataset_setup" / "dataset-materialize.host.status.json",
+            "--dataset-materialize-status",
+        )
+        if config.get("checksums_file"):
+            checksum_log = _require_marker(
+                _required_file(args.checksum_verify_log, "--checksum-verify-log"),
+                _CHECKSUM_MARKER,
+                "--checksum-verify-log",
+            )
+            phase["checksum_verify_log"] = _require_exact(
+                checksum_log,
+                results_dir / "dataset_setup" / "checksum_verify.log",
+                "--checksum-verify-log",
+            )
+        dataset_root = pathlib.Path(str(config.get("dataset_root", "")))
+        for name in ("images", "captions"):
+            if not (dataset_root / name).is_dir():
+                raise ValueError(f"dataset root is missing {name}/ after dataset_setup")
+        for name in ("train_pairs.json", "val_pairs.json"):
+            _required_json(dataset_root / name, f"dataset_root/{name}", root_type=list)
+        phase["iaa_splits_dir"] = str(splits)
+        phase["source_pool_parquet"] = str(source_pool)
+        phase["verify_log"] = verify_log
+    elif stage == "pool_embed":
+        output = pathlib.Path(
+            _required_parquet(
+                args.pool_embeddings_parquet,
+                "--pool-embeddings-parquet",
+                required_columns={"filepath", "embedding"},
+            )
+        )
+        _require_exact(
+            str(output),
+            results_dir / "embeddings" / "source" / "embeddings.parquet",
+            "--pool-embeddings-parquet",
+        )
+        phase["pool_embed_command_status"] = _require_exact(
+            _required_command_status(
+                args.pool_embed_command_status,
+                "--pool-embed-command-status",
+                scope=results_dir,
+                required_output=output,
+                required_name="pool_embed",
+                required_command=expected_container_command(
+                    "pool_embed", iter_label, config
+                ),
+                required_image_kind=expected_image_kind("pool_embed"),
+                required_image=config["ds_image"],
+                required_hf_forwarding=expected_hf_forwarding("pool_embed", config),
+            ),
+            results_dir / "embeddings" / "source" / "pool_embed.status.json",
+            "--pool-embed-command-status",
+        )
+        phase["pool_embeddings_parquet"] = str(output)
+    elif stage == "evaluate":
+        evaluate_dir = phase_root / "evaluate"
+        eval_config = pathlib.Path(
+            _require_exact(
+                _required_file(args.eval_config, "--eval-config"),
+                phase_root / "specs" / "eval_config.yaml",
+                "--eval-config",
+            )
+        )
+        eval_config_status = _required_command_status(
+            args.eval_config_status,
+            "--eval-config-status",
+            scope=phase_root,
+            required_output=eval_config,
+            required_name="eval-config",
+        )
+        phase["eval_config"] = str(eval_config)
+        phase["eval_config_status"] = _require_exact(
+            eval_config_status,
+            phase_root / "specs" / "eval-config.host.status.json",
+            "--eval-config-status",
+        )
+        metrics = _require_exact(
+            _required_file(args.metrics_aggregate_csv, "--metrics-aggregate-csv"),
+            evaluate_dir / "nvidia_iaa_metrics_aggregate.csv",
+            "--metrics-aggregate-csv",
+        )
+        eval_status = _require_exact(
+            _require_marker(
+                _required_file(args.eval_status_json, "--eval-status-json"),
+                _EVAL_SUCCESS_MARKER,
+                "--eval-status-json",
+            ),
+            evaluate_dir / "status.json",
+            "--eval-status-json",
+        )
+        phase["eval_command_status"] = _require_exact(
+            _required_command_status(
+                args.eval_command_status,
+                "--eval-command-status",
+                scope=phase_root,
+                required_outputs=[pathlib.Path(metrics), pathlib.Path(eval_status)],
+                required_name="evaluate",
+                required_command=expected_container_command(
+                    "evaluate", iter_label, config
+                ),
+                required_image_kind=expected_image_kind("evaluate"),
+                required_image=config["pyt_image"],
+                required_hf_forwarding=expected_hf_forwarding("evaluate", config),
+            ),
+            evaluate_dir / "evaluate.status.json",
+            "--eval-command-status",
+        )
+        phase["metrics_aggregate_csv"] = metrics
+        phase["eval_status_json"] = eval_status
+        required = ("metric_result",)
+        missing = [field for field in required if not phase.get(field)]
+        if missing or phase.get("status") != "complete":
+            raise ValueError(
+                "evaluate metric commit is incomplete; missing "
+                f"{missing or ['status=complete']}"
+            )
+        if iter_label != "baseline":
+            summary = _require_exact(
+                _required_json(
+                    args.iteration_summary,
+                    "--iteration-summary",
+                    root_type=dict,
+                )[0],
+                phase_root / "iteration_summary.json",
+                "--iteration-summary",
+            )
+            phase["iteration_summary"] = summary
+            summary_status = _required_command_status(
+                args.iteration_summary_status,
+                "--iteration-summary-status",
+                scope=phase_root,
+                required_output=pathlib.Path(summary),
+                required_name="iteration-summary",
+            )
+            phase["iteration_summary_status"] = _require_exact(
+                summary_status,
+                phase_root / "iteration-summary.host.status.json",
+                "--iteration-summary-status",
+            )
+    elif stage == "gap_analysis":
+        feed_number = 1 if iter_label == "baseline" else int(iter_label[4:]) + 1
+        gaps = _required_parquet(
+            args.gaps_parquet,
+            "--gaps-parquet",
+            required_columns={"filepath", "text", "weak_attribute"},
+        )
+        phase["gaps_parquet"] = _require_exact(
+            gaps,
+            results_dir / f"iter_{feed_number}" / "gaps" / "kpi_gaps.parquet",
+            "--gaps-parquet",
+        )
+        history_path, history_payload = _required_json(
+            args.caption_history, "--caption-history", root_type=dict
+        )
+        phase["caption_history"] = _require_exact(
+            history_path,
+            results_dir / "caption_selection_history.json",
+            "--caption-history",
+        )
+        gap_status = _required_command_status(
+            args.gap_analysis_status,
+            "--gap-analysis-status",
+            scope=results_dir / f"iter_{feed_number}",
+            required_output=pathlib.Path(phase["gaps_parquet"]),
+            required_name="gap-analysis",
+        )
+        phase["gap_analysis_status"] = _require_exact(
+            gap_status,
+            results_dir
+            / f"iter_{feed_number}"
+            / "gaps"
+            / "gap-analysis.host.status.json",
+            "--gap-analysis-status",
+        )
+        entries = history_payload.get("entries")
+        if not isinstance(entries, list) or not any(
+            isinstance(item, dict) and item.get("iter") == feed_number
+            for item in entries
+        ):
+            raise ValueError(
+                f"--caption-history has no selection entry for feed iteration {feed_number}"
+            )
+    elif stage == "data_mining":
+        target = pathlib.Path(
+            _required_parquet(
+                args.target_embeddings_parquet,
+                "--target-embeddings-parquet",
+                required_columns={"filepath", "embedding"},
+            )
+        )
+        mined = pathlib.Path(
+            _required_parquet(
+                args.mined_parquet,
+                "--mined-parquet",
+                required_columns={"filepath"},
+            )
+        )
+        candidate_dir = (
+            phase_root / "mining" / "history_candidates"
+            if config.get("history_aware")
+            else phase_root / "mining"
+        )
+        candidate = _required_json(
+            args.candidate_pairs, "--candidate-pairs", root_type=list
+        )[0]
+        phase["target_embeddings_parquet"] = _require_exact(
+            str(target),
+            phase_root / "embeddings" / "target" / "embeddings.parquet",
+            "--target-embeddings-parquet",
+        )
+        phase["mined_parquet"] = _require_exact(
+            str(mined),
+            phase_root / "mining" / "mined_samples.parquet",
+            "--mined-parquet",
+        )
+        phase["candidate_pairs"] = _require_exact(
+            candidate,
+            candidate_dir / "mined_pairs.json",
+            "--candidate-pairs",
+        )
+        phase["target_embed_command_status"] = _require_exact(
+            _required_command_status(
+                args.target_embed_command_status,
+                "--target-embed-command-status",
+                scope=phase_root,
+                required_output=target,
+                required_name="target_embed",
+                required_command=expected_container_command(
+                    "target_embed", iter_label, config
+                ),
+                required_image_kind=expected_image_kind("target_embed"),
+                required_image=config["ds_image"],
+                required_hf_forwarding=expected_hf_forwarding("target_embed", config),
+            ),
+            phase_root / "embeddings" / "target" / "target_embed.status.json",
+            "--target-embed-command-status",
+        )
+        phase["knn_command_status"] = _require_exact(
+            _required_command_status(
+                args.knn_command_status,
+                "--knn-command-status",
+                scope=phase_root,
+                required_output=mined,
+                required_name="knn",
+                required_command=expected_container_command("knn", iter_label, config),
+                required_image_kind=expected_image_kind("knn"),
+                required_image=config["ds_image"],
+                required_hf_forwarding=expected_hf_forwarding("knn", config),
+            ),
+            phase_root / "mining" / "knn.status.json",
+            "--knn-command-status",
+        )
+        postprocess_status = _required_command_status(
+            args.mining_postprocess_status,
+            "--mining-postprocess-status",
+            scope=phase_root,
+            required_output=pathlib.Path(phase["candidate_pairs"]),
+            required_name="mining-postprocess",
+        )
+        phase["mining_postprocess_status"] = _require_exact(
+            postprocess_status,
+            phase_root / "mining" / "mining-postprocess.host.status.json",
+            "--mining-postprocess-status",
+        )
+    elif stage == "history_select":
+        phase["mined_image_list"] = _require_exact(
+            _required_file(args.mined_image_list, "--mined-image-list"),
+            phase_root / "mining" / "mined_image_list.txt",
+            "--mined-image-list",
+        )
+        phase["mined_pairs"] = _require_exact(
+            _required_json(args.mined_pairs, "--mined-pairs", root_type=list)[0],
+            phase_root / "mining" / "mined_pairs.json",
+            "--mined-pairs",
+        )
+        phase["mined_manifest"] = _require_exact(
+            _required_json(args.mined_manifest, "--mined-manifest", root_type=dict)[0],
+            phase_root / "mining" / "mined_dataset.json",
+            "--mined-manifest",
+        )
+        phase["cumulative_names"] = _require_exact(
+            _required_json(args.cumulative_names, "--cumulative-names", root_type=list)[0],
+            phase_root / "mining" / "cumulative_mined_unique_names.json",
+            "--cumulative-names",
+        )
+        if config.get("history_aware"):
+            history_path, history_payload = _required_json(
+                args.mining_history, "--mining-history", root_type=dict
+            )
+            _require_exact(
+                history_path,
+                results_dir / "mining_selection_history.json",
+                "--mining-history",
+            )
+            iteration_number = int(iter_label[4:])
+            raw_iterations = history_payload.get("iterations")
+            if isinstance(raw_iterations, dict):
+                present = str(iteration_number) in raw_iterations or iteration_number in raw_iterations
+            elif isinstance(raw_iterations, list):
+                present = any(
+                    isinstance(item, dict) and item.get("iteration") == iteration_number
+                    for item in raw_iterations
+                )
+            else:
+                present = False
+            if not present:
+                raise ValueError(
+                    f"--mining-history has no committed entry for iteration {iteration_number}"
+                )
+            phase["mining_history"] = history_path
+        history_outputs = [
+            pathlib.Path(phase[field])
+            for field in (
+                "mined_image_list",
+                "mined_pairs",
+                "mined_manifest",
+                "cumulative_names",
+            )
+        ]
+        if phase.get("mining_history"):
+            history_outputs.append(pathlib.Path(phase["mining_history"]))
+        history_status = _required_command_status(
+            args.history_select_status,
+            "--history-select-status",
+            scope=phase_root,
+            required_outputs=history_outputs,
+            required_name="history-select",
+            allow_stale_resume=True,
+        )
+        phase["history_select_status"] = _require_exact(
+            history_status,
+            phase_root / "mining" / "history-select.host.status.json",
+            "--history-select-status",
+        )
+    elif stage == "visualize":
+        if args.skip:
+            # Documented branch skip: the loop config disabled visualization,
+            # so there is no t-SNE plot to record. The skip still occupies its
+            # slot in the ordered log so train remains the next legal stage.
+            phase["visualize_skipped"] = True
+        else:
+            prepare_outputs: list[pathlib.Path] = []
+            if config.get("visualize"):
+                phase["samples_dir"] = _require_exact(
+                    _required_image_dir(args.samples_dir, "--samples-dir"),
+                    phase_root / "visualization" / "samples",
+                    "--samples-dir",
+                )
+                prepare_outputs.append(pathlib.Path(phase["samples_dir"]))
+            if config.get("visualize_embeddings"):
+                weak_input = phase_root / "embeddings" / "viz_weak" / "input.parquet"
+                mined_input = phase_root / "mining" / "mined_unique_images.parquet"
+                _required_parquet(
+                    weak_input,
+                    "visualization weak input",
+                    required_columns={"filepath"},
+                )
+                _required_parquet(
+                    mined_input,
+                    "visualization mined input",
+                    required_columns={"filepath"},
+                )
+                prepare_outputs.extend([weak_input, mined_input])
+                previous_input = (
+                    phase_root / "embeddings" / "previous" / "prev_pool.parquet"
+                )
+                if previous_input.is_file() and previous_input.stat().st_size > 0:
+                    _required_parquet(
+                        previous_input,
+                        "visualization previous input",
+                        required_columns={"filepath"},
+                    )
+                    prepare_outputs.append(previous_input)
+                phase["tsne_plot"] = _require_exact(
+                    _required_png(args.tsne_plot, "--tsne-plot"),
+                    phase_root / "visualization" / "tsne_plot.png",
+                    "--tsne-plot",
+                )
+                statuses = args.visualize_command_status or []
+                expected_outputs = [
+                    phase_root / "embeddings" / "viz_weak" / "embeddings.parquet",
+                    phase_root / "embeddings" / "augmented" / "mined_embeddings.parquet",
+                ]
+                previous_input = (
+                    phase_root / "embeddings" / "previous" / "prev_pool.parquet"
+                )
+                if previous_input.is_file() and previous_input.stat().st_size > 0:
+                    expected_outputs.append(
+                        phase_root / "embeddings" / "previous" / "embeddings.parquet"
+                    )
+                if len(statuses) != len(expected_outputs):
+                    raise ValueError(
+                        "--visualize-command-status must be supplied in weak, mined, "
+                        "and optional previous-data order (expected "
+                        f"{len(expected_outputs)}, got {len(statuses)})"
+                    )
+                checked_statuses: list[str] = []
+                for status, output in zip(statuses, expected_outputs):
+                    _required_parquet(
+                        output,
+                        "visualization embedding output",
+                        required_columns={"filepath", "embedding"},
+                    )
+                    command_name = (
+                        "viz_weak_embed"
+                        if len(checked_statuses) == 0
+                        else "viz_mined_embed"
+                        if len(checked_statuses) == 1
+                        else "viz_previous_embed"
+                    )
+                    checked_statuses.append(
+                        _require_exact(
+                            _required_command_status(
+                                status,
+                                "--visualize-command-status",
+                                scope=phase_root,
+                                required_output=output,
+                                required_name=command_name,
+                                required_command=expected_container_command(
+                                    command_name, iter_label, config
+                                ),
+                                required_image_kind=expected_image_kind(command_name),
+                                required_image=config["ds_image"],
+                                required_hf_forwarding=expected_hf_forwarding(
+                                    command_name, config
+                                ),
+                            ),
+                            output.parent / f"{command_name}.status.json",
+                            "--visualize-command-status",
+                        )
+                    )
+                phase["visualize_command_statuses"] = checked_statuses
+            prepare_status = _required_command_status(
+                args.visualize_prepare_status,
+                "--visualize-prepare-status",
+                scope=phase_root,
+                required_outputs=prepare_outputs,
+                required_name="visualize-prepare",
+            )
+            phase["visualize_prepare_status"] = _require_exact(
+                prepare_status,
+                phase_root / "visualization" / "visualize-prepare.host.status.json",
+                "--visualize-prepare-status",
+            )
+            if config.get("visualize_embeddings"):
+                finish_status = _required_command_status(
+                    args.visualize_finish_status,
+                    "--visualize-finish-status",
+                    scope=phase_root,
+                    required_output=pathlib.Path(phase["tsne_plot"]),
+                    required_name="visualize-finish",
+                )
+                phase["visualize_finish_status"] = _require_exact(
+                    finish_status,
+                    phase_root / "visualization" / "visualize-finish.host.status.json",
+                    "--visualize-finish-status",
+                )
+    elif stage == "train":
+        train_dir = phase_root / "train"
+        if args.best_ckpt is None:
+            raise ValueError("--best-ckpt is required")
+        phase["pretrained_state"] = _require_exact(
+            _required_file(args.pretrained_state, "--pretrained-state"),
+            phase_root / "pretrained" / "model_state.pth",
+            "--pretrained-state",
+        )
+        phase["train_config"] = _require_exact(
+            _required_file(args.train_config, "--train-config"),
+            phase_root / "specs" / "train_config.yaml",
+            "--train-config",
+        )
+        train_config_status = _required_command_status(
+            args.train_config_status,
+            "--train-config-status",
+            scope=phase_root,
+            required_output=pathlib.Path(phase["train_config"]),
+            required_name="train-config",
+        )
+        phase["train_config_status"] = _require_exact(
+            train_config_status,
+            phase_root / "specs" / "train-config.host.status.json",
+            "--train-config-status",
+        )
+        train_tao_status = _require_exact(
+            _require_marker(
+                _required_file(args.train_tao_status_json, "--train-tao-status-json"),
+                _TRAIN_SUCCESS_MARKER,
+                "--train-tao-status-json",
+            ),
+            train_dir / "status.json",
+            "--train-tao-status-json",
+        )
+        train_command_status = _required_command_status(
+            args.train_command_status,
+            "--train-command-status",
+            scope=phase_root,
+            required_output=pathlib.Path(train_tao_status),
+            required_name="train",
+            required_command=expected_container_command("train", iter_label, config),
+            required_image_kind=expected_image_kind("train"),
+            required_image=config["pyt_image"],
+            required_hf_forwarding=expected_hf_forwarding("train", config),
+        )
+        phase["train_command_status"] = _require_exact(
+            train_command_status,
+            train_dir / "train.status.json",
+            "--train-command-status",
+        )
+        phase["train_tao_status_json"] = train_tao_status
+        train_payload = json.loads(pathlib.Path(train_command_status).read_text())
+        provenance = validate_best_checkpoint(
+            args.best_ckpt,
+            train_dir,
+            started_ns=train_payload["started_ns"],
+        )
+        phase.update(provenance)
+        publish_status = _required_command_status(
+            args.publish_checkpoint_status,
+            "--publish-checkpoint-status",
+            scope=phase_root,
+            required_outputs=[
+                pathlib.Path(phase["pretrained_state"]),
+                pathlib.Path(phase["best_ckpt_metadata"]),
+            ],
+            required_name="publish-checkpoint",
+        )
+        phase["publish_checkpoint_status"] = _require_exact(
+            publish_status,
+            phase_root / "train" / "publish-checkpoint.host.status.json",
+            "--publish-checkpoint-status",
+        )
+        publish_payload = json.loads(pathlib.Path(publish_status).read_text())
+        publish_fresh = {
+            str(pathlib.Path(os.path.abspath(pathlib.Path(str(item)).expanduser())))
+            for item in publish_payload.get("fresh_outputs", [])
+        }
+        if phase["best_ckpt_path"] not in publish_fresh:
+            raise ValueError(
+                "--publish-checkpoint-status does not bind the canonical best checkpoint"
+            )
+    elif stage != "loop_stop":
+        raise ValueError(f"unsupported stage: {stage}")
+
+    if stage != "loop_stop":
+        phase["stage_completed"] = stage
+    if stage != "evaluate" and phase.get("status") != "complete":
+        phase["status"] = "in_progress"
+
+
+def _run_audit(results_dir: pathlib.Path) -> tuple[bool, str, str]:
+    """Run the sibling audit script against the results dir.
+
+    Returns (ok, run_status, output). Missing or unrecognized audit evidence
+    fails closed and rolls the transaction back.
+    """
+    audit_script = pathlib.Path(__file__).resolve().parent / "audit_deft_run.py"
+    if not audit_script.is_file():
+        return (
+            False,
+            "MISSING",
+            f"audit script not found: {audit_script}",
+        )
+    completed = subprocess.run(
+        [sys.executable, str(audit_script), "--results-dir", str(results_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = (completed.stdout + completed.stderr).strip()
+    match = re.search(r"DEFT_RUN_STATUS=(\S+)", output)
+    run_status = match.group(1) if match else "UNKNOWN"
+    if completed.returncode != 0 or run_status not in {
+        "IN_PROGRESS",
+        "FAILED",
+        "COMPLETE",
+    }:
+        return False, run_status, output
+    return True, run_status, output
+
+
+def commit(args: argparse.Namespace) -> dict[str, Any]:
+    if not re.fullmatch(r"baseline|iter[1-9][0-9]*", args.iter_label):
+        raise ValueError("--iter-label must be baseline or iterN (N >= 1)")
+    if args.skip and args.stage not in SKIPPABLE_STAGES:
+        raise ValueError(
+            f"--skip is valid only for: {', '.join(SKIPPABLE_STAGES)}"
+        )
+    if args.skip and args.status == "error":
+        raise ValueError("--skip and --status error are mutually exclusive")
+    if not args.summary.strip():
+        raise ValueError("--summary must be a non-empty outcome description")
+
+    results_dir = args.results_dir.expanduser().resolve()
+    state_path = results_dir / "deft_state.json"
+    log_path = results_dir / "loop_log.jsonl"
+    transaction_path = results_dir / ".deft_commit_transaction.json"
+    if not state_path.is_file():
+        raise ValueError(f"state file not found: {state_path}")
+    original_state_text = state_path.read_text()
+    original_log = log_path.read_text() if log_path.exists() else None
+    if transaction_path.exists():
+        raise ValueError(
+            f"unfinished stage transaction found: {transaction_path}; run "
+            "recover_commit.py before committing another stage"
+        )
+    state = json.loads(original_state_text)
+    if (
+        not isinstance(state, dict)
+        or state.get("workflow") != "tao-run-deft-iaa"
+        or state.get("schema_version") != "3"
+    ):
+        raise ValueError("deft_state.json must be an IAA DEFT schema-v3 object")
+    if pathlib.Path(str(state.get("results_dir", ""))).resolve() != results_dir:
+        raise ValueError("state.results_dir does not match --results-dir")
+
+    entries = _load_log(log_path)
+    _validate_transition(entries, state, args.iter_label, args.stage)
+    log_status = "skip" if args.skip else args.status
+
+    if args.status == "ok" and args.stage == "loop_stop":
+        _validate_loop_stop(state, args)
+    match = re.fullmatch(r"iter([1-9][0-9]*)", args.iter_label)
+    if (
+        args.status == "ok"
+        and args.stage == "data_mining"
+        and match
+        and int(match.group(1)) > int(state.get("max_iterations", 0))
+    ):
+        raise ValueError(
+            f"{args.iter_label} exceeds max_iterations="
+            f"{state.get('max_iterations')}; commit loop_stop instead"
+        )
+
+    _atomic_json(
+        transaction_path,
+        {
+            "schema_version": "1",
+            "workflow": "tao-run-deft-iaa",
+            "results_dir": str(results_dir),
+            "iteration": args.iter_label,
+            "stage": args.stage,
+            "original_state_text": original_state_text,
+            "original_log_text": original_log,
+        },
+    )
+    try:
+        if args.stage == "evaluate" and args.status == "ok":
+            if commit_metric_result is None:
+                raise ValueError(
+                    "record_metric_result.py was not found next to "
+                    "commit_stage.py; evaluate commits require the metric "
+                    "recorder"
+                )
+            commit_metric_result(
+                argparse.Namespace(
+                    results_dir=results_dir,
+                    iter_label=args.iter_label,
+                    metric_result=args.metric_result,
+                    metrics_csv=args.metrics_aggregate_csv,
+                )
+            )
+            state = json.loads(state_path.read_text())
+
+        iterations = state.get("iterations")
+        if not isinstance(iterations, dict):
+            raise ValueError("state.iterations must be an object")
+        if args.stage == "loop_stop":
+            if args.status == "ok":
+                state["loop_stop_reason"] = args.reason
+        else:
+            existing = iterations.setdefault(
+                args.iter_label, {"status": "in_progress"}
+            )
+            if not isinstance(existing, dict):
+                raise ValueError(
+                    f"state.iterations.{args.iter_label} must be an object"
+                )
+            if args.status == "error":
+                existing["status"] = "failed"
+            else:
+                _apply_success(
+                    state,
+                    existing,
+                    args.stage,
+                    args,
+                    results_dir,
+                    args.iter_label,
+                )
+                if args.stage == "evaluate":
+                    result = existing.get("metric_result")
+                    if isinstance(result, dict) and result.get("passed") is True:
+                        state["gate_met"] = True
+
+        if match:
+            state["current_iteration"] = max(
+                int(match.group(1)), int(state.get("current_iteration", 0))
+            )
+
+        _atomic_json(state_path, state)
+        append_stage(
+            log_path,
+            iteration=args.iter_label,
+            stage=args.stage,
+            status=log_status,
+            summary=args.summary,
+            duration_s=args.duration_s,
+        )
+        # State and log are now both durable. Remove the rollback journal
+        # before auditing; a crash before this point is recovered by
+        # recover_commit.py, while a crash after it leaves a complete pair.
+        transaction_path.unlink()
+        audit_ok, run_status, audit_output = _run_audit(results_dir)
+        if not audit_ok:
+            raise ValueError(
+                "post-commit audit failed; state and log rolled back:\n"
+                + (audit_output or f"audit exited with status {run_status}")
+            )
+    except Exception:
+        _atomic_text(state_path, original_state_text)
+        if original_log is None:
+            try:
+                log_path.unlink()
+            except FileNotFoundError:
+                pass
+        else:
+            _atomic_text(log_path, original_log)
+        try:
+            transaction_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+    return {
+        "status": run_status,
+        "last_committed": {
+            "seq": next_seq(log_path) - 1,
+            "iteration": args.iter_label,
+            "stage": args.stage,
+            "status": log_status,
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--iter-label", required=True)
+    parser.add_argument("--stage", required=True, choices=STAGES)
+    parser.add_argument("--status", choices=("ok", "error"), default="ok")
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--duration-s", type=float, default=None)
+    parser.add_argument(
+        "--skip",
+        action="store_true",
+        help=(
+            "Record a documented skip instead of artifacts; logs status=skip "
+            f"and marks the stage completed. Valid only for: "
+            f"{', '.join(SKIPPABLE_STAGES)}."
+        ),
+    )
+    parser.add_argument("--iaa-splits-dir", type=pathlib.Path)
+    parser.add_argument("--dataset-materialize-status", type=pathlib.Path)
+    parser.add_argument("--source-pool-parquet", type=pathlib.Path)
+    parser.add_argument(
+        "--verify-log",
+        type=pathlib.Path,
+        help=f'dataset_setup verification log; must contain "{_VERIFY_MARKER}".',
+    )
+    parser.add_argument("--checksum-verify-log", type=pathlib.Path)
+    parser.add_argument("--pool-embeddings-parquet", type=pathlib.Path)
+    parser.add_argument("--pool-embed-command-status", type=pathlib.Path)
+    parser.add_argument("--metrics-aggregate-csv", type=pathlib.Path)
+    parser.add_argument(
+        "--eval-status-json",
+        type=pathlib.Path,
+        help=f'evaluate status artifact; must contain "{_EVAL_SUCCESS_MARKER}".',
+    )
+    parser.add_argument("--metric-result", type=pathlib.Path)
+    parser.add_argument("--eval-command-status", type=pathlib.Path)
+    parser.add_argument("--eval-config", type=pathlib.Path)
+    parser.add_argument("--eval-config-status", type=pathlib.Path)
+    parser.add_argument("--iteration-summary", type=pathlib.Path)
+    parser.add_argument("--iteration-summary-status", type=pathlib.Path)
+    parser.add_argument("--gaps-parquet", type=pathlib.Path)
+    parser.add_argument("--caption-history", type=pathlib.Path)
+    parser.add_argument("--gap-analysis-status", type=pathlib.Path)
+    parser.add_argument("--target-embeddings-parquet", type=pathlib.Path)
+    parser.add_argument("--target-embed-command-status", type=pathlib.Path)
+    parser.add_argument("--mined-parquet", type=pathlib.Path)
+    parser.add_argument("--knn-command-status", type=pathlib.Path)
+    parser.add_argument("--candidate-pairs", type=pathlib.Path)
+    parser.add_argument("--mining-postprocess-status", type=pathlib.Path)
+    parser.add_argument("--mined-image-list", type=pathlib.Path)
+    parser.add_argument("--mined-pairs", type=pathlib.Path)
+    parser.add_argument("--mined-manifest", type=pathlib.Path)
+    parser.add_argument("--cumulative-names", type=pathlib.Path)
+    parser.add_argument("--mining-history", type=pathlib.Path)
+    parser.add_argument("--history-select-status", type=pathlib.Path)
+    parser.add_argument("--samples-dir", type=pathlib.Path)
+    parser.add_argument("--tsne-plot", type=pathlib.Path)
+    parser.add_argument("--visualize-prepare-status", type=pathlib.Path)
+    parser.add_argument("--visualize-finish-status", type=pathlib.Path)
+    parser.add_argument(
+        "--visualize-command-status", action="append", type=pathlib.Path
+    )
+    parser.add_argument("--best-ckpt", type=pathlib.Path)
+    parser.add_argument("--pretrained-state", type=pathlib.Path)
+    parser.add_argument("--train-config", type=pathlib.Path)
+    parser.add_argument("--train-command-status", type=pathlib.Path)
+    parser.add_argument(
+        "--train-tao-status-json",
+        type=pathlib.Path,
+        help=f'train status artifact; must contain "{_TRAIN_SUCCESS_MARKER}".',
+    )
+    parser.add_argument("--train-config-status", type=pathlib.Path)
+    parser.add_argument("--publish-checkpoint-status", type=pathlib.Path)
+    parser.add_argument("--reason", choices=_LOOP_STOP_REASONS)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        report = commit(args)
+    except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
+        print(f"commit_stage: {exc}", file=sys.stderr)
+        return 2
+    last = report["last_committed"]
+    print(
+        f"committed seq={last['seq']} {last['iteration']}/{last['stage']} "
+        f"status={last['status']} run={report['status']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/deft_python.sh
+++ b/skills/applications/tao-run-deft-iaa/scripts/deft_python.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Select one already-provisioned host Python and execute it. This wrapper is
+# intentionally install-free and consumes credentials only from its inherited
+# process environment. Use ``--runtime`` for bundled IAA/data stages; control
+# scripts need Python 3.9+.
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_parent=$(CDPATH= cd -- "$script_dir/../../../../.." && pwd)
+export PYTHONPATH="$script_dir${PYTHONPATH:+:$PYTHONPATH}"
+
+runtime=false
+workspace_arg=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --runtime)
+      runtime=true
+      shift
+      ;;
+    --workspace)
+      [ "$#" -ge 2 ] || {
+        echo "deft_python: --workspace requires a path" >&2
+        exit 2
+      }
+      workspace_arg=$2
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# Cap the BLAS/OpenMP thread pools before any Python runs (probe or exec).
+# WHY: hosts with >128 cores crash the numpy/sklearn OpenBLAS (built with a
+# 128-thread cap) during t-SNE, killing the whole process. min(64, nproc)
+# keeps every host safe; values already set by the caller are respected.
+cores=$(nproc 2>/dev/null || echo 64)
+if [ "$cores" -gt 64 ]; then
+  cores=64
+fi
+export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-$cores}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-$cores}"
+export MKL_NUM_THREADS="${MKL_NUM_THREADS:-$cores}"
+
+control_probe='import sys; assert sys.version_info >= (3, 9)'
+if [ "$runtime" = true ] && [ ! -f "$script_dir/iaa_deft/__init__.py" ]; then
+  echo "deft_python: bundled IAA runtime is missing from the installed skill" >&2
+  exit 2
+fi
+
+runtime_probe='import sys; assert sys.version_info >= (3, 9); import pandas,numpy,pyarrow,PIL,yaml,matplotlib,sklearn,torch'
+candidates=(
+  "${DEFT_PYTHON:-}"
+  "${workspace_arg:+$workspace_arg/.venv/bin/python}"
+  "${workspace_arg:+$workspace_arg/.venv/bin/python3}"
+  "${WORKSPACE_DIR:-}/.venv/bin/python"
+  "${WORKSPACE_DIR:-}/.venv/bin/python3"
+  "${WORKSPACE:-}/.venv/bin/python"
+  "${WORKSPACE:-}/.venv/bin/python3"
+  "$script_dir/../.venv/bin/python3"
+  /usr/bin/python3
+  "$repo_parent/.venv/bin/python3"
+  "$HOME/.venvs/deft/bin/python3"
+  "$(command -v python3 2>/dev/null || true)"
+)
+
+selected=
+for candidate in "${candidates[@]}"; do
+  [ -n "$candidate" ] || continue
+  [ -x "$candidate" ] || continue
+  [ "$candidate" != "$script_dir/deft_python.sh" ] || continue
+  probe=$control_probe
+  if [ "$runtime" = true ]; then
+    probe=$runtime_probe
+  fi
+  if "$candidate" -c "$probe" >/dev/null 2>&1; then
+    selected=$candidate
+    break
+  fi
+done
+
+if [ -z "$selected" ]; then
+  if [ "$runtime" = true ]; then
+    echo "deft_python: no installed Python provides the bundled IAA runtime dependencies (pandas,numpy,pyarrow,PIL,yaml,matplotlib,sklearn,torch)" >&2
+    echo "deft_python: provision the approved workspace venv, then retry" >&2
+  else
+    echo "deft_python: Python 3.9+ not found" >&2
+  fi
+  exit 2
+fi
+
+if [ "$#" -eq 0 ]; then
+  printf '%s\n' "$selected"
+  exit 0
+fi
+
+exec "$selected" "$@"

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/__init__.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bundled and adapted from the Apache-2.0 NVIDIA TAO Tutorials IAA DEFT utilities so the
+# customer workflow does not depend on an external source checkout.
+
+"""Bundled CLIP DEFT pipeline utilities used by this skill."""
+
+from iaa_deft.config import IaaDeftConfig
+
+__all__ = ["IaaDeftConfig"]

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/analyze_gaps.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/analyze_gaps.py
@@ -1,0 +1,1108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bundled and adapted from the Apache-2.0 NVIDIA TAO Tutorials IAA DEFT utilities so the
+# customer workflow does not depend on an external source checkout.
+
+"""Gap analysis for DEFT pipelines.
+
+- :func:`analyze_clip_inference_gaps` — TAO CLIP IAA gap analysis.
+"""
+
+def analyze_clip_inference_gaps(
+    results_dir: str,
+    gaps_parquet: str,
+    kpi_image_dir: str,
+    logs_dir: str,
+    kpi_caption_dir: str = "",
+    caption_file_suffix: str = "",
+    kpi_pairs_file: str = "",
+    metric_name: str = "Rank-1",
+    queries_per_slice: int = 200,
+    min_num_queries: int = 1,
+    query_types: str = "",
+    weak_attribute_topk: int = 8,
+    target_query_count: int = 100000,
+    caption_diversity_enabled: str = "false",
+    caption_history_file: str = "",
+    iter_num: int = 1,
+    total_iters: int = 1,
+    continual_dataset: str = "true",
+    caption_history_policy: str = "auto",
+    caption_coverage_target: float = 1.0,
+    min_unique_texts_per_attribute: int = 0,
+    max_unique_texts_per_attribute: int = 0,
+    max_rows_per_unique_text: int = 1,
+    max_rows_per_image_path: int = 1,
+    recent_exclude_iters: int = 0,
+    replay_fraction_when_noncontinual: float = 0.25,
+) -> str:
+    """Emit weak IAA text queries from TAO CLIP IAA evaluation metrics.
+
+    Args:
+        results_dir:         Directory containing the prior iteration's
+                             TAO IAA evaluation output.
+        gaps_parquet:        Output path for the weak-sample parquet.
+        kpi_image_dir:       Root containing the KPI images.
+        logs_dir:            Directory where the stub writes its summary.
+        kpi_caption_dir:     Root containing the KPI captions.
+        caption_file_suffix: Caption file suffix (e.g. ``.txt``).
+        kpi_pairs_file:      TAO-FT ``test_pairs.json``.
+        metric_name:         Metric used to choose weak attributes.
+        queries_per_slice:   Max captions sampled per weak attribute.
+        min_num_queries:     Ignore metric rows with fewer queries.
+        query_types:         Optional comma-separated query type filter.
+        target_query_count:  Final mined-query budget.
+        caption_diversity_enabled: Enable coverage-aware caption rotation.
+        caption_history_file: JSON file tracking selected captions.
+        iter_num:            Current DEFT iteration number.
+        total_iters:         Planned total DEFT iterations.
+        continual_dataset:   Whether previous mined datasets remain in training.
+
+    Returns:
+        Path to ``gaps_parquet``.
+    """
+    import csv
+    import json
+    import math
+    import os
+
+    import pandas as pd
+
+    _ = (kpi_caption_dir, caption_file_suffix)
+
+    import glob
+    import re
+    from collections import Counter, defaultdict
+
+    color_aliases = {
+        "black": "black", "white": "white", "gray": "gray", "grey": "gray",
+        "red": "red", "maroon": "red", "blue": "blue", "navy": "blue",
+        "cyan": "blue", "teal": "blue", "green": "green", "olive": "green",
+        "yellow": "yellow", "brown": "brown", "purple": "purple",
+        "pink": "pink", "orange": "orange", "beige": "beige/tan",
+        "tan": "beige/tan", "khaki": "beige/tan", "blond": "blonde",
+        "blonde": "blonde",
+    }
+    color_order = [
+        "black", "white", "gray", "red", "blue", "green", "yellow",
+        "brown", "purple", "pink", "orange", "beige/tan", "blonde",
+    ]
+    clothing_aliases = {
+        "shirt": "shirt", "shirts": "shirt", "tshirt": "t-shirt",
+        "tee": "t-shirt", "top": "top", "jacket": "jacket",
+        "coat": "coat", "hoodie": "hoodie", "sweater": "sweater",
+        "blouse": "blouse", "tank": "tank top", "vest": "vest",
+        "suit": "suit", "jersey": "jersey", "uniform": "uniform",
+        "dress": "dress", "polo": "polo", "cardigan": "cardigan",
+        "pants": "pants", "trousers": "pants", "jeans": "jeans",
+        "shorts": "shorts", "skirt": "skirt", "leggings": "leggings",
+        "slacks": "pants", "shoe": "shoes", "shoes": "shoes",
+        "sneaker": "sneakers", "sneakers": "sneakers", "boot": "boots",
+        "boots": "boots", "sandal": "sandals", "sandals": "sandals",
+        "footwear": "shoes", "bag": "bag", "backpack": "backpack",
+        "purse": "purse", "handbag": "handbag", "hat": "hat",
+        "cap": "hat", "helmet": "helmet", "mask": "mask",
+        "scarf": "scarf", "tie": "tie", "belt": "belt",
+        "glasses": "glasses", "sunglasses": "glasses",
+    }
+    concept_tokens = {
+        "Top clothing": {
+            "shirt", "shirts", "tshirt", "tee", "top", "jacket", "coat",
+            "hoodie", "sweater", "blouse", "tank", "vest", "suit",
+            "jersey", "uniform", "dress", "polo", "cardigan",
+        },
+        "Bottom clothing": {
+            "pants", "trousers", "jeans", "shorts", "skirt", "leggings",
+            "slacks",
+        },
+        "Shoe terms": {
+            "shoe", "shoes", "sneaker", "sneakers", "boot", "boots",
+            "sandal", "sandals", "footwear",
+        },
+        "Accessories": {
+            "bag", "backpack", "purse", "handbag", "glasses",
+            "sunglasses", "hat", "cap", "helmet", "mask", "umbrella",
+            "phone", "watch", "headphones", "headset", "scarf", "tie",
+            "belt", "bracelet", "wristband", "necklace",
+        },
+        "Hair/head": {"hair", "bald", "ponytail", "head"},
+        "Body/view/action": {
+            "person", "man", "woman", "male", "female", "boy", "girl",
+            "child", "walking", "standing", "sitting", "front", "back",
+            "side", "profile", "facing", "tall", "short", "thin", "slim",
+            "heavy",
+        },
+        "Pattern/logo": {
+            "stripe", "stripes", "striped", "logo", "pattern",
+            "patterned", "plain", "floral", "printed", "print",
+            "checkered", "plaid",
+        },
+    }
+    concept_order = [
+        "Color terms", "Top clothing", "Bottom clothing", "Shoe terms",
+        "Accessories", "Hair/head", "Body/view/action", "Pattern/logo",
+    ]
+
+    def _truthy(value):
+        return str(value).strip().lower() in ("true", "1", "yes", "y")
+
+    def _tokens(text):
+        cleaned = (
+            str(text or "").lower()
+            .replace("t-shirt", "tshirt")
+            .replace("t shirt", "tshirt")
+        )
+        return re.findall(r"[a-z0-9]+", cleaned)
+
+    def _normalize_caption_text(text):
+        return " ".join(_tokens(text))
+
+    def _colors(text):
+        found = {
+            color_aliases[token]
+            for token in set(_tokens(text))
+            if token in color_aliases
+        }
+        return [color for color in color_order if color in found]
+
+    def _color_item_pairs(text):
+        toks = _tokens(text)
+        pairs = set()
+        for idx, token in enumerate(toks):
+            if token == "top" and idx > 0 and toks[idx - 1] == "tank":
+                continue
+            item = clothing_aliases.get(token)
+            if not item:
+                continue
+            start = max(0, idx - 3)
+            stop = min(len(toks), idx + 2)
+            nearby = {
+                color_aliases[toks[pos]]
+                for pos in range(start, stop)
+                if pos != idx and toks[pos] in color_aliases
+            }
+            for color in nearby:
+                pairs.add(f"{color} {item}")
+        return sorted(pairs)
+
+    def _attributes(text):
+        toks = set(_tokens(text))
+        attrs = []
+        if _colors(text):
+            attrs.append("Color terms")
+        for name in concept_order:
+            if name == "Color terms":
+                continue
+            if toks & concept_tokens[name]:
+                attrs.append(name)
+        return attrs
+
+    def _normalize_attribute_name(value):
+        raw = str(value or "").strip()
+        low = raw.lower().replace("-", "_").replace(" ", "_")
+        if not raw:
+            return ""
+        checks = [
+            ("Color terms", ("color", "colour", "black", "white", "blue", "red", "green")),
+            ("Top clothing", ("upper", "top", "shirt", "coat", "jacket", "dress", "hoodie")),
+            ("Bottom clothing", ("lower", "bottom", "pants", "trouser", "jeans", "shorts", "skirt")),
+            ("Shoe terms", ("shoe", "sneaker", "boot", "sandal", "footwear")),
+            ("Accessories", ("access", "bag", "hat", "cap", "glasses", "mask", "umbrella")),
+            ("Hair/head", ("hair", "head", "bald", "ponytail")),
+            ("Body/view/action", ("body", "view", "action", "pose", "gender", "age", "person")),
+            ("Pattern/logo", ("pattern", "logo", "stripe", "print", "plaid")),
+        ]
+        for name, needles in checks:
+            if any(token in low for token in needles):
+                return name
+        return raw
+
+    def _split_csv(value):
+        return {item.strip() for item in str(value or "").split(",") if item.strip()}
+
+    def _infer_dataset(image_path):
+        normalized = str(image_path or "").replace("\\", "/")
+        parts = [p for p in normalized.split("/") if p]
+        for marker in ("images", "data"):
+            if marker in parts:
+                idx = parts.index(marker)
+                if idx + 1 < len(parts):
+                    return parts[idx + 1].strip()
+        return parts[0].strip() if parts else ""
+
+    def _iter_json_records(path):
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        compact = (
+            second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if compact:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s or s in ("[", "]"):
+                        continue
+                    if s.endswith(","):
+                        s = s[:-1]
+                    if s:
+                        yield json.loads(s)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for row in json.load(f):
+                yield row
+
+    def _metrics_path(base_dir):
+        candidates = [
+            os.path.join(base_dir, "nvidia_iaa_metrics.csv"),
+            os.path.join(base_dir, "evaluate", "nvidia_iaa_metrics.csv"),
+            os.path.join(base_dir, "iaa_eval", "nvidia_iaa_metrics.csv"),
+        ]
+        for path in candidates:
+            if os.path.isfile(path):
+                return path
+        raise FileNotFoundError(
+            "Could not find nvidia_iaa_metrics.csv under "
+            f"{base_dir}. Checked: {candidates}"
+        )
+
+    def _query_text(query):
+        for key in ("query_text", "caption", "text", "query"):
+            value = str(query.get(key) or "").strip()
+            if value:
+                return value
+        return ""
+
+    def _query_metrics(query):
+        matches = list(query.get("top_matches", []) or [])
+        flags = [bool(m.get("is_correct")) for m in matches if isinstance(m, dict)]
+        correct = sum(1 for ok in flags if ok)
+        try:
+            gt = int(query.get("num_ground_truth") or 0)
+        except (TypeError, ValueError):
+            gt = 0
+        denom = max(1, min(14, gt))
+        first = next((idx + 1 for idx, ok in enumerate(flags[:14]) if ok), 15)
+        return {
+            "Rank-1": 1.0 if flags and flags[0] else 0.0,
+            "Match@14": correct / denom,
+            "Zero@14": 1.0 if correct == 0 else 0.0,
+            "First@14": float(first),
+        }
+
+    def _metric_from_sums(sums, metric):
+        n = max(1, int(sums["n"]))
+        if metric == "Match@14":
+            return sums["Match@14"] / n
+        if metric == "Zero@14":
+            return sums["Zero@14"] / n
+        if metric in ("First@14", "First Pos"):
+            return sums["First@14"] / n
+        return sums["Rank-1"] / n
+
+    metrics_path = _metrics_path(results_dir)
+    if not kpi_pairs_file:
+        raise ValueError("IAA CLIP gap analysis requires kpi_pairs_file.")
+    if not os.path.isfile(kpi_pairs_file):
+        raise FileNotFoundError(f"kpi_pairs_file not found: {kpi_pairs_file}")
+
+    selection_qtype_filter = _split_csv(query_types)
+    selection_qtype_label = ",".join(sorted(selection_qtype_filter)) if selection_qtype_filter else "all"
+    metric_name = str(metric_name or "Rank-1")
+    high_is_weak = metric_name.lower().startswith("zero@")
+    weak_attribute_topk = int(weak_attribute_topk or 0)
+    queries_per_slice = int(queries_per_slice or 0)
+    min_num_queries = int(min_num_queries or 0)
+    target_query_count = int(target_query_count or 0)
+
+    metric_rows = []
+    with open(metrics_path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            dataset = str(row.get("Dataset") or "").strip()
+            qtype = str(row.get("QueryType") or "").strip()
+            if not dataset or dataset.startswith(("AVG_", "WAVG_")):
+                continue
+            if qtype == "image_to_image" or (selection_qtype_filter and qtype not in selection_qtype_filter):
+                continue
+            try:
+                n_queries = int(float(row.get("num_queries") or 0))
+            except ValueError:
+                n_queries = 0
+            if n_queries < min_num_queries:
+                continue
+            if metric_name not in row or row.get(metric_name, "") == "":
+                continue
+            try:
+                metric_value = float(row[metric_name])
+            except ValueError:
+                continue
+            metric_rows.append({
+                "dataset": dataset,
+                "query_type": qtype,
+                "attribute": "",
+                "raw_attribute": str(row.get("EasyAttribute") or ""),
+                "metric_name": metric_name,
+                "metric_value": metric_value,
+                "num_queries": n_queries,
+                "selection_basis": "metrics_csv_dataset_query_type",
+            })
+    if not metric_rows:
+        raise ValueError(f"No usable IAA metric rows found in {metrics_path}")
+
+    result_paths = []
+    result_roots = [
+        results_dir,
+        os.path.join(results_dir, "evaluate"),
+        os.path.join(results_dir, "iaa_eval"),
+    ]
+    seen_paths = set()
+    for root in result_roots:
+        if not os.path.isdir(root):
+            continue
+        for path in glob.glob(os.path.join(root, "**", "*_results.json"), recursive=True):
+            if path not in seen_paths:
+                result_paths.append(path)
+                seen_paths.add(path)
+
+    attr_sums = defaultdict(lambda: {
+        "n": 0, "Rank-1": 0.0, "Match@14": 0.0,
+        "Zero@14": 0.0, "First@14": 0.0,
+    })
+    for path in result_paths:
+        dataset = os.path.basename(path).replace("_results.json", "")
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        for query in payload.get("queries", []) or []:
+            qtype = str(query.get("query_type") or "").strip()
+            if selection_qtype_filter and qtype not in selection_qtype_filter:
+                continue
+            attrs = _attributes(_query_text(query))
+            if not attrs:
+                continue
+            query_metric = _query_metrics(query)
+            for attr in attrs:
+                sums = attr_sums[(dataset, qtype, attr, attr, "per_query_results_json")]
+                sums["n"] += 1
+                for key in ("Rank-1", "Match@14", "Zero@14", "First@14"):
+                    sums[key] += query_metric[key]
+
+    attribute_rows = []
+    for (dataset, qtype, attr, raw_attr, basis), sums in attr_sums.items():
+        if int(sums["n"]) < min_num_queries:
+            continue
+        metric_for_rows = metric_name if metric_name in sums or metric_name == "First Pos" else "Rank-1"
+        attribute_rows.append({
+            "dataset": dataset,
+            "query_type": qtype,
+            "attribute": attr,
+            "raw_attribute": raw_attr,
+            "metric_name": metric_for_rows,
+            "metric_value": _metric_from_sums(sums, metric_for_rows),
+            "num_queries": int(sums["n"]),
+            "selection_basis": basis,
+        })
+
+    selection_pair_rows = []
+    selection_qtype_counts = Counter()
+    skipped_pairs = 0
+    for row in _iter_json_records(kpi_pairs_file):
+        qtype = str(row.get("query_type") or "").strip()
+        use_for_selection = (
+            not selection_qtype_filter or qtype in selection_qtype_filter
+        )
+        if not use_for_selection:
+            skipped_pairs += 1
+            continue
+        caption = str(row.get("caption") or "").strip()
+        unique_name = str(row.get("unique_name") or "").strip()
+        image_path = str(row.get("image_path") or "")
+        dataset = str(row.get("dataset") or "").strip() or _infer_dataset(image_path)
+        if not caption or not unique_name or not dataset:
+            skipped_pairs += 1
+            continue
+        out = dict(row)
+        out.update({
+            "dataset": dataset,
+            "query_type": qtype,
+            "caption": caption,
+            "unique_name": unique_name,
+        })
+        selection_pair_rows.append(out)
+        selection_qtype_counts[qtype or "(blank)"] += 1
+
+    if not selection_pair_rows:
+        raise ValueError(
+            "No KPI pair rows matched gap_analysis.query_types="
+            f"{selection_qtype_label!r}; cannot select weak attributes."
+        )
+
+    if not attribute_rows:
+        for row in metric_rows:
+            raw_attr = str(row.get("raw_attribute") or "").strip()
+            attr = _normalize_attribute_name(raw_attr)
+            if not raw_attr or not attr:
+                continue
+            attribute_rows.append({
+                "dataset": row["dataset"],
+                "query_type": row["query_type"],
+                "attribute": attr,
+                "raw_attribute": raw_attr,
+                "metric_name": row["metric_name"],
+                "metric_value": row["metric_value"],
+                "num_queries": row["num_queries"],
+                "selection_basis": "metrics_csv_easy_attribute",
+            })
+
+    if not attribute_rows:
+        metric_by_slice = {
+            (row["dataset"], row["query_type"]): row
+            for row in metric_rows
+        }
+        proxy_sums = defaultdict(lambda: {
+            "n": 0,
+            "metric_sum": 0.0,
+            "datasets": Counter(),
+            "query_types": Counter(),
+        })
+        for row in selection_pair_rows:
+            metric_row = metric_by_slice.get(
+                (row["dataset"], row["query_type"])
+            )
+            if not metric_row:
+                continue
+            attrs = _attributes(row.get("caption", ""))
+            if not attrs:
+                continue
+            for attr in attrs:
+                sums = proxy_sums[attr]
+                sums["n"] += 1
+                sums["metric_sum"] += float(metric_row["metric_value"])
+                sums["datasets"][row["dataset"]] += 1
+                sums["query_types"][row["query_type"]] += 1
+        for attr, sums in proxy_sums.items():
+            if int(sums["n"]) < min_num_queries:
+                continue
+            attribute_rows.append({
+                "dataset": "ALL",
+                "query_type": selection_qtype_label,
+                "attribute": attr,
+                "raw_attribute": attr,
+                "metric_name": metric_name,
+                "metric_value": sums["metric_sum"] / max(1, int(sums["n"])),
+                "num_queries": int(sums["n"]),
+                "selection_basis": "metrics_csv_attribute_proxy",
+                "datasets": ";".join(sums["datasets"].keys()),
+                "query_types": ";".join(sums["query_types"].keys()),
+            })
+
+    metric_rows = sorted(metric_rows, key=lambda r: r["metric_value"], reverse=high_is_weak)
+    attribute_rows = sorted(attribute_rows, key=lambda r: r["metric_value"], reverse=high_is_weak)
+    if not attribute_rows:
+        raise ValueError(
+            "No attribute metrics could be derived from per-query results, "
+            "EasyAttribute metrics, or KPI "
+            f"captions filtered by query_types={selection_qtype_label!r}."
+        )
+    weak_groups = attribute_rows[:weak_attribute_topk or len(attribute_rows)]
+    if not weak_groups:
+        raise ValueError("No weak IAA groups were selected.")
+    selection_basis = weak_groups[0]["selection_basis"]
+
+    group_keys = [
+        (row.get("attribute", ""),)
+        for row in weak_groups
+    ]
+    group_rank = {key: idx for idx, key in enumerate(group_keys)}
+    group_meta = {key: row for key, row in zip(group_keys, weak_groups)}
+    per_group_budget = queries_per_slice
+
+    def _matching_keys(row):
+        attrs = _attributes(row.get("caption", ""))
+        keys = [
+            (attr,)
+            for attr in attrs
+            if (attr,) in group_meta
+        ]
+        return sorted(keys, key=lambda key: group_rank.get(key, 999999))
+
+    caption_diversity_on = _truthy(caption_diversity_enabled)
+    current_iter = max(1, int(iter_num or 1))
+    planned_iters = max(current_iter, int(total_iters or current_iter))
+    remaining_iters = max(1, planned_iters - current_iter + 1)
+    continual_dataset_on = _truthy(continual_dataset)
+    resolved_history_policy = str(caption_history_policy or "auto").strip().lower()
+    if resolved_history_policy == "auto":
+        resolved_history_policy = (
+            "prefer_unseen" if continual_dataset_on else "novelty_with_replay"
+        )
+    caption_coverage_target = max(0.0, float(caption_coverage_target or 0.0))
+    min_unique_texts_per_attribute = max(
+        0, int(min_unique_texts_per_attribute or 0)
+    )
+    max_unique_texts_per_attribute = max(
+        0, int(max_unique_texts_per_attribute or 0)
+    )
+    max_rows_per_unique_text = max(1, int(max_rows_per_unique_text or 1))
+    max_rows_per_image_path = max(0, int(max_rows_per_image_path or 0))
+    recent_exclude_iters = max(0, int(recent_exclude_iters or 0))
+    replay_fraction_when_noncontinual = min(
+        1.0, max(0.0, float(replay_fraction_when_noncontinual or 0.0))
+    )
+
+    def _serialize_group_key(key):
+        return "||".join(str(part) for part in key)
+
+    def _display_group_key(key):
+        return " / ".join(str(part) for part in key if str(part))
+
+    def _entry_iter(entry):
+        try:
+            return int(entry.get("iter", 0) or 0)
+        except (AttributeError, TypeError, ValueError):
+            return 0
+
+    history_payload = {"version": 1, "entries": []}
+    history_entries = []
+    if caption_diversity_on and caption_history_file and os.path.isfile(caption_history_file):
+        try:
+            with open(caption_history_file, "r", encoding="utf-8") as f:
+                loaded_history = json.load(f)
+            if isinstance(loaded_history, dict):
+                history_payload.update(loaded_history)
+                history_entries = list(loaded_history.get("entries") or [])
+            elif isinstance(loaded_history, list):
+                history_entries = list(loaded_history)
+                history_payload["entries"] = history_entries
+        except (OSError, json.JSONDecodeError):
+            history_entries = []
+
+    history_counts = Counter()
+    global_history_counts = Counter()
+    prior_captions_by_group = defaultdict(set)
+    prior_captions_global = set()
+    recent_captions_by_group = defaultdict(set)
+    recent_captions_global = set()
+    for entry in history_entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_iter = _entry_iter(entry)
+        if entry_iter >= current_iter:
+            continue
+        group_key_text = str(
+            entry.get("group_key")
+            or entry.get("attribute")
+            or entry.get("weak_attribute")
+            or ""
+        )
+        norm = str(
+            entry.get("normalized_caption")
+            or _normalize_caption_text(entry.get("caption", ""))
+        )
+        if not group_key_text or not norm:
+            continue
+        history_counts[(group_key_text, norm)] += 1
+        global_history_counts[norm] += 1
+        prior_captions_by_group[group_key_text].add(norm)
+        prior_captions_global.add(norm)
+        if recent_exclude_iters and entry_iter >= current_iter - recent_exclude_iters:
+            recent_captions_by_group[group_key_text].add(norm)
+            recent_captions_global.add(norm)
+
+    caption_candidate_rows_by_key = defaultdict(dict)
+    caption_pool_by_key = defaultdict(set)
+    if caption_diversity_on:
+        for order, row in enumerate(selection_pair_rows):
+            norm = _normalize_caption_text(row.get("caption", ""))
+            if not norm:
+                continue
+            for key in _matching_keys(row):
+                caption_pool_by_key[key].add(norm)
+                rows_for_text = caption_candidate_rows_by_key[key].setdefault(
+                    norm, []
+                )
+                if len(rows_for_text) < max_rows_per_unique_text:
+                    rows_for_text.append((order, row, norm))
+
+    unique_text_budget_by_key = {}
+    caption_diversity_stats = []
+    if caption_diversity_on:
+        for key in group_keys:
+            pool = caption_pool_by_key.get(key, set())
+            pool_count = len(pool)
+            group_key_text = _serialize_group_key(key)
+            seen_count = len(pool & prior_captions_by_group.get(group_key_text, set()))
+            global_seen_count = len(pool & prior_captions_global)
+            unseen_count = max(0, pool_count - global_seen_count)
+            if unseen_count:
+                auto_budget = int(
+                    math.ceil((unseen_count * caption_coverage_target) / remaining_iters)
+                )
+            else:
+                auto_budget = (
+                    0 if resolved_history_policy == "prefer_unseen"
+                    else pool_count
+                )
+            if (
+                pool_count
+                and min_unique_texts_per_attribute
+                and (
+                    unseen_count
+                    or resolved_history_policy != "prefer_unseen"
+                )
+            ):
+                auto_budget = max(
+                    auto_budget,
+                    min(min_unique_texts_per_attribute, pool_count),
+                )
+            if max_unique_texts_per_attribute:
+                auto_budget = min(auto_budget, max_unique_texts_per_attribute)
+            if per_group_budget:
+                unique_cap_from_rows = max(
+                    1,
+                    int(math.ceil(per_group_budget / max_rows_per_unique_text)),
+                )
+                auto_budget = min(auto_budget, unique_cap_from_rows)
+            auto_budget = min(max(0, auto_budget), pool_count)
+            unique_text_budget_by_key[key] = auto_budget
+            caption_diversity_stats.append({
+                "group": _display_group_key(key),
+                "group_key": group_key_text,
+                "candidate_unique_texts": pool_count,
+                "history_unique_texts": seen_count,
+                "global_history_unique_texts": global_seen_count,
+                "remaining_unseen_unique_texts": unseen_count,
+                "unique_text_budget": auto_budget,
+                "selected_unique_texts": 0,
+                "selected_rows": 0,
+            })
+
+    selected_query_keys = set()
+    selected_queries = []
+    selected_text_counts_by_key = defaultdict(Counter)
+    selected_unique_texts_by_key = defaultdict(set)
+    selected_text_counts_global = Counter()
+    selected_image_path_counts = Counter()
+    selected_query_caption_info = {}
+    per_group_counts = Counter()
+
+    def _row_query_key(row):
+        return (
+            str(row.get("unique_name") or ""),
+            str(row.get("query_type") or ""),
+            str(row.get("caption") or ""),
+        )
+
+    def _append_selected(row, key, norm):
+        name = str(row.get("unique_name") or "")
+        query_key = _row_query_key(row)
+        if query_key in selected_query_keys:
+            return False
+        selected_query_keys.add(query_key)
+        selected_queries.append((row, key))
+        selected_text_counts_by_key[key][norm] += 1
+        selected_unique_texts_by_key[key].add(norm)
+        selected_text_counts_global[norm] += 1
+        image_key = str(row.get("image_path") or name)
+        if image_key:
+            selected_image_path_counts[image_key] += 1
+        selected_query_caption_info[query_key] = {
+            "normalized_text": norm,
+            "caption_history_count": history_counts.get(
+                (_serialize_group_key(key), norm), 0
+            ),
+            "group_key": _serialize_group_key(key),
+        }
+        per_group_counts[key] += 1
+        return True
+
+    def _can_select(row, key, norm, enforce_budget, unique_limit,
+                    allow_seen, allow_recent, prefer_seen_only=False):
+        if enforce_budget and per_group_budget and per_group_counts[key] >= per_group_budget:
+            return False
+        query_key = _row_query_key(row)
+        if query_key in selected_query_keys:
+            return False
+        group_key_text = _serialize_group_key(key)
+        prior_count = history_counts.get((group_key_text, norm), 0)
+        global_prior_count = global_history_counts.get(norm, 0)
+        if prefer_seen_only and prior_count == 0 and global_prior_count == 0:
+            return False
+        if not allow_seen and (prior_count > 0 or global_prior_count > 0):
+            return False
+        if (
+            not allow_recent
+            and (
+                norm in recent_captions_by_group.get(group_key_text, set())
+                or norm in recent_captions_global
+            )
+        ):
+            return False
+        if (
+            max_rows_per_unique_text
+            and selected_text_counts_by_key[key][norm] >= max_rows_per_unique_text
+        ):
+            return False
+        if (
+            max_rows_per_unique_text
+            and selected_text_counts_global[norm] >= max_rows_per_unique_text
+        ):
+            return False
+        is_new_text = norm not in selected_unique_texts_by_key[key]
+        if unique_limit and is_new_text and len(selected_unique_texts_by_key[key]) >= unique_limit:
+            return False
+        image_key = str(row.get("image_path") or row.get("unique_name") or "")
+        if (
+            max_rows_per_image_path
+            and image_key
+            and selected_image_path_counts[image_key] >= max_rows_per_image_path
+        ):
+            return False
+        return True
+
+    def _candidate_sort_key(key, item, prefer_seen=False):
+        order, _row, norm = item
+        group_key_text = _serialize_group_key(key)
+        prior_count = history_counts.get((group_key_text, norm), 0)
+        global_prior_count = global_history_counts.get(norm, 0)
+        recent = (
+            norm in recent_captions_by_group.get(group_key_text, set())
+            or norm in recent_captions_global
+        )
+        seen_rank = 0 if (prior_count > 0 or global_prior_count > 0) else 1
+        if not prefer_seen:
+            seen_rank = 0 if (prior_count == 0 and global_prior_count == 0) else 1
+        return (seen_rank, bool(recent), prior_count + global_prior_count, order)
+
+    def _select_candidates_for_group(key, unique_limit, allow_seen,
+                                     allow_recent, prefer_seen=False,
+                                     prefer_seen_only=False):
+        candidate_rows = []
+        for rows_for_text in caption_candidate_rows_by_key.get(key, {}).values():
+            candidate_rows.extend(rows_for_text)
+        candidates = sorted(
+            candidate_rows,
+            key=lambda item: _candidate_sort_key(key, item, prefer_seen=prefer_seen),
+        )
+        selected_any = False
+        for _order, row, norm in candidates:
+            if not _can_select(
+                row,
+                key,
+                norm,
+                enforce_budget=True,
+                unique_limit=unique_limit,
+                allow_seen=allow_seen,
+                allow_recent=allow_recent,
+                prefer_seen_only=prefer_seen_only,
+            ):
+                continue
+            if _append_selected(row, key, norm):
+                selected_any = True
+        return selected_any
+
+    def _select(row, enforce_budget):
+        keys = _matching_keys(row)
+        if not keys:
+            return False
+        key = keys[0]
+        if enforce_budget and per_group_budget and per_group_counts[key] >= per_group_budget:
+            return False
+        norm = _normalize_caption_text(row.get("caption", ""))
+        return _append_selected(row, key, norm)
+
+    if caption_diversity_on:
+        for key in group_keys:
+            unique_budget = unique_text_budget_by_key.get(key, 0)
+            if unique_budget <= 0:
+                continue
+            if resolved_history_policy == "novelty_with_replay":
+                replay_budget = int(
+                    math.floor(unique_budget * replay_fraction_when_noncontinual)
+                )
+                novelty_budget = max(0, unique_budget - replay_budget)
+            else:
+                replay_budget = 0
+                novelty_budget = unique_budget
+            if novelty_budget:
+                _select_candidates_for_group(
+                    key,
+                    novelty_budget,
+                    allow_seen=False,
+                    allow_recent=False,
+                )
+                _select_candidates_for_group(
+                    key,
+                    novelty_budget,
+                    allow_seen=False,
+                    allow_recent=True,
+                )
+            if replay_budget:
+                _select_candidates_for_group(
+                    key,
+                    unique_budget,
+                    allow_seen=True,
+                    allow_recent=True,
+                    prefer_seen=True,
+                    prefer_seen_only=True,
+                )
+            if (
+                resolved_history_policy != "prefer_unseen"
+                and len(selected_unique_texts_by_key[key]) < unique_budget
+            ):
+                _select_candidates_for_group(
+                    key,
+                    unique_budget,
+                    allow_seen=True,
+                    allow_recent=True,
+                )
+    else:
+        for row in selection_pair_rows:
+            _select(row, enforce_budget=True)
+
+    if not selected_queries:
+        for row in selection_pair_rows:
+            keys = _matching_keys(row)
+            if not keys:
+                continue
+            norm = _normalize_caption_text(row.get("caption", ""))
+            if _append_selected(row, keys[0], norm):
+                break
+
+    if caption_diversity_on:
+        stats_by_key = {
+            stat["group_key"]: stat for stat in caption_diversity_stats
+        }
+        for key in group_keys:
+            stat = stats_by_key.get(_serialize_group_key(key))
+            if not stat:
+                continue
+            stat["selected_unique_texts"] = len(selected_unique_texts_by_key[key])
+            stat["selected_rows"] = sum(selected_text_counts_by_key[key].values())
+
+    def _record(row, keys, stage):
+        caption = str(row.get("caption") or "")
+        name = str(row.get("unique_name") or "")
+        dataset = str(row.get("dataset") or "")
+        qtype = str(row.get("query_type") or "")
+        metas = [group_meta[key] for key in keys if key in group_meta]
+        meta = metas[0] if metas else {
+            "metric_name": metric_name, "metric_value": "",
+            "num_queries": "", "selection_basis": selection_basis,
+        }
+        weak_attrs = [
+            str(m.get("attribute") or "")
+            for m in metas
+            if str(m.get("attribute") or "")
+        ]
+        weak_attr_text = ";".join(dict.fromkeys(weak_attrs))
+        attrs = _attributes(caption)
+        norm_caption = _normalize_caption_text(caption)
+        query_info = selected_query_caption_info.get(_row_query_key(row), {})
+        if not query_info and keys:
+            query_info = {
+                "normalized_text": norm_caption,
+                "caption_history_count": history_counts.get(
+                    (_serialize_group_key(keys[0]), norm_caption), 0
+                ),
+                "group_key": _serialize_group_key(keys[0]),
+            }
+        return {
+            "filepath": os.path.abspath(os.path.join(kpi_image_dir, name))
+            if kpi_image_dir and name else "",
+            "text": caption,
+            "normalized_text": query_info.get("normalized_text", norm_caption),
+            "label": ":".join(x for x in (dataset, qtype, weak_attr_text) if x),
+            "dataset": dataset,
+            "query_type": qtype,
+            "weak_attribute": weak_attr_text,
+            "easy_attribute": weak_attr_text,
+            "attributes": ";".join(attrs),
+            "colors": ";".join(_colors(caption)),
+            "color_item_pairs": ";".join(_color_item_pairs(caption)),
+            "metric_name": meta.get("metric_name", metric_name),
+            "metric_value": meta.get("metric_value", ""),
+            "num_queries": meta.get("num_queries", ""),
+            "selection_basis": meta.get("selection_basis", selection_basis),
+            "selection_stage": stage,
+            "caption_history_count": query_info.get("caption_history_count", 0),
+            "caption_history_group_key": query_info.get("group_key", ""),
+            "unique_name": name,
+            "image_path": str(row.get("image_path") or ""),
+        }
+
+    records = []
+    for row, key in selected_queries:
+        records.append(_record(row, [key], "selected_query"))
+
+    columns = [
+        "filepath", "text", "label", "dataset", "query_type",
+        "weak_attribute", "easy_attribute", "attributes", "colors",
+        "color_item_pairs", "metric_name", "metric_value", "num_queries",
+        "selection_basis", "selection_stage",
+        "normalized_text", "caption_history_count",
+        "caption_history_group_key",
+        "unique_name", "image_path",
+    ]
+    gaps_df = pd.DataFrame(records, columns=columns)
+    gaps_dir = os.path.dirname(gaps_parquet)
+    if gaps_dir:
+        os.makedirs(gaps_dir, exist_ok=True)
+    gaps_df.to_parquet(gaps_parquet, index=False)
+
+    os.makedirs(logs_dir, exist_ok=True)
+    summary_path = os.path.join(logs_dir, "weak_samples_breakdown.txt")
+    groups_path = os.path.join(logs_dir, "weak_iaa_attributes.csv")
+    all_attributes_path = os.path.join(logs_dir, "iaa_attribute_metrics.csv")
+    samples_csv_path = os.path.join(logs_dir, "weak_iaa_samples.csv")
+    samples_jsonl_path = os.path.join(logs_dir, "weak_iaa_samples.jsonl")
+    preview_path = os.path.join(logs_dir, "weak_iaa_samples_preview.txt")
+    caption_diversity_summary_path = os.path.join(
+        logs_dir, "caption_diversity_summary.csv"
+    )
+    pd.DataFrame(weak_groups).to_csv(groups_path, index=False)
+    pd.DataFrame(attribute_rows or metric_rows).to_csv(all_attributes_path, index=False)
+    gaps_df.to_csv(samples_csv_path, index=False)
+    gaps_df.to_json(samples_jsonl_path, orient="records", lines=True, force_ascii=False)
+    if caption_diversity_on:
+        pd.DataFrame(caption_diversity_stats).to_csv(
+            caption_diversity_summary_path, index=False
+        )
+        if caption_history_file:
+            history_dir = os.path.dirname(caption_history_file)
+            if history_dir:
+                os.makedirs(history_dir, exist_ok=True)
+            existing_entries = [
+                entry for entry in history_entries
+                if isinstance(entry, dict) and _entry_iter(entry) != current_iter
+            ]
+            new_entries = []
+            for row, key in selected_queries:
+                caption = str(row.get("caption") or "")
+                norm = _normalize_caption_text(caption)
+                if not norm:
+                    continue
+                new_entries.append({
+                    "iter": current_iter,
+                    "group": _display_group_key(key),
+                    "group_key": _serialize_group_key(key),
+                    "caption": caption,
+                    "normalized_caption": norm,
+                    "weak_attribute": key[0] if key else "",
+                    "dataset": str(row.get("dataset") or ""),
+                    "query_type": str(row.get("query_type") or ""),
+                    "unique_name": str(row.get("unique_name") or ""),
+                    "image_path": str(row.get("image_path") or ""),
+                })
+            history_payload.update({
+                "version": 1,
+                "last_iter": current_iter,
+                "history_policy": resolved_history_policy,
+                "continual_dataset": continual_dataset_on,
+                "entries": existing_entries + new_entries,
+            })
+            with open(caption_history_file, "w", encoding="utf-8") as f:
+                json.dump(history_payload, f, indent=2, ensure_ascii=False)
+
+    preview_lines = ["IAA weak query sample preview", ""]
+    for idx, row in gaps_df.head(100).iterrows():
+        text_preview = str(row.get("text") or "").replace("\n", " ")[:240]
+        preview_lines.append(
+            f"[{idx}] {row.get('dataset', '')} / {row.get('query_type', '')} "
+            f"{row.get('weak_attribute', '')} "
+            f"{row.get('metric_name', metric_name)}={row.get('metric_value', '')}: "
+            f"{text_preview}"
+        )
+    if len(preview_lines) == 2:
+        preview_lines.append("No weak query rows emitted.")
+    with open(preview_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(preview_lines) + "\n")
+
+    count_lines = []
+    if not gaps_df.empty:
+        group_cols = ["dataset", "query_type"]
+        group_cols.append("weak_attribute")
+        count_df = (
+            gaps_df.groupby(group_cols, dropna=False)
+            .size()
+            .reset_index(name="sampled")
+            .sort_values(group_cols)
+        )
+        for _, row in count_df.iterrows():
+            attr = (
+                f" / {row['weak_attribute']}"
+                if "weak_attribute" in row and row.get("weak_attribute") else ""
+            )
+            count_lines.append(
+                f"  {row['dataset']} / {row['query_type']}{attr}: "
+                f"{int(row['sampled'])}"
+            )
+
+    summary_lines = [
+        "IAA weak-attribute gap analysis",
+        f"Metrics: {metrics_path}",
+        f"KPI pairs: {kpi_pairs_file}",
+        f"Weak metric: {metric_name} ({'higher' if high_is_weak else 'lower'} is weaker)",
+        f"Selection basis: {selection_basis}",
+        f"Detailed result JSON files: {len(result_paths)}",
+        f"Weak groups selected: {len(weak_groups)}",
+        f"Attribute selection query types: {selection_qtype_label}",
+        f"KPI selection pair rows: {len(selection_pair_rows)}",
+        f"Mined output target query budget: {target_query_count or 'unlimited'}",
+        f"Weak driver per-attribute row budget: {per_group_budget or 'unlimited'}",
+        f"Caption diversity enabled: {caption_diversity_on}",
+        f"Caption history policy: {resolved_history_policy}",
+        f"Caption history file: {caption_history_file or 'disabled'}",
+        f"Caption diversity summary CSV: {caption_diversity_summary_path if caption_diversity_on else 'disabled'}",
+        "Note: mined output budget is applied after kNN and source-pair recovery.",
+        f"Selected seed query rows: {len(selected_queries)}",
+        f"Weak query rows emitted: {len(gaps_df)}",
+        f"Skipped/malformed pair rows: {skipped_pairs}",
+        f"Weak samples parquet: {gaps_parquet}",
+        f"Weak samples CSV: {samples_csv_path}",
+        f"Weak samples JSONL: {samples_jsonl_path}",
+        f"Weak samples preview: {preview_path}",
+        f"Weak group CSV: {groups_path}",
+        f"All attribute metric CSV: {all_attributes_path}",
+    ]
+    if selection_qtype_counts:
+        summary_lines.extend(["", "KPI selection rows by query type:"])
+        for qtype, count in selection_qtype_counts.most_common():
+            summary_lines.append(f"  {qtype}: {count}")
+    if caption_diversity_on and caption_diversity_stats:
+        summary_lines.extend(["", "Caption diversity by weak group:"])
+        for stat in caption_diversity_stats:
+            summary_lines.append(
+                f"  {stat['group']}: "
+                f"candidate_unique_texts={stat['candidate_unique_texts']}, "
+                f"history_unique_texts={stat['history_unique_texts']}, "
+                f"global_history_unique_texts={stat['global_history_unique_texts']}, "
+                f"remaining_unseen={stat['remaining_unseen_unique_texts']}, "
+                f"unique_text_budget={stat['unique_text_budget']}, "
+                f"selected_unique_texts={stat['selected_unique_texts']}, "
+                f"selected_rows={stat['selected_rows']}"
+            )
+    summary_lines.extend(["", "Selected weak groups:"])
+    for row in weak_groups:
+        key = (row.get("attribute", ""),)
+        summary_lines.append(
+            f"  {row.get('attribute', '')}: "
+            f"{row['metric_name']}={float(row['metric_value']):.6g}, "
+            f"selection_queries={row['num_queries']}, "
+            f"selected_rows={per_group_counts.get(key, 0)}, "
+            f"basis={row.get('selection_basis', '')}"
+        )
+    if count_lines:
+        summary_lines.extend(["", "Weak query row counts:"])
+        summary_lines.extend(count_lines)
+    summary_text = "\n".join(summary_lines) + "\n"
+    with open(summary_path, "w", encoding="utf-8") as f:
+        f.write(summary_text)
+
+    print(summary_text.strip())
+    print(f"Saved weak IAA groups to {groups_path}")
+    print(f"Saved weak IAA samples to {samples_csv_path}")
+    print(f"Saved weak IAA sample preview to {preview_path}")
+    print(f"Saved weak query parquet to {gaps_parquet}")
+    return gaps_parquet

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/config.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/config.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bundled and adapted from the Apache-2.0 NVIDIA TAO Tutorials IAA DEFT utilities so the
+# customer workflow does not depend on an external source checkout.
+
+"""Parsed configuration for an IAA CLIP DEFT experiment."""
+
+import json
+import os
+import yaml
+
+
+def _bool_str(value) -> str:
+    """Convert a config value to the 'true'/'false' string expected by pipeline functions."""
+    return "true" if str(value).strip().lower() in ("true", "1", "yes", "y") else "false"
+
+
+def _abs_data_path(value: str) -> str:
+    """Absolutize an IAA data path, leaving blanks and absolute paths untouched.
+
+    These values are handed to both host-side code (which reads the files) and
+    the TAO container specs (which read them again through a bind mount), so a
+    single string has to be valid on both sides. The workflow mounts the data
+    root at its own host path to make that true, which only holds if the path
+    is absolute — a relative ``data/...`` resolves against the container's
+    working directory (``/opt/nvidia``) and silently finds nothing.
+    """
+    value = str(value or "")
+    return os.path.abspath(value) if value else value
+
+
+class IaaDeftConfig:
+    """All parsed parameters for an IAA CLIP DEFT experiment.
+
+    Loads a YAML spec file once and exposes every pipeline parameter as an
+    attribute, so callers never touch raw dicts directly.
+
+    Usage::
+
+        cfg = IaaDeftConfig("configs/clip_config.yaml")
+    """
+
+    CLIP_CKPT_RELPATH = "best/clip_best_val_t2i_mAP.pth"
+    # Model-only copy of the above with the LightningModule "model." prefix
+    # stripped, written by normalize_clip_pretrained_checkpoint. This is what
+    # carries into the next iteration's train.pretrained_model_path; the raw
+    # checkpoint above is what eval consumes.
+    CLIP_PRETRAINED_RELPATH = "pretrained/model_state.pth"
+
+    def __init__(
+        self,
+        config_path: str,
+    ):
+        self.config_path = config_path
+
+        with open(config_path) as f:
+            _cfg = yaml.safe_load(f)
+
+        self.sweep_args_str: str = json.dumps({
+            "config": config_path,
+        })
+
+        # ── Experiment ─────────────────────────────────────────────────────
+        _exp = _cfg["experiment"]
+        self.experiment_name: str = _exp["name"]
+        self.base_experiment_path: str = _exp["results_path"]
+        self.train_config: str = _exp["train_config"]
+        self.eval_config: str = _exp["eval_config"]
+
+        self.tao_pytorch_root: str = _exp.get("tao_pytorch_root", "")
+        if not self.tao_pytorch_root:
+            for _p in (self.train_config, self.eval_config):
+                _marker = "/nvidia_tao_pytorch/"
+                if _marker in _p:
+                    self.tao_pytorch_root = _p.split(_marker, 1)[0]
+                    break
+
+        self.visualize: bool = bool(_exp.get("visualize", False))
+        self.visualize_embeddings: bool = bool(_exp.get("visualize_embeddings", False))
+
+        # ── Training ───────────────────────────────────────────────────────
+        _train = _cfg["training"]
+        self.init_checkpoint: str = _train["init_checkpoint"]
+        self.continual_model: bool = bool(_train["continual_model"])
+        self.continual_dataset: bool = bool(_train["continual_dataset"])
+
+        # ── Mining ─────────────────────────────────────────────────────────
+        _mining = _cfg["mining"]
+        self.mining_topn: int = int(_mining.get("topn", 5) or 5)
+        self.knn_metric: str = _mining.get("knn_metric", "cosine")
+
+        _history_aware = _mining.get("history_aware", {}) or {}
+        self.history_aware_enabled: str = _bool_str(_history_aware.get("enabled", False))
+        self.history_aware_history_file: str = (
+            f"{self.base_experiment_path}/mining_selection_history.json"
+        )
+        self.history_aware_replay_fraction: float = float(
+            _history_aware.get("replay_fraction", 0.20) or 0.0
+        )
+
+        _cap_exp = (_mining.get("recovery") or {}).get("caption_expansion") or {}
+        self.caption_expansion_enabled: str = _bool_str(_cap_exp.get("enabled", False))
+        self.caption_expansion_mode: str = _cap_exp.get("mode", "nearest")
+        self.caption_expansion_max_pairs_per_image_path: int = int(
+            _cap_exp.get("max_pairs_per_image_path", 2) or 0
+        )
+        self.caption_expansion_max_expanded_pair_fraction: float = float(
+            _cap_exp.get("max_expanded_pair_fraction", 0.25) or 0.0
+        )
+        self.caption_expansion_dedupe_normalized_caption: str = _bool_str(
+            _cap_exp.get("dedupe_normalized_caption", True)
+        )
+        self.caption_expansion_count_expanded_pairs_toward_target: str = str(
+            _cap_exp.get("count_expanded_pairs_toward_target", "auto")
+        ).lower()
+
+        # ── Visualization (contact sheets / t-SNE) ─────────────────────────
+        _viz = _cfg.get("lepton_e2e", {}) or {}
+        self.viz_max_samples_per_group: int = int(_viz.get("viz_max_samples_per_group", 12) or 12)
+        self.viz_max_total_samples: int = int(_viz.get("viz_max_total_samples", 96) or 96)
+        self.viz_tile_size: int = int(_viz.get("viz_tile_size", 192) or 192)
+
+        # ── IAA ────────────────────────────────────────────────────────────
+        _iaa = _cfg["iaa"]
+        self.iaa_splits_dir: str = f"{self.base_experiment_path}/iaa_splits"
+        self.iaa_seed_exclude_datasets: str = _iaa.get(
+            "seed_exclude_datasets", "CUHK_PEDES,ICFG_PEDES"
+        )
+        self.iaa_augmented_suffix: str = _iaa.get("augmented_suffix", "_Aug")
+        self.iaa_query_types: str = _iaa.get(
+            "query_types", "easy,medium,hard,natural_caption,original_captions"
+        )
+        self.iaa_max_seed_rows: int = int(_iaa.get("max_seed_rows", 0) or 0)
+        self.iaa_max_aug_pool_rows: int = int(_iaa.get("max_aug_pool_rows", 0) or 0)
+        self.iaa_mining_pool_mode: str = _iaa.get("mining_pool_mode", "real_and_augmented")
+        self.iaa_val_sample_size: int = int(_iaa.get("val_sample_size", 512) or 512)
+        self.iaa_train_pairs_source_file: str = _abs_data_path(
+            _iaa.get("train_pairs_source_file", "")
+        )
+        self.iaa_pool_pairs_source_file: str = (
+            _abs_data_path(_iaa.get("pool_pairs_source_file", ""))
+            or self.iaa_train_pairs_source_file
+        )
+        self.iaa_eval_pairs_source_file: str = _abs_data_path(
+            _iaa["eval_pairs_source_file"]
+        )
+        self.iaa_train_image_dir: str = _abs_data_path(_iaa["train_image_dir"])
+        self.iaa_train_caption_dir: str = _abs_data_path(_iaa["train_caption_dir"])
+        self.iaa_source_image_dir: str = _abs_data_path(_iaa["source_image_dir"])
+        self.iaa_source_caption_dir: str = _abs_data_path(_iaa["source_caption_dir"])
+        self.iaa_eval_image_dir: str = _abs_data_path(_iaa["eval_image_dir"])
+        self.iaa_eval_caption_dir: str = _abs_data_path(_iaa["eval_caption_dir"])
+
+        # ── Gap analysis ───────────────────────────────────────────────────
+        _gap = _cfg.get("gap_analysis", {}) or {}
+        self.gap_metric_name: str = _gap.get("metric_name", "Rank-1")
+        self.queries_per_slice: int = int(_gap.get("queries_per_slice", 256) or 0)
+        self.min_gap_num_queries: int = int(_gap.get("min_num_queries", 1) or 0)
+        self.gap_query_types: str = _gap.get("query_types", "easy,medium")
+        self.weak_attribute_topk: int = int(_gap.get("weak_attribute_topk", 8) or 0)
+        self.target_query_count: int = int(_gap.get("target_query_count", 100000) or 0)
+        self.gap_total_queries_map: int = int(_gap.get("total_queries_mAP", 768) or 768)
+        self.analyze_by_map: bool = bool(_gap.get("analyze_by_mAP", False))
+
+        _cap_div = _gap.get("caption_diversity", {}) or {}
+        self.caption_diversity_enabled: str = _bool_str(_cap_div.get("enabled", False))
+        self.caption_history_file: str = (
+            f"{self.base_experiment_path}/"
+            f"{_cap_div.get('history_file', 'caption_selection_history.json')}"
+        )
+        self.caption_history_policy: str = _cap_div.get("history_policy", "auto")
+        self.caption_coverage_target: float = float(
+            _cap_div.get("coverage_target", 1.0) or 0.0
+        )
+        self.min_unique_texts_per_attribute: int = int(
+            _cap_div.get("min_unique_texts_per_attribute", 0) or 0
+        )
+        self.max_unique_texts_per_attribute: int = int(
+            _cap_div.get("max_unique_texts_per_attribute", 0) or 0
+        )
+        self.max_rows_per_unique_text: int = int(
+            _cap_div.get("max_rows_per_unique_text", 1) or 1
+        )
+        self.max_rows_per_image_path: int = int(
+            _cap_div.get("max_rows_per_image_path", 1) or 1
+        )
+        self.recent_exclude_iters: int = int(
+            _cap_div.get("recent_exclude_iters", 0) or 0
+        )
+        self.replay_fraction_when_noncontinual: float = float(
+            _cap_div.get("replay_fraction_when_noncontinual", 0.25) or 0.0
+        )
+
+        # ── Misc ───────────────────────────────────────────────────────────
+        self.kratos_namespace: str = _cfg.get("kratos_namespace", "")
+        self.iter_start: int = _cfg["iteration"]["start"]
+        self.iter_end: int = _cfg["iteration"]["end"]
+
+    # ──────────────────────────────────────────────────────────────────────
+
+    def training_checkpoint_for_iter(self, iter_num: int) -> str:
+        """Resolve the training checkpoint to use at the start of a DEFT iteration.
+
+        Returns a *container* path (leading ``/``), since the value is written
+        into the TAO spec as ``train.pretrained_model_path``. The normalized model-only
+        checkpoint is used rather than the raw Lightning one.
+        """
+        if not self.continual_model:
+            return self.init_checkpoint
+        if iter_num == 1:
+            host_ckpt = (
+                f"{self.base_experiment_path}/sft/{self.CLIP_PRETRAINED_RELPATH}"
+            )
+            return (
+                f"/{host_ckpt}"
+                if (bool(self.iaa_train_pairs_source_file)
+                    and os.path.exists(host_ckpt))
+                else self.init_checkpoint
+            )
+        return (
+            f"/{self.base_experiment_path}/iter_{iter_num - 1}"
+            f"/{self.CLIP_PRETRAINED_RELPATH}"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"IaaDeftConfig(experiment={self.experiment_name!r}, "
+            f"path={self.config_path!r})"
+        )

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/data_mining.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/data_mining.py
@@ -1,0 +1,1702 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bundled and adapted from the Apache-2.0 NVIDIA TAO Tutorials IAA DEFT utilities so the
+# customer workflow does not depend on an external source checkout.
+
+"""Data-mining and training-split utilities for DEFT pipelines.
+
+- :func:`materialize_iaa_eval_split` — materialize IAA eval image list and pairs file.
+- :func:`materialize_iaa_training_split` — write real/non-excluded seed training rows.
+- :func:`materialize_iaa_pool_split` — write mining pool rows.
+- :func:`convert_vcn_csv_to_parquet` — VCN CSV → per-image parquet with absolute filepaths.
+- :func:`convert_mined_parquet_to_csv` — reverse mined filepaths back to VCN training CSV rows.
+- :func:`merge_train_csvs` — merge augmentation CSVs with the base training set.
+- :func:`convert_clip_image_list_to_parquet` — CLIP image list → embedding parquet.
+- :func:`convert_mined_parquet_to_clip_image_list` — mined parquet → CLIP image-list + pairs.
+- :func:`summarize_knn_mining` — post-k-NN mining summary (txt + json).
+- :func:`track_cumulative_mined_unique_names` — cumulative mined names across iterations.
+- :func:`write_iteration_summary` — per-iteration artifact/checkpoint summary.
+"""
+
+
+def materialize_iaa_eval_split(
+    eval_pairs_source_file: str,
+    eval_image_list_file: str,
+    eval_pairs_file: str,
+    query_types: str = "",
+    val_image_list_file: str = "",
+    val_sample_size: int = 512,
+):
+    """Materialize the IAA eval image list and pairs file from test_pairs.json.
+
+    Args:
+        eval_pairs_source_file:  Path to the source test_pairs.json.
+        eval_image_list_file:    Output image list for eval rows.
+        eval_pairs_file:         Output pairs JSON for eval rows.
+        query_types:             Optional comma-separated query type filter.
+        val_image_list_file:     Optional output path for a small sampled
+                                 validation image list used during TAO training.
+        val_sample_size:         Number of images to sample for the validation
+                                 list (default 512).
+    """
+    import json
+    import os
+    import random
+
+    def _split_csv(value):
+        return {item.strip() for item in str(value or "").split(",") if item.strip()}
+
+    def _infer_dataset(image_path):
+        normalized = str(image_path or "").replace("\\", "/")
+        parts = [p for p in normalized.split("/") if p]
+        for marker in ("images", "data"):
+            if marker in parts:
+                idx = parts.index(marker)
+                if idx + 1 < len(parts):
+                    return parts[idx + 1].strip()
+        return parts[0].strip() if len(parts) > 1 else ""
+
+    def _normalize_row(row):
+        unique_name = str(row.get("unique_name") or "").strip()
+        caption = str(row.get("caption") or "").strip()
+        image_path = str(row.get("image_path") or "").strip()
+        dataset = str(row.get("dataset") or "").strip() or _infer_dataset(image_path)
+        if not unique_name or not caption or not dataset:
+            return None
+        out_row = dict(row)
+        out_row["dataset"] = dataset
+        out_row["query_type"] = str(row.get("query_type") or "").strip()
+        out_row["caption"] = caption
+        out_row["unique_name"] = unique_name
+        return out_row
+
+    def _iter_json_records(path):
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        compact = (
+            second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if compact:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s or s in ("[", "]"):
+                        continue
+                    if s.endswith(","):
+                        s = s[:-1]
+                    if s:
+                        yield json.loads(s)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for row in json.load(f):
+                yield row
+
+    required = [p for p in (eval_image_list_file, eval_pairs_file, val_image_list_file) if p]
+    if required and all(os.path.isfile(p) for p in required):
+        print("IAA eval split already exists; skipping")
+        return
+
+    if not eval_pairs_source_file:
+        raise ValueError("eval_pairs_source_file must be set")
+    if not os.path.isfile(eval_pairs_source_file):
+        raise FileNotFoundError(f"IAA eval pairs file not found: {eval_pairs_source_file}")
+
+    qtypes = _split_csv(query_types)
+    for path in required:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+
+    eval_rows = 0
+    eval_images = []
+    eval_seen = set()
+    eval_skipped = 0
+    pairs_handle = None
+    first = True
+    try:
+        if eval_pairs_file:
+            pairs_handle = open(eval_pairs_file, "w", encoding="utf-8")
+            pairs_handle.write("[\n")
+        for row in _iter_json_records(eval_pairs_source_file):
+            query_type = str(row.get("query_type") or "").strip()
+            if qtypes and query_type not in qtypes:
+                eval_skipped += 1
+                continue
+            out_row = _normalize_row(row)
+            if out_row is None:
+                eval_skipped += 1
+                continue
+            name = out_row["unique_name"]
+            if name not in eval_seen:
+                eval_seen.add(name)
+                eval_images.append(name)
+            if pairs_handle:
+                if not first:
+                    pairs_handle.write(",\n")
+                pairs_handle.write(json.dumps(out_row, ensure_ascii=False))
+                first = False
+            eval_rows += 1
+    finally:
+        if pairs_handle:
+            pairs_handle.write("\n]\n")
+            pairs_handle.close()
+
+    if eval_image_list_file:
+        with open(eval_image_list_file, "w", encoding="utf-8") as f:
+            for name in eval_images:
+                f.write(f"{name}\n")
+
+    if val_image_list_file and val_sample_size > 0 and eval_images:
+        rng = random.Random(42)
+        sample = rng.sample(eval_images, min(val_sample_size, len(eval_images)))
+        val_parent = os.path.dirname(val_image_list_file)
+        if val_parent:
+            os.makedirs(val_parent, exist_ok=True)
+        with open(val_image_list_file, "w", encoding="utf-8") as f:
+            for name in sample:
+                f.write(f"{name}\n")
+
+    print(
+        f"IAA eval split: {eval_rows} rows / {len(eval_images)} images "
+        f"({eval_skipped} skipped) -> {eval_pairs_file}"
+    )
+
+
+def materialize_iaa_training_split(
+    train_pairs_source_file: str,
+    seed_image_list_file: str,
+    seed_pairs_file: str,
+    seed_exclude_datasets: str = "CUHK_PEDES,ICFG_PEDES",
+    augmented_suffix: str = "_Aug",
+    query_types: str = "",
+    max_seed_rows: int = 0,
+):
+    """Materialize the IAA seed/training image list and pairs file.
+
+    Writes real, non-excluded rows from train_pairs.json to the seed
+    training files. Skips silently if both output files already exist.
+
+    Args:
+        train_pairs_source_file:  Path to the source train_pairs.json.
+        seed_image_list_file:     Output image list for real seed rows.
+        seed_pairs_file:          Output pairs JSON for real seed rows.
+        seed_exclude_datasets:    Comma-separated real datasets to exclude.
+        augmented_suffix:         Dataset suffix identifying augmented data.
+        query_types:              Optional comma-separated query type filter.
+        max_seed_rows:            Optional cap; 0 means no cap.
+    """
+    import json
+    import os
+
+    def _split_csv(value):
+        return {item.strip() for item in str(value or "").split(",") if item.strip()}
+
+    def _infer_dataset(image_path):
+        normalized = str(image_path or "").replace("\\", "/")
+        parts = [p for p in normalized.split("/") if p]
+        for marker in ("images", "data"):
+            if marker in parts:
+                idx = parts.index(marker)
+                if idx + 1 < len(parts):
+                    return parts[idx + 1].strip()
+        return parts[0].strip() if len(parts) > 1 else ""
+
+    def _normalize_row(row):
+        unique_name = str(row.get("unique_name") or "").strip()
+        caption = str(row.get("caption") or "").strip()
+        image_path = str(row.get("image_path") or "").strip()
+        dataset = str(row.get("dataset") or "").strip() or _infer_dataset(image_path)
+        if not unique_name or not caption or not dataset:
+            return None
+        out_row = dict(row)
+        out_row["dataset"] = dataset
+        out_row["query_type"] = str(row.get("query_type") or "").strip()
+        out_row["caption"] = caption
+        out_row["unique_name"] = unique_name
+        return out_row
+
+    def _iter_json_records(path):
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        compact = (
+            second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if compact:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s or s in ("[", "]"):
+                        continue
+                    if s.endswith(","):
+                        s = s[:-1]
+                    if s:
+                        yield json.loads(s)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for row in json.load(f):
+                yield row
+
+    required = [p for p in (seed_image_list_file, seed_pairs_file) if p]
+    if required and all(os.path.isfile(p) for p in required):
+        print("IAA training split already exists; skipping")
+        return
+
+    if not train_pairs_source_file:
+        raise ValueError("train_pairs_source_file must be set")
+    if not os.path.isfile(train_pairs_source_file):
+        raise FileNotFoundError(
+            f"IAA train_pairs.json not found: {train_pairs_source_file}"
+        )
+
+    for path in required:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+
+    excluded = _split_csv(seed_exclude_datasets)
+    qtypes = _split_csv(query_types)
+    max_seed_rows = int(max_seed_rows or 0)
+
+    seed_count = 0
+    skipped_query_type = 0
+    skipped_unknown_dataset = 0
+    first_seed = True
+
+    seed_list_handle = None
+    seed_pairs_handle = None
+    try:
+        if seed_image_list_file:
+            seed_list_handle = open(seed_image_list_file, "w", encoding="utf-8")
+        if seed_pairs_file:
+            seed_pairs_handle = open(seed_pairs_file, "w", encoding="utf-8")
+            seed_pairs_handle.write("[\n")
+
+        for row in _iter_json_records(train_pairs_source_file):
+            query_type = str(row.get("query_type") or "").strip()
+            if qtypes and query_type not in qtypes:
+                skipped_query_type += 1
+                continue
+            out_row = _normalize_row(row)
+            if out_row is None:
+                skipped_unknown_dataset += 1
+                continue
+            dataset = out_row["dataset"]
+            unique_name = out_row["unique_name"]
+
+            if "is_augmented" in out_row:
+                value = out_row.get("is_augmented")
+                if isinstance(value, bool):
+                    is_aug = value
+                else:
+                    normalized_val = str(value).strip().lower()
+                    if normalized_val in {"true", "1", "yes", "y", "on"}:
+                        is_aug = True
+                    elif normalized_val in {"false", "0", "no", "n", "off"}:
+                        is_aug = False
+                    else:
+                        is_aug = bool(augmented_suffix) and dataset.endswith(augmented_suffix)
+            else:
+                is_aug = bool(augmented_suffix) and dataset.endswith(augmented_suffix)
+            is_real = not is_aug
+
+            if is_real and dataset not in excluded:
+                if not max_seed_rows or seed_count < max_seed_rows:
+                    if seed_pairs_handle:
+                        if not first_seed:
+                            seed_pairs_handle.write(",\n")
+                        seed_pairs_handle.write(json.dumps(out_row, ensure_ascii=False))
+                        first_seed = False
+                    if seed_list_handle:
+                        seed_list_handle.write(f"{unique_name}\n")
+                    seed_count += 1
+
+    finally:
+        if seed_pairs_handle:
+            seed_pairs_handle.write("\n]\n")
+            seed_pairs_handle.close()
+        if seed_list_handle:
+            seed_list_handle.close()
+
+    print(
+        f"IAA training split: {seed_count} rows "
+        f"({skipped_unknown_dataset} malformed, {skipped_query_type} query-type-filtered) "
+        f"-> {seed_pairs_file}"
+    )
+
+
+def materialize_iaa_pool_split(
+    pool_pairs_source_file: str,
+    aug_pool_image_list_file: str,
+    aug_pool_pairs_file: str,
+    augmented_suffix: str = "_Aug",
+    query_types: str = "",
+    max_aug_pool_rows: int = 0,
+    mining_pool_mode: str = "augmented",
+):
+    """Materialize the IAA mining pool image list and pairs file.
+
+    Writes pool rows from pool_pairs_source_file based on mining_pool_mode.
+    Skips silently if both output files already exist.
+
+    Args:
+        pool_pairs_source_file:    Path to the source pairs JSON for the mining pool.
+        aug_pool_image_list_file:  Output image list for pool rows.
+        aug_pool_pairs_file:       Output pairs JSON for pool rows.
+        augmented_suffix:          Dataset suffix identifying augmented data.
+        query_types:               Optional comma-separated query type filter.
+        max_aug_pool_rows:         Optional cap; 0 means no cap.
+        mining_pool_mode:          Which rows go into pool:
+                                   ``real``, ``augmented``, or
+                                   ``real_and_augmented``.
+    """
+    import json
+    import os
+
+    def _split_csv(value):
+        return {item.strip() for item in str(value or "").split(",") if item.strip()}
+
+    def _infer_dataset(image_path):
+        normalized = str(image_path or "").replace("\\", "/")
+        parts = [p for p in normalized.split("/") if p]
+        for marker in ("images", "data"):
+            if marker in parts:
+                idx = parts.index(marker)
+                if idx + 1 < len(parts):
+                    return parts[idx + 1].strip()
+        return parts[0].strip() if len(parts) > 1 else ""
+
+    def _normalize_row(row):
+        unique_name = str(row.get("unique_name") or "").strip()
+        caption = str(row.get("caption") or "").strip()
+        image_path = str(row.get("image_path") or "").strip()
+        dataset = str(row.get("dataset") or "").strip() or _infer_dataset(image_path)
+        if not unique_name or not caption or not dataset:
+            return None
+        out_row = dict(row)
+        out_row["dataset"] = dataset
+        out_row["query_type"] = str(row.get("query_type") or "").strip()
+        out_row["caption"] = caption
+        out_row["unique_name"] = unique_name
+        return out_row
+
+    def _iter_json_records(path):
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        compact = (
+            second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if compact:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s or s in ("[", "]"):
+                        continue
+                    if s.endswith(","):
+                        s = s[:-1]
+                    if s:
+                        yield json.loads(s)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for row in json.load(f):
+                yield row
+
+    def _is_augmented_row(row, dataset):
+        if "is_augmented" in row:
+            value = row.get("is_augmented")
+            if isinstance(value, bool):
+                return value
+            normalized = str(value).strip().lower()
+            if normalized in {"true", "1", "yes", "y", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "off"}:
+                return False
+        return bool(augmented_suffix) and dataset.endswith(augmented_suffix)
+
+    def _mode_tokens(value):
+        normalized = str(value or "").lower().replace("+", ",").replace(";", ",")
+        tokens = _split_csv(normalized)
+        if "real_and_augmented" in tokens or "all" in tokens:
+            tokens.update({"real", "augmented"})
+        if "aug" in tokens:
+            tokens.add("augmented")
+        return tokens or {"augmented"}
+
+    required = [p for p in (aug_pool_image_list_file, aug_pool_pairs_file) if p]
+    if required and all(os.path.isfile(p) for p in required):
+        print("IAA pool split already exists; skipping")
+        return
+
+    if not pool_pairs_source_file:
+        raise ValueError("pool_pairs_source_file must be set")
+    if not os.path.isfile(pool_pairs_source_file):
+        raise FileNotFoundError(
+            f"Pool pairs file not found: {pool_pairs_source_file}"
+        )
+
+    for path in required:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+
+    qtypes = _split_csv(query_types)
+    max_aug_pool_rows = int(max_aug_pool_rows or 0)
+    pool_modes = _mode_tokens(mining_pool_mode)
+    include_real_pool = "real" in pool_modes
+    include_aug_pool = "augmented" in pool_modes
+
+    pool_count = 0
+    skipped_query_type = 0
+    skipped_unknown_dataset = 0
+    first_pool = True
+
+    pool_list_handle = None
+    pool_pairs_handle = None
+    try:
+        if aug_pool_image_list_file:
+            pool_list_handle = open(aug_pool_image_list_file, "w", encoding="utf-8")
+        if aug_pool_pairs_file:
+            pool_pairs_handle = open(aug_pool_pairs_file, "w", encoding="utf-8")
+            pool_pairs_handle.write("[\n")
+
+        for row in _iter_json_records(pool_pairs_source_file):
+            query_type = str(row.get("query_type") or "").strip()
+            if qtypes and query_type not in qtypes:
+                skipped_query_type += 1
+                continue
+            out_row = _normalize_row(row)
+            if out_row is None:
+                skipped_unknown_dataset += 1
+                continue
+            dataset = out_row["dataset"]
+            unique_name = out_row["unique_name"]
+            is_aug = _is_augmented_row(out_row, dataset)
+            is_real = not is_aug
+
+            if (is_aug and include_aug_pool) or (is_real and include_real_pool):
+                if not max_aug_pool_rows or pool_count < max_aug_pool_rows:
+                    if pool_pairs_handle:
+                        if not first_pool:
+                            pool_pairs_handle.write(",\n")
+                        pool_pairs_handle.write(json.dumps(out_row, ensure_ascii=False))
+                        first_pool = False
+                    if pool_list_handle:
+                        pool_list_handle.write(f"{unique_name}\n")
+                    pool_count += 1
+
+    finally:
+        if pool_pairs_handle:
+            pool_pairs_handle.write("\n]\n")
+            pool_pairs_handle.close()
+        if pool_list_handle:
+            pool_list_handle.close()
+
+    print(
+        f"IAA pool split: {pool_count} rows (mode={sorted(pool_modes)}) "
+        f"({skipped_unknown_dataset} malformed, {skipped_query_type} query-type-filtered) "
+        f"-> {aug_pool_pairs_file}"
+    )
+
+
+def convert_clip_image_list_to_parquet(
+    image_list_file: str,
+    image_dir: str,
+    output_parquet: str,
+    caption_dir: str = "",
+    caption_file_suffix: str = "",
+    pairs_file: str = "",
+) -> str:
+    """Convert a CLIP-format ``image_list_file`` to an embedding parquet.
+
+    Args:
+        image_list_file:     Path to a text file with one image basename per line.
+        image_dir:           Flat directory of images.
+        output_parquet:      Path where the output parquet will be written.
+        caption_dir:         Optional caption directory.
+        caption_file_suffix: Caption file suffix (e.g. ``.txt``).
+        pairs_file:          Optional TAO-FT ``*_pairs.json``.
+
+    Returns:
+        Path to ``output_parquet``.
+    """
+    import json
+    import os
+
+    import pandas as pd
+
+    def _infer_dataset(image_path):
+        normalized = str(image_path or "").replace("\\", "/")
+        parts = [p for p in normalized.split("/") if p]
+        for marker in ("images", "data"):
+            if marker in parts:
+                idx = parts.index(marker)
+                if idx + 1 < len(parts):
+                    return parts[idx + 1].strip()
+        if len(parts) > 1:
+            return parts[0].strip()
+        return ""
+
+    def _iter_json_records(path):
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        compact = (
+            second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if compact:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s or s in ("[", "]"):
+                        continue
+                    if s.endswith(","):
+                        s = s[:-1]
+                    if s:
+                        yield json.loads(s)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for row in json.load(f):
+                yield row
+
+    out_dir = os.path.dirname(output_parquet)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    with open(image_list_file, "r", encoding="utf-8") as f:
+        basenames = [line.strip() for line in f if line.strip()]
+
+    if pairs_file:
+        wanted = set(basenames)
+        records = []
+        for row in _iter_json_records(pairs_file):
+            name = str(row.get("unique_name") or "").strip()
+            if name not in wanted:
+                continue
+            image_path = str(row.get("image_path") or "")
+            dataset = str(row.get("dataset") or "").strip() or _infer_dataset(image_path)
+            records.append({
+                "filepath": os.path.abspath(os.path.join(image_dir, name)),
+                "text": str(row.get("caption") or "").strip(),
+                "unique_name": name,
+                "image_path": image_path,
+                "query_type": str(row.get("query_type") or "").strip(),
+                "dataset": dataset,
+            })
+        out_df = pd.DataFrame(records)
+        out_df.to_parquet(output_parquet, index=False)
+        print(
+            f"Converted CLIP pairs to parquet: "
+            f"{len(records)} rows from {pairs_file} -> {output_parquet}"
+        )
+        return output_parquet
+
+    include_text = bool(caption_dir) and bool(caption_file_suffix)
+    records = []
+    for name in basenames:
+        rec = {"filepath": os.path.abspath(os.path.join(image_dir, name))}
+        if include_text:
+            stem = os.path.splitext(name)[0]
+            caption_path = os.path.join(
+                caption_dir, f"{stem}{caption_file_suffix}",
+            )
+            with open(caption_path, "r", encoding="utf-8") as f:
+                rec["text"] = f.read().strip()
+        records.append(rec)
+
+    columns = ["filepath", "text"] if include_text else ["filepath"]
+    out_df = pd.DataFrame(records, columns=columns)
+    out_df.to_parquet(output_parquet, index=False)
+    print(
+        f"Converted CLIP image_list_file to parquet: "
+        f"{len(basenames)} basenames -> {output_parquet}"
+    )
+    return output_parquet
+
+
+def convert_mined_parquet_to_clip_image_list(
+    mined_parquet: str,
+    image_dir: str,
+    caption_dir: str,
+    caption_file_suffix: str,
+    output_image_list_file: str,
+    manifest_path: str,
+    source_pairs_file: str = "",
+    output_pairs_file: str = "",
+    target_query_count: int = 0,
+    caption_expansion_enabled: str = "false",
+    caption_expansion_mode: str = "nearest",
+    caption_expansion_max_pairs_per_image_path: int = 2,
+    caption_expansion_max_expanded_pair_fraction: float = 0.25,
+    caption_expansion_dedupe_normalized_caption: str = "true",
+    caption_expansion_count_expanded_pairs_toward_target: str = "auto",
+    source_embedding_shards_dir: str = "",
+    write_detailed_csv: str = "true",
+    source_embeddings_parquet: str = "",
+    target_embeddings_parquet: str = "",
+) -> str:
+    """Convert mined filepaths into CLIP image-list, pairs, and stats files.
+
+    When history-aware selection runs downstream, call this with
+    ``target_query_count=0`` so the candidate set stays uncapped: the budget
+    belongs to the selector, which spends it after partitioning novel from
+    previously-committed names. ``write_detailed_csv`` should be off in that
+    case, since the selector writes its own detail CSV over the committed
+    selection and this one would only describe discarded candidates.
+
+    The mine step emits only ``filepath``, so the candidate order it produces
+    is its emission order — grouped by target query, not by similarity.
+    Truncating that to ``target_query_count`` starves whichever weak queries
+    happen to sit at the tail of the file. Pass ``source_embeddings_parquet``
+    and ``target_embeddings_parquet`` (both are already written upstream) to
+    recompute each candidate's best cosine similarity to any weak query and
+    order by it first. Skipped when the mined parquet already carries a
+    ``score`` column, so a future mine step that emits scores directly wins.
+    """
+    import json
+    import math
+    import os
+    from collections import Counter
+
+    import numpy as np
+    import pandas as pd
+
+    def _iter_json_records(path):
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        compact = (
+            second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if compact:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s or s in ("[", "]"):
+                        continue
+                    if s.endswith(","):
+                        s = s[:-1]
+                    if s:
+                        yield json.loads(s)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for row in json.load(f):
+                yield row
+
+    def _counter_records(counter):
+        total = sum(counter.values())
+        rows = []
+        for value, count in counter.most_common():
+            rows.append({
+                "value": value,
+                "count": int(count),
+                "pct": (100.0 * count / total) if total else 0.0,
+            })
+        return rows
+
+    def _truthy(value):
+        return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    def _falsey(value):
+        return str(value).strip().lower() in {"0", "false", "no", "n", "off"}
+
+    def _pair_name(row):
+        return str(row.get("unique_name") or "").strip().replace("\\", "/")
+
+    def _pair_image_path(row):
+        return str(row.get("image_path") or "").strip().replace("\\", "/")
+
+    def _pair_caption(row):
+        return str(row.get("caption") or row.get("text") or "").strip()
+
+    def _normalize_caption(value):
+        return " ".join(str(value or "").strip().lower().split())
+
+    def _lexical_similarity(a, b):
+        a_tokens = set(_normalize_caption(a).split())
+        b_tokens = set(_normalize_caption(b).split())
+        if not a_tokens and not b_tokens:
+            return 1.0
+        if not a_tokens or not b_tokens:
+            return 0.0
+        return len(a_tokens & b_tokens) / len(a_tokens | b_tokens)
+
+    def _dense_vector(value):
+        if value is None:
+            return None
+        arr = np.asarray(value, dtype=np.float32)
+        if arr.ndim != 1 or arr.size == 0:
+            return None
+        norm = float(np.linalg.norm(arr))
+        if not math.isfinite(norm) or norm <= 0:
+            return None
+        return arr / norm
+
+    def _load_embeddings_for_names(shards_dir, wanted_names):
+        embeddings = {}
+        if not shards_dir or not wanted_names:
+            return embeddings, 0
+        shard_dir = os.path.normpath(os.path.realpath(shards_dir))
+        if not os.path.isdir(shard_dir):
+            return embeddings, 0
+        shard_paths = sorted(
+            os.path.join(shard_dir, name)
+            for name in os.listdir(shard_dir)
+            if name.endswith("_embeddings.parquet")
+        )
+        wanted = set(wanted_names)
+        rows_scanned = 0
+        for shard_path in shard_paths:
+            df = pd.read_parquet(
+                shard_path,
+                columns=["unique_name", "embedding"],
+            )
+            rows_scanned += len(df)
+            if df.empty:
+                continue
+            names = df["unique_name"].fillna("").astype(str)
+            mask = names.isin(wanted)
+            if not mask.any():
+                continue
+            for name, embedding in zip(names[mask], df.loc[mask, "embedding"]):
+                normed = _dense_vector(embedding)
+                if normed is not None:
+                    embeddings[str(name)] = normed
+        return embeddings, rows_scanned
+
+    image_root = os.path.normpath(os.path.realpath(image_dir))
+
+    def _mined_unique_name(row):
+        name = str(row.get("unique_name") or "").strip()
+        if name:
+            return name.replace("\\", "/")
+        filepath = str(row.get("filepath") or "").strip()
+        if not filepath:
+            return ""
+        abs_path = os.path.normpath(os.path.realpath(filepath))
+        try:
+            rel = os.path.relpath(abs_path, image_root)
+        except ValueError:
+            rel = ""
+        if (
+            rel
+            and rel != os.curdir
+            and rel != os.pardir
+            and not rel.startswith(os.pardir + os.sep)
+            and not os.path.isabs(rel)
+        ):
+            return rel.replace(os.sep, "/")
+        return os.path.basename(filepath).replace("\\", "/")
+
+    mined = pd.read_parquet(mined_parquet)
+    if "filepath" not in mined.columns:
+        raise ValueError(
+            f"mined parquet at {mined_parquet} missing required "
+            f"'filepath' column; found {list(mined.columns)}"
+        )
+
+    def _rescore_by_similarity(mined_df):
+        """Order candidates by best cosine similarity to any weak query.
+
+        Streams the source-pool embeddings in batches and keeps only the
+        mined rows, so peak memory is one batch plus the mined subset rather
+        than the whole pool (which runs to several GB).
+        """
+        import pyarrow.parquet as pq
+
+        for label, path in (
+            ("source", source_embeddings_parquet),
+            ("target", target_embeddings_parquet),
+        ):
+            if not os.path.isfile(path):
+                print(
+                    f"{label} embeddings parquet not found at {path}; "
+                    "keeping mined order"
+                )
+                return mined_df, False
+
+        wanted = set(mined_df["filepath"].astype(str))
+        target_df = pd.read_parquet(target_embeddings_parquet)
+        if "embedding" not in target_df.columns or not len(target_df):
+            print(
+                "Target embeddings unusable for rescoring "
+                f"({target_embeddings_parquet}); keeping mined order"
+            )
+            return mined_df, False
+
+        paths, vectors = [], []
+        parquet_file = pq.ParquetFile(source_embeddings_parquet)
+        for batch in parquet_file.iter_batches(
+            columns=["filepath", "embedding"], batch_size=65536,
+        ):
+            chunk = batch.to_pandas()
+            chunk = chunk[chunk["filepath"].astype(str).isin(wanted)]
+            if len(chunk):
+                paths.extend(chunk["filepath"].astype(str).tolist())
+                vectors.extend(chunk["embedding"].tolist())
+        if not paths:
+            print(
+                "No mined filepath matched the source embeddings at "
+                f"{source_embeddings_parquet}; keeping mined order"
+            )
+            return mined_df, False
+
+        candidates = np.asarray(np.vstack(vectors), dtype=np.float32)
+        targets = np.asarray(
+            np.vstack(target_df["embedding"].to_numpy()), dtype=np.float32,
+        )
+        candidates /= np.maximum(
+            np.linalg.norm(candidates, axis=1, keepdims=True), 1e-12,
+        )
+        targets /= np.maximum(
+            np.linalg.norm(targets, axis=1, keepdims=True), 1e-12,
+        )
+        similarity = candidates @ targets.T
+        best_target = similarity.argmax(axis=1)
+        best_score = similarity.max(axis=1)
+
+        scored = pd.DataFrame({"filepath": paths, "score": best_score})
+        # Recovering which weak query each candidate is nearest to also
+        # restores the per-attribute mining-coverage breakdown.
+        for column, out_name in (
+            ("query_type", "target_query_type"),
+            ("weak_attribute", "target_attribute"),
+        ):
+            if column in target_df.columns:
+                scored[out_name] = target_df[column].to_numpy()[best_target]
+        scored = (
+            scored.sort_values("score", ascending=False)
+            .drop_duplicates(subset=["filepath"])
+        )
+
+        merged = mined_df.merge(scored, on="filepath", how="left")
+        unscored = int(merged["score"].isna().sum())
+        merged = merged.sort_values(
+            "score", ascending=False, na_position="last", kind="mergesort",
+        ).reset_index(drop=True)
+        print(
+            f"Rescored {len(scored)} mined candidates against "
+            f"{len(target_df)} weak queries "
+            f"({unscored} had no source embedding and sort last); "
+            f"score range {merged['score'].min():.4f}..{merged['score'].max():.4f}"
+        )
+        return merged, True
+
+    rescored_by_similarity = False
+    if "score" in mined.columns:
+        # A mine step that emits scores directly wins; just honour it.
+        mined = mined.sort_values(
+            "score", ascending=False, na_position="last", kind="mergesort",
+        ).reset_index(drop=True)
+        rescored_by_similarity = True
+        print("Mined parquet carries a score column; ordered by it directly.")
+    elif source_embeddings_parquet and target_embeddings_parquet:
+        try:
+            mined, rescored_by_similarity = _rescore_by_similarity(mined)
+        except Exception as exc:  # noqa: BLE001
+            # Ordering is an optimisation; a failure here must not take the
+            # whole conversion down. The warning below still fires, so a
+            # degraded run is never silent.
+            print(f"Similarity rescoring failed ({type(exc).__name__}: {exc})")
+            rescored_by_similarity = False
+    if not rescored_by_similarity:
+        print(
+            "WARNING: mined candidates are in the mine step's emission order, "
+            "which is grouped by target query rather than by similarity. Any "
+            "target_query_count truncation below will keep whichever queries "
+            "come first in the file, not the nearest images. Pass "
+            "source_embeddings_parquet and target_embeddings_parquet to fix."
+        )
+
+    raw_rows = len(mined)
+    raw_unique_filepaths = int(mined["filepath"].drop_duplicates().shape[0])
+    raw_unique_names = 0
+    if "unique_name" in mined.columns:
+        raw_unique_names = int(
+            mined["unique_name"].fillna("").astype(str)
+            .loc[lambda values: values.astype(bool)]
+            .drop_duplicates()
+            .shape[0]
+        )
+    target_query_count = int(target_query_count or 0)
+    write_details = _truthy(write_detailed_csv)
+    basenames = (
+        mined.apply(_mined_unique_name, axis=1)
+        .loc[lambda values: values.astype(bool)]
+        .drop_duplicates()
+        .tolist()
+    )
+
+    pairs_by_name = {}
+    selected_pair_items = []
+    missing_pairs = 0
+    train_pairs_file = ""
+    pairs_count = 0
+    pre_budget_unique_basenames = len(basenames)
+    pre_budget_recovered_pairs = 0
+    budget_omitted_basenames = 0
+    budget_reached = False
+    source_pair_rows_scanned = 0
+    target_pair_shortfall = 0
+    expansion_enabled = _truthy(caption_expansion_enabled)
+    expansion_mode = str(caption_expansion_mode or "nearest").strip().lower()
+    if expansion_mode not in {"nearest", "all"}:
+        raise ValueError(
+            "caption_expansion_mode must be one of: nearest, all; "
+            f"got {caption_expansion_mode!r}"
+        )
+    max_pairs_per_image_path = max(
+        0,
+        int(caption_expansion_max_pairs_per_image_path or 0),
+    )
+    max_expanded_pair_fraction = max(
+        0.0,
+        min(1.0, float(caption_expansion_max_expanded_pair_fraction or 0.0)),
+    )
+    dedupe_expansion_captions = _truthy(
+        caption_expansion_dedupe_normalized_caption
+    )
+    count_expanded_raw = str(
+        caption_expansion_count_expanded_pairs_toward_target or "auto"
+    ).strip().lower()
+    if count_expanded_raw in {"", "auto"}:
+        count_expanded_pairs_toward_target = expansion_mode != "all"
+    elif _truthy(count_expanded_raw):
+        count_expanded_pairs_toward_target = True
+    elif _falsey(count_expanded_raw):
+        count_expanded_pairs_toward_target = False
+    else:
+        raise ValueError(
+            "caption_expansion_count_expanded_pairs_toward_target must be "
+            f"auto, true, or false; got {caption_expansion_count_expanded_pairs_toward_target!r}"
+        )
+    caption_expansion_stats = {
+        "enabled": bool(expansion_enabled),
+        "mode": expansion_mode,
+        "uses_nearest_caps": bool(expansion_mode == "nearest"),
+        "count_expanded_pairs_toward_target": bool(
+            count_expanded_pairs_toward_target
+        ),
+        "target_budget_applies_to": (
+            "total_pairs"
+            if count_expanded_pairs_toward_target
+            else "anchor_pairs"
+        ),
+        "max_pairs_per_image_path": int(max_pairs_per_image_path),
+        "max_expanded_pair_fraction": float(max_expanded_pair_fraction),
+        "dedupe_normalized_caption": bool(dedupe_expansion_captions),
+        "source_embedding_shards_dir": source_embedding_shards_dir,
+        "source_pair_rows_scanned_for_expansion": 0,
+        "source_embedding_rows_scanned_for_expansion": 0,
+        "candidate_image_paths": 0,
+        "candidate_pair_rows": 0,
+        "candidate_pair_names": 0,
+        "candidate_pairs_after_dedup": 0,
+        "planned_anchor_pairs": 0,
+        "planned_expanded_pairs": 0,
+        "final_anchor_pairs": 0,
+        "final_expanded_pairs": 0,
+        "final_unique_image_paths": 0,
+        "missing_anchor_embeddings": 0,
+        "missing_candidate_embeddings": 0,
+        "deduped_caption_rows": 0,
+        "similarity_backend": "none",
+    }
+    if source_pairs_file:
+        if not output_pairs_file:
+            stem, _ = os.path.splitext(output_image_list_file)
+            output_pairs_file = f"{stem}_pairs.json"
+        wanted = set(basenames)
+        for row in _iter_json_records(source_pairs_file):
+            source_pair_rows_scanned += 1
+            name = _pair_name(row)
+            if name in wanted:
+                pairs_by_name.setdefault(name, []).append(row)
+        missing_pairs = len(wanted) - len(pairs_by_name)
+        if missing_pairs:
+            print(
+                f"Warning: {missing_pairs} mined basenames were not found "
+                f"in {source_pairs_file}; they will be omitted from the "
+                "mined image list to keep train_pairs_file aligned."
+            )
+        basenames = [name for name in basenames if name in pairs_by_name]
+        anchor_basenames = list(basenames)
+        pre_budget_unique_basenames = len(basenames)
+
+        expansion_by_anchor = {}
+        if expansion_enabled and basenames:
+            anchor_image_paths = {}
+            for name in basenames:
+                pair_rows = pairs_by_name.get(name, [])
+                image_path = _pair_image_path(pair_rows[0]) if pair_rows else ""
+                if image_path:
+                    anchor_image_paths[name] = image_path
+            wanted_image_paths = set(anchor_image_paths.values())
+            rows_by_image_path = {}
+            seen_caption_keys = set()
+            deduped_caption_rows = 0
+            expansion_pair_rows_scanned = 0
+            for row in _iter_json_records(source_pairs_file):
+                expansion_pair_rows_scanned += 1
+                image_path = _pair_image_path(row)
+                if image_path not in wanted_image_paths:
+                    continue
+                if dedupe_expansion_captions:
+                    caption_key = (image_path, _normalize_caption(_pair_caption(row)))
+                    if caption_key[1] and caption_key in seen_caption_keys:
+                        deduped_caption_rows += 1
+                        continue
+                    if caption_key[1]:
+                        seen_caption_keys.add(caption_key)
+                rows_by_image_path.setdefault(image_path, []).append(row)
+
+            candidate_names = set()
+            anchor_name_set = set(basenames)
+            for rows in rows_by_image_path.values():
+                for row in rows:
+                    name = _pair_name(row)
+                    if name and name not in anchor_name_set:
+                        candidate_names.add(name)
+
+            embeddings_by_name = {}
+            embedding_rows_scanned = 0
+            if expansion_mode == "nearest":
+                embeddings_by_name, embedding_rows_scanned = _load_embeddings_for_names(
+                    source_embedding_shards_dir,
+                    candidate_names | anchor_name_set,
+                )
+                caption_expansion_stats["similarity_backend"] = (
+                    "embedding" if embeddings_by_name else "lexical"
+                )
+            else:
+                caption_expansion_stats["similarity_backend"] = "source_order"
+
+            missing_anchor_embeddings = 0
+            missing_candidate_embeddings = 0
+            for anchor_name in basenames:
+                anchor_rows = pairs_by_name.get(anchor_name, [])
+                if not anchor_rows:
+                    continue
+                anchor_row = anchor_rows[0]
+                anchor_image_path = anchor_image_paths.get(anchor_name, "")
+                candidate_rows = rows_by_image_path.get(anchor_image_path, [])
+                ranked = []
+                anchor_embedding = embeddings_by_name.get(anchor_name)
+                if expansion_mode == "nearest" and anchor_embedding is None:
+                    missing_anchor_embeddings += 1
+                for candidate_index, row in enumerate(candidate_rows):
+                    candidate_name = _pair_name(row)
+                    if (
+                        not candidate_name
+                        or candidate_name == anchor_name
+                        or candidate_name in anchor_name_set
+                    ):
+                        continue
+                    if expansion_mode == "nearest":
+                        candidate_embedding = embeddings_by_name.get(candidate_name)
+                        if anchor_embedding is not None and candidate_embedding is not None:
+                            score = float(np.dot(anchor_embedding, candidate_embedding))
+                        else:
+                            if candidate_embedding is None:
+                                missing_candidate_embeddings += 1
+                            score = float(_lexical_similarity(
+                                _pair_caption(anchor_row),
+                                _pair_caption(row),
+                            ))
+                        ranked.append((score, candidate_index, row))
+                    else:
+                        ranked.append((0.0, candidate_index, row))
+                if expansion_mode == "nearest":
+                    ranked.sort(key=lambda item: (-item[0], item[1]))
+                    if max_pairs_per_image_path > 0:
+                        ranked = ranked[:max(0, max_pairs_per_image_path - 1)]
+                else:
+                    ranked.sort(key=lambda item: item[1])
+                expansion_by_anchor[anchor_name] = [
+                    (row, score) for score, _, row in ranked
+                ]
+
+            caption_expansion_stats.update({
+                "source_pair_rows_scanned_for_expansion": int(
+                    expansion_pair_rows_scanned
+                ),
+                "source_embedding_rows_scanned_for_expansion": int(
+                    embedding_rows_scanned
+                ),
+                "candidate_image_paths": int(len(wanted_image_paths)),
+                "candidate_pair_rows": int(
+                    sum(len(rows) for rows in rows_by_image_path.values())
+                ),
+                "candidate_pair_names": int(len(candidate_names)),
+                "candidate_pairs_after_dedup": int(
+                    sum(len(rows) for rows in rows_by_image_path.values())
+                ),
+                "missing_anchor_embeddings": int(missing_anchor_embeddings),
+                "missing_candidate_embeddings": int(missing_candidate_embeddings),
+                "deduped_caption_rows": int(deduped_caption_rows),
+            })
+
+        expanded_pair_limit = None
+        if (
+            expansion_enabled
+            and expansion_mode == "nearest"
+            and count_expanded_pairs_toward_target
+            and target_query_count > 0
+        ):
+            expanded_pair_limit = int(
+                math.floor(target_query_count * max_expanded_pair_fraction)
+            )
+
+        planned_items = []
+        planned_names = set()
+        planned_expanded_pairs = 0
+
+        def _append_planned(row, is_expansion, anchor_name, score=None):
+            nonlocal planned_expanded_pairs
+            name = _pair_name(row) or anchor_name
+            if not name or name in planned_names:
+                return False
+            if is_expansion:
+                if (
+                    expanded_pair_limit is not None
+                    and planned_expanded_pairs >= expanded_pair_limit
+                ):
+                    return False
+                planned_expanded_pairs += 1
+            planned_names.add(name)
+            planned_items.append((row, bool(is_expansion), anchor_name, score))
+            return True
+
+        for name in basenames:
+            for row in pairs_by_name.get(name, []):
+                _append_planned(row, False, name, None)
+            if expansion_enabled:
+                for row, score in expansion_by_anchor.get(name, []):
+                    _append_planned(row, True, name, score)
+
+        pre_budget_recovered_pairs = len(planned_items)
+        planned_anchor_pairs = sum(
+            1 for _, is_expansion, _, _ in planned_items if not is_expansion
+        )
+        planned_expanded_pairs = sum(
+            1 for _, is_expansion, _, _ in planned_items if is_expansion
+        )
+        caption_expansion_stats["planned_anchor_pairs"] = int(planned_anchor_pairs)
+        caption_expansion_stats["planned_expanded_pairs"] = int(planned_expanded_pairs)
+        if target_query_count > 0:
+            budget_basis_count = (
+                len(planned_items)
+                if count_expanded_pairs_toward_target
+                else planned_anchor_pairs
+            )
+            target_pair_shortfall = max(
+                0, target_query_count - budget_basis_count
+            )
+            if target_pair_shortfall:
+                budget_basis_label = (
+                    "text-image pairs"
+                    if count_expanded_pairs_toward_target
+                    else "anchor text-image pairs"
+                )
+                print(
+                    "Warning: mined candidates recover only "
+                    f"{budget_basis_count} {budget_basis_label} before "
+                    f"budgeting, short of target {target_query_count} by "
+                    f"{target_pair_shortfall}. Increase mining.topn or the "
+                    "weak-query selection breadth if this should be closer "
+                    "to the requested budget."
+                )
+            if count_expanded_pairs_toward_target:
+                selected_pair_items = planned_items[:target_query_count]
+                budget_reached = len(planned_items) >= target_query_count
+            else:
+                selected_anchor_names = []
+                seen_anchor_names = set()
+                for _, is_expansion, anchor_name, _ in planned_items:
+                    if is_expansion or anchor_name in seen_anchor_names:
+                        continue
+                    seen_anchor_names.add(anchor_name)
+                    selected_anchor_names.append(anchor_name)
+                    if len(selected_anchor_names) >= target_query_count:
+                        break
+                selected_anchor_name_set = set(selected_anchor_names)
+                selected_pair_items = [
+                    item for item in planned_items
+                    if item[2] in selected_anchor_name_set
+                ]
+                budget_reached = planned_anchor_pairs >= target_query_count
+        else:
+            selected_pair_items = planned_items
+        selected_anchor_names = {
+            anchor_name
+            for _, is_expansion, anchor_name, _ in selected_pair_items
+            if not is_expansion
+        }
+        budget_omitted_basenames = max(
+            0,
+            len(anchor_basenames) - len(selected_anchor_names),
+        )
+        basenames = []
+        seen_output_names = set()
+        for row, _, anchor_name, _ in selected_pair_items:
+            name = _pair_name(row) or anchor_name
+            if name and name not in seen_output_names:
+                seen_output_names.add(name)
+                basenames.append(name)
+
+        pairs_dir = os.path.dirname(output_pairs_file)
+        if pairs_dir:
+            os.makedirs(pairs_dir, exist_ok=True)
+        with open(output_pairs_file, "w", encoding="utf-8") as f:
+            f.write("[\n")
+            first = True
+            for row, _, _, _ in selected_pair_items:
+                if not first:
+                    f.write(",\n")
+                f.write(json.dumps(row, ensure_ascii=False))
+                first = False
+                pairs_count += 1
+            f.write("\n]\n")
+        train_pairs_file = output_pairs_file
+    elif target_query_count > 0:
+        basenames = basenames[:target_query_count]
+        budget_reached = len(basenames) >= target_query_count
+        selected_pair_items = [
+            ({"unique_name": name}, False, name, None)
+            for name in basenames
+        ]
+    else:
+        selected_pair_items = [
+            ({"unique_name": name}, False, name, None)
+            for name in basenames
+        ]
+
+    out_dir = os.path.dirname(output_image_list_file)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(output_image_list_file, "w", encoding="utf-8") as f:
+        for name in basenames:
+            f.write(f"{name}\n")
+
+    detail_records = []
+    dataset_counts = Counter()
+    qtype_counts = Counter()
+    dataset_qtype_counts = Counter()
+    image_dataset_counts = Counter()
+    final_image_paths = set()
+    counted_image_paths_for_dataset = set()
+    final_anchor_pairs = 0
+    final_expanded_pairs = 0
+    for pair_idx, (pair, is_expansion, anchor_name, expansion_score) in enumerate(
+        selected_pair_items
+    ):
+        name = _pair_name(pair) or anchor_name
+        dataset = str(pair.get("dataset") or "")
+        qtype = str(pair.get("query_type") or "")
+        image_path = _pair_image_path(pair)
+        if image_path:
+            final_image_paths.add(image_path)
+        if dataset:
+            dataset_counts[dataset] += 1
+            image_dataset_key = image_path or name
+            if image_dataset_key not in counted_image_paths_for_dataset:
+                counted_image_paths_for_dataset.add(image_dataset_key)
+                image_dataset_counts[dataset] += 1
+        if qtype:
+            qtype_counts[qtype] += 1
+        if dataset or qtype:
+            dataset_qtype_counts[f"{dataset}/{qtype}"] += 1
+        if is_expansion:
+            final_expanded_pairs += 1
+        else:
+            final_anchor_pairs += 1
+        if write_details:
+            detail_records.append({
+                "unique_name": name,
+                "pair_index": pair_idx,
+                "filepath": os.path.abspath(os.path.join(image_dir, name)),
+                "dataset": dataset,
+                "query_type": qtype,
+                "image_path": image_path,
+                "caption": _pair_caption(pair),
+                "is_caption_expansion": bool(is_expansion),
+                "anchor_unique_name": anchor_name if is_expansion else "",
+                "caption_expansion_score": (
+                    "" if expansion_score is None else float(expansion_score)
+                ),
+            })
+    caption_expansion_stats["final_anchor_pairs"] = int(final_anchor_pairs)
+    caption_expansion_stats["final_expanded_pairs"] = int(final_expanded_pairs)
+    caption_expansion_stats["final_unique_image_paths"] = int(len(final_image_paths))
+
+    stats_json_path = os.path.join(out_dir or ".", "mined_stats.json")
+    stats_txt_path = os.path.join(out_dir or ".", "mined_stats.txt")
+    details_csv_path = ""
+    if write_details:
+        details_csv_path = os.path.join(
+            out_dir or ".", "mined_samples_detailed.csv"
+        )
+        pd.DataFrame(detail_records).to_csv(details_csv_path, index=False)
+
+    stats = {
+        "mined_parquet": mined_parquet,
+        "source_pairs_file": source_pairs_file,
+        "raw_mined_rows": int(raw_rows),
+        "raw_unique_filepaths": int(raw_unique_filepaths),
+        "raw_unique_names": int(raw_unique_names),
+        "source_pair_rows_scanned": int(source_pair_rows_scanned),
+        "target_query_count": int(target_query_count),
+        "pre_budget_unique_basenames": int(pre_budget_unique_basenames),
+        "pre_budget_recovered_pairs": int(pre_budget_recovered_pairs),
+        "pre_budget_anchor_pairs": int(
+            caption_expansion_stats["planned_anchor_pairs"]
+        ),
+        "pre_budget_expanded_pairs": int(
+            caption_expansion_stats["planned_expanded_pairs"]
+        ),
+        "target_budget_applies_to": caption_expansion_stats[
+            "target_budget_applies_to"
+        ],
+        "avg_pairs_per_pre_budget_basename": (
+            float(pre_budget_recovered_pairs) / pre_budget_unique_basenames
+            if pre_budget_unique_basenames else 0.0
+        ),
+        "target_pair_shortfall": int(target_pair_shortfall),
+        "final_unique_basenames": int(len(basenames)),
+        "final_unique_image_paths": int(len(final_image_paths)),
+        "recovered_pairs": int(pairs_count),
+        "missing_pairs": int(missing_pairs),
+        "budget_omitted_basenames": int(budget_omitted_basenames),
+        "budget_reached": bool(budget_reached),
+        "caption_expansion": caption_expansion_stats,
+        "image_list_file": output_image_list_file,
+        "train_pairs_file": train_pairs_file,
+        "details_csv": details_csv_path,
+        "dataset_counts": _counter_records(dataset_counts),
+        "query_type_counts": _counter_records(qtype_counts),
+        "dataset_query_type_counts": _counter_records(dataset_qtype_counts),
+        "image_dataset_counts": _counter_records(image_dataset_counts),
+    }
+    with open(stats_json_path, "w", encoding="utf-8") as f:
+        json.dump(stats, f, indent=2, ensure_ascii=False)
+
+    summary_lines = [
+        "IAA mined sample stats",
+        f"Mined parquet: {mined_parquet}",
+        f"Raw mined rows: {raw_rows}",
+        f"Raw unique filepaths: {raw_unique_filepaths}",
+        f"Raw unique names: {raw_unique_names}",
+        f"Source pair rows scanned: {source_pair_rows_scanned}",
+        f"Requested mined query target: {target_query_count or 'unlimited'}",
+        f"Pre-budget unique basenames: {pre_budget_unique_basenames}",
+        f"Pre-budget recovered text-image pairs: {pre_budget_recovered_pairs}",
+        "Pre-budget anchor text-image pairs: "
+        f"{caption_expansion_stats['planned_anchor_pairs']}",
+        "Pre-budget expanded text-image pairs: "
+        f"{caption_expansion_stats['planned_expanded_pairs']}",
+        "Target budget applies to: "
+        f"{caption_expansion_stats['target_budget_applies_to']}",
+        "Average source pairs per pre-budget basename: "
+        f"{stats['avg_pairs_per_pre_budget_basename']:.3f}",
+        f"Target pair shortfall before budget: {target_pair_shortfall}",
+        f"Final unique basenames: {len(basenames)}",
+        f"Final unique image paths: {len(final_image_paths)}",
+        f"Recovered text-image pairs: {pairs_count}",
+        f"Missing source-pair images: {missing_pairs}",
+        f"Budget omitted basenames: {budget_omitted_basenames}",
+        f"Budget reached: {budget_reached}",
+        "Caption expansion enabled: "
+        f"{caption_expansion_stats['enabled']}",
+        f"Caption expansion mode: {caption_expansion_stats['mode']}",
+        "Caption expansion final pairs: "
+        f"{caption_expansion_stats['final_expanded_pairs']}",
+        f"Image list: {output_image_list_file}",
+        f"Pairs JSON: {train_pairs_file or '(not written)'}",
+        f"Detailed CSV: {details_csv_path or '(disabled)'}",
+        f"Stats JSON: {stats_json_path}",
+        "",
+        "By dataset (pair rows):",
+    ]
+    for row in stats["dataset_counts"]:
+        summary_lines.append(
+            f"  {row['value']}: {row['count']} ({row['pct']:.1f}%)"
+        )
+    summary_lines.append("")
+    summary_lines.append("By query type (pair rows):")
+    for row in stats["query_type_counts"]:
+        summary_lines.append(
+            f"  {row['value']}: {row['count']} ({row['pct']:.1f}%)"
+        )
+    summary_text = "\n".join(summary_lines) + "\n"
+    with open(stats_txt_path, "w", encoding="utf-8") as f:
+        f.write(summary_text)
+
+    manifest_dir = os.path.dirname(manifest_path)
+    if manifest_dir:
+        os.makedirs(manifest_dir, exist_ok=True)
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "image_dir": image_dir,
+                "caption_dir": caption_dir,
+                "image_list_file": output_image_list_file,
+                "caption_file_suffix": caption_file_suffix,
+                "train_pairs_file": train_pairs_file,
+                "target_query_count": target_query_count,
+                "caption_expansion": caption_expansion_stats,
+                "stats_json": stats_json_path,
+                "stats_txt": stats_txt_path,
+                "details_csv": details_csv_path,
+            },
+            f,
+            indent=2,
+        )
+
+    print(summary_text.strip())
+    print(
+        f"Converted mined parquet to CLIP image list: "
+        f"{raw_rows} rows -> {len(basenames)} unique basenames -> "
+        f"{output_image_list_file} (+ manifest {manifest_path})"
+    )
+    if train_pairs_file:
+        print(
+            f"Recovered mined TAO-FT pairs: {pairs_count} rows -> "
+            f"{train_pairs_file}"
+        )
+    return output_image_list_file
+
+
+def summarize_knn_mining(
+    mined_parquet: str,
+    target_parquet: str,
+    output_dir: str,
+    topn: int = 0,
+) -> str:
+    """Write mining_summary.txt and mining_summary.json after k-NN mining.
+
+    The ``tmm nearest_neighbors`` step already de-duplicates by filepath
+    before writing, so raw-vs-deduped counts reflect that:
+    raw_neighbor_rows is the pre-dedup estimate (target_queries * topn) and
+    unique_mined_filepaths is the actual parquet row count.
+
+    Args:
+        mined_parquet:  Path to the k-NN output parquet (filepath column).
+        target_parquet: Path to the target embeddings parquet used as k-NN queries.
+        output_dir:     Directory where mining_summary.txt and .json are written.
+        topn:           k-NN topn value; used to estimate raw_neighbor_rows.
+
+    Returns:
+        Path to the written mining_summary.txt.
+    """
+    import json
+    import os
+
+    import pandas as pd
+
+    def _counts(df, column, limit=12):
+        if df.empty or column not in df.columns:
+            return ["  (none)"]
+        counts = df[column].fillna("").astype(str).value_counts().head(limit)
+        if counts.empty:
+            return ["  (none)"]
+        return [f"  {str(v) or '(blank)'}: {int(c)}" for v, c in counts.items()]
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    target_df = pd.read_parquet(target_parquet)
+    n_targets = len(target_df)
+
+    mined_df = pd.read_parquet(mined_parquet)
+    unique_mined_filepaths = len(mined_df)
+    # Distinguish "the mine step did not emit this column" from a real
+    # zero — the parquet carries only `filepath` unless the mine step is
+    # configured to pass the target linkage through.
+    _NA = "(not available: nearest_neighbors output has no such column)"
+    unique_mined_names = (
+        int(
+            mined_df["unique_name"]
+            .fillna("")
+            .astype(str)
+            .loc[lambda s: s.astype(bool)]
+            .drop_duplicates()
+            .shape[0]
+        )
+        if "unique_name" in mined_df.columns
+        else None
+    )
+
+    # The nearest_neighbors step de-dupes before writing,
+    # so estimate the raw pre-dedup row count from topn when available.
+    raw_neighbor_rows = (n_targets * int(topn)) if topn else None
+
+    summary_payload = {
+        "target_parquet": target_parquet,
+        "mined_parquet": mined_parquet,
+        "target_queries": n_targets,
+        "similar_items_per_query": int(topn) if topn else None,
+        "raw_neighbor_rows_estimate": raw_neighbor_rows,
+        "unique_mined_filepaths": unique_mined_filepaths,
+        "unique_mined_names": unique_mined_names,
+    }
+
+    summary_lines = [
+        "k-NN mining summary",
+        f"Target parquet: {target_parquet}",
+        f"Mined parquet: {mined_parquet}",
+        f"Target queries: {n_targets}",
+    ]
+    if topn:
+        summary_lines.append(f"Similar items per query: {topn}")
+        summary_lines.append(
+            f"Raw neighbor rows (estimate, pre-dedup): {raw_neighbor_rows}"
+        )
+    summary_lines += [
+        f"Unique mined filepaths (post-dedup): {unique_mined_filepaths}",
+        "Unique mined names (post-dedup): "
+        + (_NA if unique_mined_names is None else str(unique_mined_names)),
+        "",
+        "Target query rows by query type:",
+    ]
+    summary_lines.extend(_counts(target_df, "query_type"))
+    summary_lines.extend(["", "Target query rows by attribute:"])
+    summary_lines.extend(_counts(target_df, "weak_attribute"))
+    summary_lines.extend(["", "Mined rows by target query type:"])
+    summary_lines.extend(
+        _counts(mined_df, "target_query_type")
+        if "target_query_type" in mined_df.columns else [f"  {_NA}"]
+    )
+    summary_lines.extend(["", "Mined rows by target attribute:"])
+    summary_lines.extend(
+        _counts(mined_df, "target_attribute")
+        if "target_attribute" in mined_df.columns else [f"  {_NA}"]
+    )
+    summary_lines.append("")
+
+    summary_text = "\n".join(summary_lines)
+    txt_path = os.path.join(output_dir, "mining_summary.txt")
+    json_path = os.path.join(output_dir, "mining_summary.json")
+    with open(txt_path, "w", encoding="utf-8") as f:
+        f.write(summary_text)
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(summary_payload, f, indent=2)
+    print(summary_text.strip())
+    return txt_path
+
+
+def track_cumulative_mined_unique_names(
+    mined_pairs_file: str,
+    base_experiment_path: str,
+    iter_num: int,
+    output_file: str,
+) -> str:
+    """Track the cumulative set of mined unique names across DEFT iterations.
+
+    Reads the current iteration's mined pairs file, extracts unique names, and
+    merges them with the previous iteration's cumulative set (when iter_num > 1)
+    to produce a deduplicated cumulative list.
+
+    Args:
+        mined_pairs_file:       Path to the current iteration's mined_pairs.json.
+        base_experiment_path:   Root directory for all experiment outputs.
+        iter_num:               Current DEFT iteration number (1-based).
+        output_file:            Path where the cumulative unique names JSON is written.
+
+    Returns:
+        Path to the written cumulative unique names JSON file.
+    """
+    import os
+
+    import pandas as pd
+
+    curr_pairs = pd.read_json(mined_pairs_file)
+    curr_unique_names = (
+        curr_pairs[["unique_name"]]
+        if "unique_name" in curr_pairs.columns
+        else pd.DataFrame(columns=["unique_name"])
+    )
+
+    if iter_num > 1:
+        prev_cumulative_file = os.path.join(
+            base_experiment_path,
+            f"iter_{iter_num - 1}",
+            "mining",
+            "cumulative_mined_unique_names.json",
+        )
+        if os.path.isfile(prev_cumulative_file):
+            prev_cumulative = pd.read_json(prev_cumulative_file)
+            cumulative = (
+                pd.concat([prev_cumulative, curr_unique_names])
+                .drop_duplicates()
+                .reset_index(drop=True)
+            )
+        else:
+            cumulative = curr_unique_names
+    else:
+        cumulative = curr_unique_names
+
+    output_dir = os.path.dirname(output_file)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    cumulative.to_json(output_file, orient="records")
+    print(
+        f"Cumulative mined unique names: iter={iter_num}, "
+        f"this_iter={len(curr_unique_names)}, "
+        f"cumulative={len(cumulative)}, output={output_file}"
+    )
+    return output_file
+
+
+def write_iteration_summary(
+    experiment_dir: str,
+    iter_num: int,
+    gaps_parquet: str,
+    mined_parquet: str,
+    mined_pairs_file: str,
+    training_checkpoint: str,
+    next_checkpoint_path: str,
+    experiment_id: str = "",
+) -> str:
+    """Write iteration_summary.json at the end of a DEFT iteration.
+
+    Captures the key artifact paths and checkpoint state for each iteration.
+
+    Args:
+        experiment_dir:       Directory for this iteration's outputs.
+        iter_num:             Current DEFT iteration number (1-based).
+        gaps_parquet:         Path to the gap-analysis output parquet.
+        mined_parquet:        Path to the raw k-NN mined parquet.
+        mined_pairs_file:     Path to the final mined pairs JSON.
+        training_checkpoint:  Checkpoint used as input for this iteration's training.
+        next_checkpoint_path: Expected path of the best checkpoint produced by training.
+        experiment_id:        Optional unique ID for this experiment run.
+
+    Returns:
+        Path to the written iteration_summary.json.
+    """
+    import json
+    import os
+
+    os.makedirs(experiment_dir, exist_ok=True)
+    payload = {
+        "iteration": int(iter_num),
+        "experiment_id": experiment_id,
+        "experiment_dir": experiment_dir,
+        "training_checkpoint": training_checkpoint,
+        "next_checkpoint_path": next_checkpoint_path,
+        "gaps_parquet": gaps_parquet,
+        "mined_parquet": mined_parquet,
+        "mined_pairs_file": mined_pairs_file,
+        "eval_results_dir": experiment_dir,
+    }
+    out_path = os.path.join(experiment_dir, "iteration_summary.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+    print(f"Iteration {iter_num} summary written to {out_path}")
+    return out_path

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/history_aware_mining.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/history_aware_mining.py
@@ -1,0 +1,616 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bundled and adapted from the Apache-2.0 NVIDIA TAO Tutorials IAA DEFT utilities so the
+# customer workflow does not depend on an external source checkout.
+
+"""Post-KNN history-aware selection for IAA CLIP DEFT mining."""
+
+
+def load_selection_history(history_file: str, iter_num: int) -> dict:
+    """Load and validate the mining selection ledger.
+
+    Returns the parsed state with every entry's ``selected_unique_names``
+    normalized. A ledger that does not exist yet — legal only at iteration 1 —
+    comes back with an empty ``iterations`` list and none of the
+    experiment-level invariants (``mode``, ``continual_dataset``,
+    ``replay_fraction``) set; :func:`select_history_aware_mined_pairs` stamps
+    those when it commits iteration 1.
+    """
+    import hashlib
+    import json
+    import os
+
+    iteration = int(iter_num)
+    if iteration < 1:
+        raise ValueError(f"iter_num must be >= 1, got {iteration}")
+
+    history_path = os.path.abspath(history_file)
+    if not os.path.isfile(history_path):
+        if iteration != 1:
+            raise FileNotFoundError(
+                f"Selection history is required before iteration {iteration}: "
+                f"{history_path}"
+            )
+        return {
+            "version": 1,
+            "identity": "unique_name",
+            "source_pool_image_list_file": "",
+            "source_pool_size": 0,
+            "iterations": [],
+        }
+
+    with open(history_path, "r", encoding="utf-8") as f:
+        state = json.load(f)
+    if not isinstance(state, dict) or state.get("version") != 1:
+        raise RuntimeError(f"Unsupported or malformed selection history: {history_path}")
+    if state.get("identity") != "unique_name":
+        raise RuntimeError("Selection history identity must be fixed to unique_name")
+
+    entries = state.get("iterations")
+    if not isinstance(entries, list):
+        raise RuntimeError("Selection history iterations must be a list")
+    iteration_numbers = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise RuntimeError("Every selection history iteration must be an object")
+        entry_iteration = int(entry.get("iteration", 0))
+        iteration_numbers.append(entry_iteration)
+        selected_names = entry.get("selected_unique_names")
+        if not isinstance(selected_names, list):
+            raise RuntimeError(
+                f"History iteration {entry_iteration} has no selected_unique_names list"
+            )
+        normalized_names = [
+            str(name or "").strip().replace("\\", "/") for name in selected_names
+        ]
+        if any(not name for name in normalized_names):
+            raise RuntimeError(
+                f"History iteration {entry_iteration} contains an empty unique_name"
+            )
+        if len(normalized_names) != len(set(normalized_names)):
+            raise RuntimeError(
+                f"History iteration {entry_iteration} contains duplicate unique_name values"
+            )
+        names_hash = hashlib.sha256(
+            "".join(f"{name}\n" for name in normalized_names).encode("utf-8")
+        ).hexdigest()
+        if names_hash != str(entry.get("image_list_sha256") or ""):
+            raise RuntimeError(
+                f"History iteration {entry_iteration} names do not match its image list"
+            )
+        entry["selected_unique_names"] = normalized_names
+    if iteration_numbers != list(range(1, len(entries) + 1)):
+        raise RuntimeError(
+            f"Selection history must contain contiguous iterations starting at 1; "
+            f"found {iteration_numbers}"
+        )
+    return state
+
+
+def select_history_aware_mined_pairs(
+    candidate_pairs_file: str,
+    candidate_manifest_file: str,
+    output_image_list_file: str,
+    output_pairs_file: str,
+    manifest_path: str,
+    history_file: str,
+    source_pool_image_list_file: str,
+    iter_num: int,
+    target_query_count: int,
+    continual_dataset: str,
+    replay_fraction: float = 0.20,
+    resume: str = "false",
+) -> str:
+    """Select final training pairs after KNN and source-pair recovery.
+
+    ``continual_dataset=true`` selects only pairs never selected by an earlier
+    iteration. The generated train config accumulates those disjoint per-iter
+    datasets, so no replay rows are read or inserted here.
+
+    ``continual_dataset=false`` keeps only the current iteration's dataset and
+    therefore selects a controlled mixture of novel and replay pairs. Replay
+    first follows the current KNN relevance order, then uses prior selected-pair
+    files only when more replay rows are needed to reach the requested budget.
+
+    The candidate pool is expected to be uncapped — the caller runs the
+    conversion step with ``target_query_count=0`` into its own directory, so
+    that this function owns the budget and spends it after the novel/replay
+    partition. Given that, a non-zero ``selection_shortfall`` means KNN
+    genuinely ran out of novel neighbours, rather than that the budget was
+    spent upstream on rows discarded here.
+    """
+    import hashlib
+    import json
+    import math
+    import os
+    import tempfile
+
+    def _truthy(value):
+        return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    def _pair_key(row):
+        if not isinstance(row, dict):
+            raise ValueError("Every mined pair must be a JSON object")
+        key = str(row.get("unique_name") or "").strip().replace("\\", "/")
+        if not key:
+            raise ValueError(
+                "Every history-aware candidate requires a non-empty unique_name"
+            )
+        return key
+
+    def _iter_json_records(path):
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        line_delimited_array = (
+            first.strip() == "["
+            and second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if line_delimited_array:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    value = line.strip()
+                    if not value or value in {"[", "]"}:
+                        continue
+                    if value.endswith(","):
+                        value = value[:-1]
+                    yield json.loads(value)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            rows = json.load(f)
+        if not isinstance(rows, list):
+            raise ValueError(f"Expected a JSON array in {path}")
+        for row in rows:
+            yield row
+
+    def _sha256(path):
+        digest = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _atomic_write_text(path, text):
+        absolute = os.path.abspath(path)
+        directory = os.path.dirname(absolute) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(
+            prefix=f".{os.path.basename(absolute)}.",
+            suffix=".tmp",
+            dir=directory,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(text)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temporary, absolute)
+            try:
+                directory_fd = os.open(directory, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            except OSError:
+                pass
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    def _json_text(value):
+        return json.dumps(value, indent=2, ensure_ascii=False) + "\n"
+
+    def _validate_committed_artifacts(entry):
+        output_dir = os.path.dirname(os.path.abspath(output_image_list_file)) or "."
+        expected_paths = {
+            "pairs_file": os.path.abspath(output_pairs_file),
+            "image_list_file": os.path.abspath(output_image_list_file),
+            "manifest_file": os.path.abspath(manifest_path),
+            "stats_file": os.path.join(output_dir, "mined_stats.json"),
+        }
+        if int(entry.get("target_query_count", 0)) != target:
+            raise RuntimeError(
+                f"Committed iteration target does not match current config: "
+                f"{entry.get('target_query_count')} != {target}"
+            )
+        artifact_fields = (
+            ("pairs_file", "pairs_sha256"),
+            ("image_list_file", "image_list_sha256"),
+            ("manifest_file", "manifest_sha256"),
+            ("stats_file", "stats_sha256"),
+        )
+        for path_field, hash_field in artifact_fields:
+            path = str(entry.get(path_field) or "")
+            expected_hash = str(entry.get(hash_field) or "")
+            if not path or not expected_hash:
+                raise RuntimeError(
+                    f"History entry {entry.get('iteration')} is missing {path_field} "
+                    f"or {hash_field}"
+                )
+            if os.path.abspath(path) != expected_paths[path_field]:
+                raise RuntimeError(
+                    f"Committed {path_field} does not match current output path: "
+                    f"{path} != {expected_paths[path_field]}"
+                )
+            if not os.path.isfile(path):
+                raise RuntimeError(f"Committed history artifact is missing: {path}")
+            actual_hash = _sha256(path)
+            if actual_hash != expected_hash:
+                raise RuntimeError(
+                    f"Committed history artifact hash mismatch: {path} "
+                    f"(expected {expected_hash}, got {actual_hash})"
+                )
+
+    iteration = int(iter_num)
+    target = int(target_query_count)
+    if iteration < 1:
+        raise ValueError(f"iter_num must be >= 1, got {iteration}")
+    if target < 1:
+        raise ValueError(
+            f"History-aware selection requires target_query_count >= 1, got {target}"
+        )
+
+    continual = _truthy(continual_dataset)
+    configured_replay_fraction = float(replay_fraction)
+    if not math.isfinite(configured_replay_fraction) or not (
+        0.0 <= configured_replay_fraction <= 1.0
+    ):
+        raise ValueError(
+            f"replay_fraction must be within [0, 1], got {replay_fraction}"
+        )
+    effective_replay_fraction = 0.0 if continual else configured_replay_fraction
+    mode = "continual_novel_only" if continual else "controlled_replay"
+
+    history_path = os.path.abspath(history_file)
+    state = load_selection_history(history_file, iteration)
+    if not state["iterations"]:
+        # Fresh ledger — stamp the experiment-level invariants that every later
+        # iteration is then checked against. Keyed on there being no committed
+        # iterations rather than on "mode" being absent, so a persisted ledger
+        # that lost its mode key fails the check below instead of being
+        # silently re-stamped with whatever this run happens to request.
+        state["mode"] = mode
+        state["continual_dataset"] = continual
+        state["replay_fraction"] = effective_replay_fraction
+
+    if state.get("mode") != mode or state.get("continual_dataset") is not continual:
+        raise RuntimeError(
+            "Cannot change continual_dataset/history-aware mode inside one experiment"
+        )
+    recorded_replay_fraction = float(state.get("replay_fraction", 0.0))
+    if abs(recorded_replay_fraction - effective_replay_fraction) > 1e-12:
+        raise RuntimeError(
+            "Cannot change replay_fraction inside one history-aware experiment"
+        )
+
+    pool_path = os.path.abspath(source_pool_image_list_file)
+    if not os.path.isfile(pool_path):
+        raise FileNotFoundError(f"Source pool image list is missing: {pool_path}")
+    pool_stat = os.stat(pool_path)
+    recorded_pool_path = str(state.get("source_pool_image_list_file") or "")
+    if recorded_pool_path and recorded_pool_path != pool_path:
+        raise RuntimeError(
+            "Cannot change source_pool_image_list_file inside one experiment"
+        )
+    recorded_pool_bytes = int(state.get("source_pool_file_size_bytes", 0) or 0)
+    recorded_pool_mtime = int(state.get("source_pool_mtime_ns", 0) or 0)
+    if recorded_pool_bytes and recorded_pool_bytes != pool_stat.st_size:
+        raise RuntimeError("Source pool image list size changed during the experiment")
+    if recorded_pool_mtime and recorded_pool_mtime != pool_stat.st_mtime_ns:
+        raise RuntimeError("Source pool image list mtime changed during the experiment")
+    state["source_pool_image_list_file"] = pool_path
+    state["source_pool_file_size_bytes"] = pool_stat.st_size
+    state["source_pool_mtime_ns"] = pool_stat.st_mtime_ns
+
+    # Structure, per-entry normalization, and contiguity are validated by
+    # load_selection_history above.
+    entries = state["iterations"]
+
+    committed_entry = next(
+        (entry for entry in entries if int(entry["iteration"]) == iteration),
+        None,
+    )
+    if committed_entry is not None:
+        _validate_committed_artifacts(committed_entry)
+        if _truthy(resume):
+            print(
+                f"Skipping committed history-aware selection for iteration {iteration}: "
+                f"{output_pairs_file}"
+            )
+            return output_image_list_file
+        raise RuntimeError(
+            f"Iteration {iteration} is already committed in {history_path}; "
+            "use --resume or a new experiment results path"
+        )
+    if len(entries) != iteration - 1:
+        raise RuntimeError(
+            f"Cannot select iteration {iteration}; history currently ends at "
+            f"iteration {len(entries)}"
+        )
+
+    historical_names = set()
+    for entry in entries:
+        historical_names.update(entry["selected_unique_names"])
+    previous_iteration_names = (
+        set(entries[-1]["selected_unique_names"]) if entries else set()
+    )
+
+    candidate_raw_count = 0
+    candidate_duplicate_count = 0
+    candidate_names = set()
+    novel_candidates = []
+    replay_candidates = []
+    for row in _iter_json_records(candidate_pairs_file):
+        candidate_raw_count += 1
+        key = _pair_key(row)
+        if key in candidate_names:
+            candidate_duplicate_count += 1
+            continue
+        candidate_names.add(key)
+        item = (candidate_raw_count - 1, key, row)
+        bucket = replay_candidates if key in historical_names else novel_candidates
+        if len(bucket) < target:
+            bucket.append(item)
+
+    with open(candidate_manifest_file, "r", encoding="utf-8") as f:
+        candidate_manifest = json.load(f)
+    if not isinstance(candidate_manifest, dict):
+        raise ValueError(f"Malformed candidate manifest: {candidate_manifest_file}")
+
+    has_history = bool(historical_names)
+    requested_replay = (
+        int(math.floor(target * effective_replay_fraction)) if has_history else 0
+    )
+    requested_novel = target - requested_replay
+
+    selected = {}
+
+    def _take(items, count):
+        added = 0
+        for source_index, key, row in items:
+            if added >= count:
+                break
+            if key in selected:
+                continue
+            selected[key] = {
+                "source_index": source_index,
+                "key": key,
+                "row": row,
+                "from_current_candidates": True,
+            }
+            added += 1
+        return added
+
+    _take(novel_candidates, requested_novel)
+    if not continual:
+        _take(replay_candidates, requested_replay)
+        history_files_loaded = 0
+
+        def _history_rows():
+            nonlocal history_files_loaded
+            for entry in entries:
+                prior_pairs_file = str(entry.get("pairs_file") or "")
+                expected_hash = str(entry.get("pairs_sha256") or "")
+                if not prior_pairs_file or not expected_hash:
+                    raise RuntimeError(
+                        f"History iteration {entry['iteration']} cannot provide replay rows"
+                    )
+                if not os.path.isfile(prior_pairs_file):
+                    raise FileNotFoundError(
+                        f"Replay pairs file is missing: {prior_pairs_file}"
+                    )
+                actual_hash = _sha256(prior_pairs_file)
+                if actual_hash != expected_hash:
+                    raise RuntimeError(
+                        f"Replay pairs hash mismatch: {prior_pairs_file}"
+                    )
+                history_files_loaded += 1
+                entry_names = set(entry["selected_unique_names"])
+                for row in _iter_json_records(prior_pairs_file):
+                    key = _pair_key(row)
+                    if key not in entry_names:
+                        raise RuntimeError(
+                            f"Replay row {key} is not recorded in history iteration "
+                            f"{entry['iteration']}"
+                        )
+                    yield key, row
+
+        history_rows = _history_rows()
+
+        def _take_history(count):
+            if count <= 0:
+                return 0
+            added = 0
+            for key, row in history_rows:
+                if key in selected:
+                    continue
+                selected[key] = {
+                    "source_index": None,
+                    "key": key,
+                    "row": row,
+                    "from_current_candidates": False,
+                }
+                added += 1
+                if added >= count:
+                    break
+            return added
+
+        # Current-KNN historical rows are preferred, but the requested replay
+        # quota is filled from prior outputs before novel fallback is allowed.
+        selected_replay = sum(1 for key in selected if key in historical_names)
+        _take_history(max(0, requested_replay - selected_replay))
+
+        # If the historical pool is too small, fill the replay deficit with
+        # extra novel rows. If novel supply is short, allow replay overflow.
+        remaining = target - len(selected)
+        if remaining > 0:
+            _take(novel_candidates, remaining)
+        remaining = target - len(selected)
+        if remaining > 0:
+            _take(replay_candidates, remaining)
+        remaining = target - len(selected)
+        if remaining > 0:
+            _take_history(remaining)
+    else:
+        history_files_loaded = 0
+
+    current_selected = sorted(
+        (item for item in selected.values() if item["from_current_candidates"]),
+        key=lambda item: item["source_index"],
+    )
+    historical_selected = [
+        item for item in selected.values() if not item["from_current_candidates"]
+    ]
+    final_items = current_selected + historical_selected
+    final_names = [item["key"] for item in final_items]
+    final_rows = [item["row"] for item in final_items]
+    selected_name_set = set(final_names)
+
+    actual_replay = len(selected_name_set & historical_names)
+    actual_novel = len(final_names) - actual_replay
+    overlap_previous = len(selected_name_set & previous_iteration_names)
+    overlap_all_prior = actual_replay
+    cumulative_unique = len(historical_names | selected_name_set)
+    replay_overflow = max(0, actual_replay - requested_replay)
+    shortfall = max(0, target - len(final_names))
+    if not final_names:
+        raise RuntimeError(
+            f"Iteration {iteration} has no selectable training pairs after "
+            "history filtering; increase mining.topn or stop the experiment"
+        )
+
+    source_pool_size = int(state.get("source_pool_size", 0) or 0)
+    if source_pool_size <= 0:
+        with open(pool_path, "r", encoding="utf-8") as f:
+            source_pool_size = sum(1 for line in f if line.strip())
+    state["source_pool_image_list_file"] = pool_path
+    state["source_pool_size"] = source_pool_size
+
+    output_dir = os.path.dirname(os.path.abspath(output_image_list_file)) or "."
+    stats_file = os.path.join(output_dir, "mined_stats.json")
+
+    stats = {
+        "iteration": iteration,
+        "mode": mode,
+        "continual_dataset": continual,
+        "identity": "unique_name",
+        "candidate_pairs_file": os.path.abspath(candidate_pairs_file),
+        "candidate_raw_count": candidate_raw_count,
+        "candidate_unique_count": len(candidate_names),
+        "candidate_duplicate_count": candidate_duplicate_count,
+        "candidate_novel_count": len(candidate_names - historical_names),
+        "candidate_replay_count": len(candidate_names & historical_names),
+        "target_query_count": target,
+        "requested_novel_count": requested_novel,
+        "requested_replay_count": requested_replay,
+        "selected_count": len(final_names),
+        "selected_novel_count": actual_novel,
+        "selected_replay_count": actual_replay,
+        "selected_replay_from_current_knn": sum(
+            1
+            for item in final_items
+            if item["from_current_candidates"] and item["key"] in historical_names
+        ),
+        "selected_replay_from_history_files": sum(
+            1 for item in final_items if not item["from_current_candidates"]
+        ),
+        "history_pair_files_loaded": history_files_loaded,
+        "replay_overflow_count": replay_overflow,
+        "actual_replay_fraction": (
+            actual_replay / len(final_names) if final_names else 0.0
+        ),
+        "selection_shortfall": shortfall,
+        "overlap_with_previous_iteration_count": overlap_previous,
+        "overlap_with_previous_iteration_rate": (
+            overlap_previous / len(final_names) if final_names else 0.0
+        ),
+        "overlap_with_all_prior_iterations_count": overlap_all_prior,
+        "overlap_with_all_prior_iterations_rate": (
+            overlap_all_prior / len(final_names) if final_names else 0.0
+        ),
+        "cumulative_unique_pair_count": cumulative_unique,
+        "source_pool_size": source_pool_size,
+        "selected_pair_coverage_rate": (
+            len(final_names) / source_pool_size if source_pool_size else 0.0
+        ),
+        "cumulative_unique_pair_coverage_rate": (
+            cumulative_unique / source_pool_size if source_pool_size else 0.0
+        ),
+        "image_list_file": os.path.abspath(output_image_list_file),
+        "train_pairs_file": os.path.abspath(output_pairs_file),
+        "history_file": history_path,
+    }
+
+    summary_text = "\n".join([
+        "IAA history-aware mined sample stats",
+        f"Iteration: {iteration}",
+        f"Mode: {mode}",
+        f"Unique post-KNN candidates: {len(candidate_names)}",
+        f"Requested pairs: {target}",
+        f"Selected pairs: {len(final_names)}",
+        f"Novel pairs: {actual_novel}",
+        f"Replay pairs: {actual_replay}",
+        f"Replay overflow: {replay_overflow}",
+        f"Selection shortfall: {shortfall}",
+        f"Overlap with previous iteration: {overlap_previous}",
+        f"Overlap with all prior iterations: {overlap_all_prior}",
+        f"Cumulative unique pairs: {cumulative_unique}",
+        "Cumulative source-pool coverage: "
+        f"{100.0 * stats['cumulative_unique_pair_coverage_rate']:.4f}%",
+        "",
+    ])
+
+    _atomic_write_text(output_image_list_file, "".join(f"{name}\n" for name in final_names))
+    _atomic_write_text(output_pairs_file, _json_text(final_rows))
+    _atomic_write_text(stats_file, _json_text(stats))
+
+    manifest = {
+        "image_dir": candidate_manifest.get("image_dir", ""),
+        "caption_dir": candidate_manifest.get("caption_dir", ""),
+        "image_list_file": os.path.abspath(output_image_list_file),
+        "caption_file_suffix": candidate_manifest.get(
+            "caption_file_suffix", ".txt"
+        ),
+        "train_pairs_file": os.path.abspath(output_pairs_file),
+        "target_query_count": target,
+        "history_aware": {
+            "enabled": True,
+            "mode": mode,
+            "continual_dataset": continual,
+            "replay_fraction": effective_replay_fraction,
+            "history_file": history_path,
+            "candidate_manifest": os.path.abspath(candidate_manifest_file),
+        },
+        "stats_json": stats_file,
+    }
+    _atomic_write_text(manifest_path, _json_text(manifest))
+
+    entry = {
+        "iteration": iteration,
+        "mode": mode,
+        "target_query_count": target,
+        "selected_count": len(final_names),
+        "novel_count": actual_novel,
+        "replay_count": actual_replay,
+        "selected_unique_names": final_names,
+        "pairs_file": os.path.abspath(output_pairs_file),
+        "pairs_sha256": _sha256(output_pairs_file),
+        "image_list_file": os.path.abspath(output_image_list_file),
+        "image_list_sha256": _sha256(output_image_list_file),
+        "manifest_file": os.path.abspath(manifest_path),
+        "manifest_sha256": _sha256(manifest_path),
+        "stats_file": stats_file,
+        "stats_sha256": _sha256(stats_file),
+    }
+    entries.append(entry)
+    state["iterations"] = entries
+    _atomic_write_text(history_path, _json_text(state))
+
+    print(summary_text.strip())
+    print(
+        f"Committed history-aware selection for iteration {iteration}: "
+        f"{len(final_names)} pairs -> {output_pairs_file}"
+    )
+    return output_image_list_file

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/utils.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/utils.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bundled and adapted from the Apache-2.0 NVIDIA TAO Tutorials IAA DEFT utilities so the
+# customer workflow does not depend on an external source checkout.
+
+"""Config generation and checkpoint resolution utilities for DEFT pipelines."""
+
+
+def create_clip_train_config(
+    base_config_yaml: str,
+    new_config_yaml: str,
+    output_dir: str,
+    checkpoint_path: str,
+    sweep_args: str,
+    mined_image_dir: str,
+    mined_caption_dir: str,
+    mined_image_list_file: str,
+    caption_file_suffix: str,
+    train_image_dir: str = "",
+    train_caption_dir: str = "",
+    train_image_list_file: str = "",
+    train_pairs_file: str = "",
+    mined_pairs_file: str = "",
+    val_image_list_file: str = "",
+    val_image_dir: str = "",
+    val_caption_dir: str = "",
+    continual_dataset: bool = False,
+) -> str:
+    """Create a TAO CLIP training config YAML by patching a source config.
+
+    Only the fields the DEFT loop owns (results dir, checkpoint, dataset
+    entries) are patched. Every other TAO setting — model, optimizer, batch
+    sizes, GPU counts — is taken from ``base_config_yaml`` as-is and must be
+    edited there directly.
+
+    Args:
+        base_config_yaml:       Path to the source YAML config.
+        new_config_yaml:        Path where the patched YAML will be written.
+        output_dir:             TAO ``results_dir`` root.
+        checkpoint_path:        Prior-iteration TAO checkpoint.
+        sweep_args:             JSON string of optimizer overrides.
+        mined_image_dir:        Mined dataset's ``image_dir``.
+        mined_caption_dir:      Mined dataset's ``caption_dir``.
+        mined_image_list_file:  Mined dataset's ``image_list_file``.
+        caption_file_suffix:    Caption file suffix for the mined entry.
+        train_image_list_file:  Optional replacement for seed image list.
+        train_pairs_file:       Optional replacement for seed pairs file.
+        mined_pairs_file:       Optional mined ``train_pairs_file``.
+        val_image_list_file:    Explicit image list for ``dataset.val``.
+        val_image_dir:          ``image_dir`` for the val dataset.
+        val_caption_dir:        ``caption_dir`` for the val dataset.
+        continual_dataset:      Keep ``base_config_yaml``'s train datasets and
+                                append to them instead of replacing them. In a
+                                continual-dataset run the base config is the
+                                previous iteration's, and its per-iteration
+                                mined sets — disjoint by construction — must
+                                all stay in training.
+
+    Returns:
+        Path to the newly written config YAML.
+    """
+    import json
+    import os
+
+    import yaml
+
+    sweep_args = json.loads(sweep_args)
+
+    with open(base_config_yaml, "r") as f:
+        config_data = yaml.safe_load(f)
+
+    config_data["results_dir"] = output_dir
+    for section_name in ("evaluate", "inference", "export"):
+        section = config_data.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        if section.get("checkpoint") in ("???", ""):
+            section["checkpoint"] = None
+        if section_name == "export" and section.get("onnx_file") in ("???", ""):
+            section["onnx_file"] = None
+
+    train_cfg = config_data.setdefault("train", {})
+    dataset_cfg = config_data.setdefault("dataset", {})
+    train_data_cfg = dataset_cfg.setdefault("train", {})
+    datasets = []
+
+    if continual_dataset:
+        for entry in train_data_cfg.get("datasets") or []:
+            if not isinstance(entry, dict):
+                continue
+            entry_image_list_file = entry.get("image_list_file")
+            # Unfilled template entries carry "???" or a null image list.
+            if not entry_image_list_file or entry_image_list_file == "???":
+                continue
+            datasets.append(dict(entry))
+        print(
+            f"Carried {len(datasets)} train dataset(s) forward from "
+            f"{base_config_yaml}"
+        )
+
+    def _add_dataset(entry):
+        """Append ``entry``, replacing any entry for the same image list."""
+        datasets[:] = [
+            existing for existing in datasets
+            if existing.get("image_list_file") != entry["image_list_file"]
+        ]
+        datasets.append(entry)
+
+    if train_image_list_file:
+        seed_entry = {
+            "image_list_file": train_image_list_file,
+            "caption_file_suffix": ".txt",
+        }
+        if train_image_dir:
+            seed_entry["image_dir"] = train_image_dir
+        if train_caption_dir:
+            seed_entry["caption_dir"] = train_caption_dir
+        if train_pairs_file:
+            seed_entry["train_pairs_file"] = train_pairs_file
+        _add_dataset(seed_entry)
+
+    if mined_image_list_file:
+        mined_entry = {
+            "image_dir": mined_image_dir,
+            "caption_dir": mined_caption_dir,
+            "image_list_file": mined_image_list_file,
+            "caption_file_suffix": caption_file_suffix,
+        }
+        if mined_pairs_file:
+            mined_entry["train_pairs_file"] = mined_pairs_file
+        _add_dataset(mined_entry)
+
+    train_data_cfg["datasets"] = datasets
+
+    if val_image_list_file:
+        val_data_cfg = dataset_cfg.setdefault("val", {})
+        val_datasets = list(val_data_cfg.get("datasets") or [])
+        if not val_datasets:
+            val_datasets.append({})
+        effective_val_image_dir = val_image_dir or train_image_dir
+        effective_val_caption_dir = val_caption_dir or train_caption_dir
+        if effective_val_image_dir:
+            val_datasets[0]["image_dir"] = effective_val_image_dir
+        if effective_val_caption_dir:
+            val_datasets[0]["caption_dir"] = effective_val_caption_dir
+        val_datasets[0]["image_list_file"] = val_image_list_file
+        val_data_cfg["datasets"] = val_datasets
+
+    val_data_cfg = dataset_cfg.setdefault("val", {})
+    val_datasets = list(val_data_cfg.get("datasets") or [])
+    if not val_datasets:
+        try:
+            val_batch_size = max(int(val_data_cfg.get("batch_size", 1)), 1)
+        except (TypeError, ValueError):
+            val_batch_size = 1
+        try:
+            num_gpus = max(int(train_cfg.get("num_gpus", 1)), 1)
+        except (TypeError, ValueError):
+            num_gpus = 1
+        gpu_ids = train_cfg.get("gpu_ids") or []
+        if isinstance(gpu_ids, list) and gpu_ids:
+            num_gpus = max(num_gpus, len(gpu_ids))
+        try:
+            num_nodes = max(int(train_cfg.get("num_nodes", 1)), 1)
+        except (TypeError, ValueError):
+            num_nodes = 1
+        min_auto_val_samples = val_batch_size * num_gpus * num_nodes
+        try:
+            requested_auto_val_samples = int(
+                os.environ.get("CLIP_AUTO_VAL_SAMPLES", "128")
+            )
+        except ValueError:
+            requested_auto_val_samples = 128
+        max_auto_val_samples = max(
+            requested_auto_val_samples,
+            min_auto_val_samples,
+        )
+
+        auto_val_source = mined_image_list_file or train_image_list_file
+        auto_val_image_dir = mined_image_dir if mined_image_list_file else train_image_dir
+        auto_val_caption_dir = mined_caption_dir if mined_image_list_file else train_caption_dir
+        auto_val_rows = []
+        if auto_val_source and auto_val_image_dir and auto_val_caption_dir:
+            seen = set()
+            with open(auto_val_source, "r", encoding="utf-8") as f:
+                for raw_line in f:
+                    image_name = raw_line.strip()
+                    if not image_name or image_name in seen:
+                        continue
+                    auto_val_rows.append(image_name)
+                    seen.add(image_name)
+                    if len(auto_val_rows) >= max_auto_val_samples:
+                        break
+
+        if auto_val_rows:
+            config_dir = os.path.dirname(new_config_yaml)
+            auto_val_list = os.path.join(config_dir, "auto_val_image_list.txt")
+            os.makedirs(config_dir, exist_ok=True)
+            with open(auto_val_list, "w", encoding="utf-8") as f:
+                f.write("\n".join(auto_val_rows) + "\n")
+            val_datasets = [{
+                "image_dir": auto_val_image_dir,
+                "caption_dir": auto_val_caption_dir,
+                "image_list_file": auto_val_list,
+                "caption_file_suffix": caption_file_suffix,
+            }]
+            val_data_cfg["datasets"] = val_datasets
+
+        validation_interval = 1
+        train_cfg["validation_interval"] = validation_interval
+        train_cfg["val_check_interval"] = None
+        if auto_val_rows:
+            print(
+                "Validation datasets were empty; created "
+                f"{len(auto_val_rows)}-sample auto validation list at "
+                f"{auto_val_list} and set train.validation_interval="
+                f"{validation_interval} (minimum validation batch size: "
+                f"{min_auto_val_samples})."
+            )
+        else:
+            print(
+                "Validation datasets are empty and no auto validation list could "
+                "be created; TAO training may require val.datasets."
+            )
+
+    train_cfg.pop("checkpointer", None)
+
+    if checkpoint_path:
+        train_cfg["pretrained_model_path"] = checkpoint_path
+
+    if "lr" in sweep_args:
+        train_cfg.setdefault("optim", {})["lr"] = sweep_args["lr"]
+
+    config_dir = os.path.dirname(new_config_yaml)
+    if config_dir:
+        os.makedirs(config_dir, exist_ok=True)
+
+    with open(new_config_yaml, "w") as f:
+        yaml.safe_dump(
+            config_data,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+    n_datasets = len(config_data["dataset"]["train"].get("datasets") or [])
+    print(
+        f"Created CLIP train config at {new_config_yaml} "
+        f"({n_datasets} dataset.train.datasets entries)"
+    )
+    return new_config_yaml
+
+def create_clip_eval_config(
+    base_config_yaml: str,
+    new_config_yaml: str,
+    output_dir: str,
+    checkpoint_path: str,
+    eval_image_dir: str = "",
+    eval_caption_dir: str = "",
+    eval_image_list_file: str = "",
+    caption_file_suffix: str = ".txt",
+) -> str:
+    """Create a TAO CLIP evaluation config YAML by patching a template.
+
+    Only the fields the DEFT loop owns (results dir, checkpoint, eval
+    dataset) are patched; all other TAO settings come from
+    ``base_config_yaml`` as-is and must be edited there directly.
+
+    Args:
+        base_config_yaml: Path to the template YAML config file.
+        new_config_yaml:  Path where the patched YAML will be written.
+        output_dir:       TAO ``results_dir`` root.
+        checkpoint_path:  Checkpoint for ``evaluate.checkpoint``.
+        eval_image_dir:   Optional evaluation image root.
+        eval_caption_dir: Optional evaluation caption root.
+        eval_image_list_file: Optional evaluation image list.
+        caption_file_suffix: Caption suffix for the evaluation dataset.
+
+    Returns:
+        Path to the newly written config YAML.
+    """
+    import os
+
+    import yaml
+
+    with open(base_config_yaml, "r") as f:
+        config_data = yaml.safe_load(f)
+
+    config_data["results_dir"] = output_dir
+    for section_name in ("evaluate", "inference", "export"):
+        section = config_data.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        if section.get("checkpoint") in ("???", ""):
+            section["checkpoint"] = None
+        if section_name == "export" and section.get("onnx_file") in ("???", ""):
+            section["onnx_file"] = None
+
+    eval_cfg = config_data.setdefault("evaluate", {})
+    eval_cfg["checkpoint"] = checkpoint_path or None
+    eval_cfg["results_dir"] = os.path.join(output_dir, "evaluate")
+    if eval_image_list_file:
+        eval_cfg["datasets"] = [{
+            "image_dir": eval_image_dir,
+            "caption_dir": eval_caption_dir,
+            "image_list_file": eval_image_list_file,
+            "caption_file_suffix": caption_file_suffix,
+        }]
+        fallback_dataset = dict(eval_cfg["datasets"][0])
+        fallback_dataset["train_pairs_file"] = None
+        dataset_cfg = config_data.setdefault("dataset", {})
+        dataset_cfg.setdefault("train", {})["datasets"] = [dict(fallback_dataset)]
+        dataset_cfg.setdefault("val", {})["datasets"] = [dict(fallback_dataset)]
+
+    config_dir = os.path.dirname(new_config_yaml)
+    if config_dir:
+        os.makedirs(config_dir, exist_ok=True)
+
+    with open(new_config_yaml, "w") as f:
+        yaml.safe_dump(
+            config_data,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+    print(f"Created CLIP eval config at {new_config_yaml}")
+    return new_config_yaml
+
+
+def get_current_checkpoint(
+    train_output_dir: str,
+    checkpoint_relpath: str = "best/clip_best_val_t2i_mAP.pth",
+    metric_name: str = "val/t2i_mAP",
+) -> str:
+    """Select the best epoch checkpoint from a TAO CLIP training run.
+
+    TAO's CLIP schema does not accept a top-k checkpointer stanza, so training
+    only emits per-epoch checkpoints plus ``clip_latest.pth``. This picks the
+    epoch checkpoint whose validation metric is best and publishes it at
+    ``checkpoint_relpath`` (symlink, falling back to hardlink then copy), which
+    is the path the eval and next-iteration configs expect.
+
+    Metrics are read from TensorBoard when available, otherwise from the
+    per-line ``kpi`` records in ``status.json``. Only stdlib is required;
+    TensorBoard is used opportunistically.
+
+    Args:
+        train_output_dir:   Root training output directory
+                            (``train.results_dir``).
+        checkpoint_relpath: Publish location, relative to train_output_dir.
+        metric_name:        Validation metric to maximise.
+
+    Returns:
+        Full path to the published checkpoint.
+
+    Raises:
+        FileNotFoundError: If no checkpoints exist under train_output_dir.
+    """
+    import json
+    import os
+    import re
+    import shutil
+
+    train_output_dir = os.path.abspath(train_output_dir)
+    ckpt_path = os.path.join(train_output_dir, checkpoint_relpath)
+
+    if os.path.exists(ckpt_path):
+        print(f"Best checkpoint already published: {ckpt_path}")
+        return ckpt_path
+
+    def _checkpoint_candidates():
+        """Epoch checkpoints, oldest first.
+
+        Skips best/, clip_latest.pth, and normalised copies.
+        """
+        candidates = []
+        for root, _, files in os.walk(train_output_dir):
+            rel_root = os.path.relpath(root, train_output_dir)
+            rel_root = "" if rel_root == "." else rel_root.replace(os.sep, "/")
+            if rel_root.startswith("best"):
+                continue
+            for filename in files:
+                lower_name = filename.lower()
+                if not lower_name.endswith((".pth", ".ckpt", ".safetensors")):
+                    continue
+                if "latest" in lower_name:
+                    continue
+                if lower_name.endswith("_pretrained.pth"):
+                    continue
+                if ".tmp" in lower_name:
+                    continue
+                path = os.path.join(root, filename)
+                match = re.search(r"epoch[_=]?(\d+).*step[_=]?(\d+)", filename)
+                candidates.append({
+                    "path": path,
+                    "epoch": int(match.group(1)) if match else None,
+                    "step": int(match.group(2)) if match else None,
+                    "mtime": os.path.getmtime(path),
+                })
+        return sorted(
+            candidates,
+            key=lambda item: (
+                item["step"] if item["step"] is not None else -1,
+                item["epoch"] if item["epoch"] is not None else -1,
+                item["mtime"],
+            ),
+        )
+
+    def _read_tensorboard_metrics():
+        metrics = []
+        try:
+            from tensorboard.backend.event_processing.event_accumulator import (
+                EventAccumulator,
+            )
+        except Exception:
+            return metrics
+        logs_dir = os.path.join(train_output_dir, "lightning_logs")
+        if not os.path.isdir(logs_dir):
+            return metrics
+        for root, _, files in os.walk(logs_dir):
+            if not any(f.startswith("events.out.tfevents") for f in files):
+                continue
+            try:
+                accumulator = EventAccumulator(root)
+                accumulator.Reload()
+                scalar_tags = set(accumulator.Tags().get("scalars", []))
+            except Exception:
+                continue
+            tag = metric_name
+            if tag not in scalar_tags:
+                tag = metric_name.replace("/", "_")
+            if tag not in scalar_tags:
+                continue
+            for event in accumulator.Scalars(tag):
+                try:
+                    value = float(event.value)
+                except (TypeError, ValueError):
+                    continue
+                metrics.append({
+                    "step": int(event.step),
+                    "epoch": None,
+                    "value": value,
+                    "source": "tensorboard",
+                })
+        return metrics
+
+    def _read_status_metrics():
+        """Parse status.json.
+
+        Carries the most recent epoch/step onto each kpi record.
+        """
+        metrics = []
+        status_path = os.path.join(train_output_dir, "status.json")
+        if not os.path.isfile(status_path):
+            return metrics
+        latest_epoch = None
+        latest_step = None
+        with open(status_path, "r", encoding="utf-8") as f:
+            for raw_line in f:
+                raw_line = raw_line.strip().rstrip(",")
+                if not raw_line:
+                    continue
+                try:
+                    record = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+                if "epoch" in record:
+                    try:
+                        latest_epoch = int(record["epoch"])
+                    except (TypeError, ValueError):
+                        pass
+                if "step" in record:
+                    try:
+                        latest_step = int(record["step"])
+                    except (TypeError, ValueError):
+                        pass
+                kpi = record.get("kpi") or {}
+                if metric_name not in kpi:
+                    continue
+                try:
+                    value = float(kpi[metric_name])
+                except (TypeError, ValueError):
+                    continue
+                metrics.append({
+                    "step": latest_step,
+                    "epoch": latest_epoch,
+                    "value": value,
+                    "source": "status",
+                })
+        return metrics
+
+    def _match_checkpoint(best_metric, candidates):
+        """Checkpoint written at, or last before, the best metric's step."""
+        if not candidates:
+            return None
+        metric_step = best_metric.get("step")
+        if metric_step is not None:
+            # Lightning writes validation metrics at a zero-based global step,
+            # while TAO checkpoint filenames use the completed one-based step.
+            # Keep exact matching first for status-derived metrics, then accept
+            # the TensorBoard ``metric_step + 1`` convention.
+            for checkpoint_step in (metric_step, metric_step + 1):
+                exact = [
+                    item for item in candidates
+                    if item["step"] is not None
+                    and item["step"] == checkpoint_step
+                ]
+                if exact:
+                    return exact[-1]
+            before = [
+                item for item in candidates
+                if item["step"] is not None and item["step"] <= metric_step
+            ]
+            if before:
+                return before[-1]
+            return min(
+                candidates,
+                key=lambda item: abs(
+                    (item["step"] if item["step"] is not None else 0)
+                    - metric_step
+                ),
+            )
+        metric_epoch = best_metric.get("epoch")
+        if metric_epoch is not None:
+            exact = [
+                item for item in candidates
+                if item["epoch"] is not None and item["epoch"] == metric_epoch
+            ]
+            if exact:
+                return exact[-1]
+        return candidates[-1]
+
+    def _publish_selected(selected, best_metric=None):
+        selected_path = selected["path"]
+        os.makedirs(os.path.dirname(ckpt_path), exist_ok=True)
+        if os.path.lexists(ckpt_path):
+            os.remove(ckpt_path)
+        try:
+            os.symlink(
+                os.path.relpath(selected_path, os.path.dirname(ckpt_path)),
+                ckpt_path,
+            )
+            link_mode = "symlink"
+        except OSError:
+            try:
+                os.link(selected_path, ckpt_path)
+                link_mode = "hardlink"
+            except OSError:
+                shutil.copy2(selected_path, ckpt_path)
+                link_mode = "copy"
+        meta_path = os.path.splitext(ckpt_path)[0] + ".json"
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump({
+                "selected_checkpoint": selected_path,
+                "published_checkpoint": ckpt_path,
+                "metric_name": metric_name,
+                "metric": best_metric,
+                "publish_mode": link_mode,
+            }, f, indent=2)
+        print(f"Published best checkpoint ({link_mode}): {ckpt_path}")
+        return ckpt_path
+
+    candidates = _checkpoint_candidates()
+    metrics = _read_tensorboard_metrics() or _read_status_metrics()
+
+    if metrics and candidates:
+        best_metric = max(
+            metrics,
+            key=lambda item: (
+                item["value"],
+                item["step"] if item.get("step") is not None else -1,
+            ),
+        )
+        selected = _match_checkpoint(best_metric, candidates)
+        if selected:
+            print(
+                f"Selected best checkpoint by {metric_name}="
+                f"{best_metric['value']:.6g} from {best_metric['source']}: "
+                f"{selected['path']}"
+            )
+            return _publish_selected(selected, best_metric)
+
+    if candidates:
+        print(f"No {metric_name} metric found; using newest checkpoint.")
+        return _publish_selected(candidates[-1], None)
+
+    raise FileNotFoundError(
+        f"No checkpoints found under {train_output_dir}"
+    )
+
+
+def normalize_clip_pretrained_checkpoint(
+    checkpoint_path: str,
+    output_path: str = "",
+) -> str:
+    """Create a model-only CLIP checkpoint for ``train.pretrained_model_path``.
+
+    Strips the ``model.`` LightningModule prefix from state-dict keys so the
+    checkpoint can be loaded directly by the SigLIP model.
+    """
+    import os
+
+    if not checkpoint_path:
+        return checkpoint_path
+
+    source_path = os.path.abspath(checkpoint_path)
+    if not os.path.isfile(source_path):
+        raise FileNotFoundError(f"Checkpoint does not exist: {source_path}")
+
+    lower_path = source_path.lower()
+    if lower_path.endswith(".safetensors"):
+        return source_path
+    if not (lower_path.endswith(".pth") or lower_path.endswith(".ckpt")):
+        return source_path
+
+    if output_path:
+        normalized_path = os.path.abspath(output_path)
+    else:
+        root, ext = os.path.splitext(source_path)
+        normalized_path = f"{root}_pretrained{ext or '.pth'}"
+
+    if (
+        os.path.isfile(normalized_path)
+        and os.path.getmtime(normalized_path) >= os.path.getmtime(source_path)
+    ):
+        print(f"Using normalized CLIP pretrained checkpoint: {normalized_path}")
+        return normalized_path
+
+    import torch
+
+    try:
+        checkpoint = torch.load(
+            source_path,
+            map_location="cpu",
+            weights_only=False,
+        )
+    except TypeError:
+        checkpoint = torch.load(source_path, map_location="cpu")
+    if isinstance(checkpoint, dict) and isinstance(checkpoint.get("state_dict"), dict):
+        state_dict = checkpoint["state_dict"]
+    elif isinstance(checkpoint, dict):
+        state_dict = checkpoint
+    else:
+        print(
+            "Checkpoint is not a state-dict mapping; using original "
+            f"checkpoint for pretrained_model_path: {source_path}"
+        )
+        return source_path
+
+    prefixed_items = {
+        key[len("model."):]: value
+        for key, value in state_dict.items()
+        if isinstance(key, str) and key.startswith("model.")
+    }
+    if not prefixed_items:
+        print(f"CLIP checkpoint is already model-loadable: {source_path}")
+        return source_path
+
+    os.makedirs(os.path.dirname(normalized_path), exist_ok=True)
+    tmp_path = f"{normalized_path}.tmp"
+    torch.save(prefixed_items, tmp_path)
+    os.replace(tmp_path, normalized_path)
+    print(
+        "Normalized CLIP pretrained checkpoint: "
+        f"{source_path} -> {normalized_path} ({len(prefixed_items)} tensors)"
+    )
+    return normalized_path
+
+
+def resolve_prev_clip_train_config(
+    base_experiment_path: str,
+    iter_num: int,
+    continual_dataset: bool,
+    base_template: str,
+    train_image_list_file: str,
+) -> str:
+    """Return the source train config for the current CLIP DEFT iteration."""
+    import os
+
+    if not continual_dataset:
+        return base_template
+
+    if iter_num <= 1:
+        sft_cfg = os.path.join(
+            base_experiment_path, "sft", "specs", "train_config.yaml",
+        )
+        if train_image_list_file and os.path.isfile(sft_cfg):
+            return sft_cfg
+        return base_template
+
+    prev_cfg = os.path.join(
+        base_experiment_path, f"iter_{iter_num - 1}",
+        "specs", "train_config.yaml",
+    )
+    if not os.path.isfile(prev_cfg):
+        raise FileNotFoundError(
+            f"continual_dataset requested but no prior CLIP train config "
+            f"found at {prev_cfg}"
+        )
+    return prev_cfg
+
+
+
+def resolve_prev_eval_dir(
+    base_experiment_path: str, iter_num: int,
+    train_ann_path: str,
+    eval_subdir: str = "evaluate",
+) -> str:
+    """Return the results directory from the previous step."""
+    import os
+
+    if iter_num <= 1:
+        zs_dir = os.path.join(base_experiment_path, "zs", eval_subdir)
+        sft_dir = os.path.join(base_experiment_path, "sft", eval_subdir)
+        if train_ann_path and os.path.isdir(sft_dir):
+            return sft_dir
+        print(
+            "Initial SFT eval output not found or not requested; "
+            f"using zero-shot eval dir: {zs_dir}"
+        )
+        return zs_dir
+    return os.path.join(
+        base_experiment_path, f"iter_{iter_num - 1}",
+        eval_subdir,
+    )

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/visualization.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/visualization.py
@@ -1,0 +1,662 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bundled and adapted from the Apache-2.0 NVIDIA TAO Tutorials IAA DEFT utilities so the
+# customer workflow does not depend on an external source checkout.
+
+"""Visualization utilities for the CLIP DEFT pipeline.
+
+Computes embeddings for weak-query samples, mined samples, and previous
+training data, then produces a t-SNE scatter plot that overlays all three
+categories with distinct colors.
+
+Note: ``create_image_embeddings_task``, ``create_text_embeddings_task``, and
+``create_video_embeddings_task`` from the Kratos pipeline are omitted — they
+build Kubeflow tasks and cannot be called locally.  Run the equivalent
+dockerised command instead::
+
+    docker run ... {tao_ds_image} embedding image_embeddings \\
+        -e /specs/image_embed_spec.yaml \\
+        input_parquet=/<input> output_parquet=/<output>
+"""
+
+
+def prepare_clip_images_for_embedding(
+    input_parquet: str,
+    output_parquet_path: str,
+    image_dir: str = "",
+) -> str:
+    """Build a unique image-filepath parquet ready for image embedding.
+
+    Works on any CLIP-side parquet that carries a ``filepath`` (or
+    ``unique_name``) column: the gap-analysis ``kpi_gaps.parquet``, the k-NN
+    ``mined_samples.parquet``, or a previous-training-data pool parquet.  Those
+    tables hold one row per (image, caption) query pair, so the same image
+    appears many times; embedding them as-is re-encodes duplicates and chokes on
+    rows whose ``filepath`` is empty.  This drops blanks, deduplicates on
+    ``filepath``, and keeps the metadata columns t-SNE and the contact sheets
+    use.
+
+    Args:
+        input_parquet:       Parquet with a ``filepath`` and/or ``unique_name``
+                             column.
+        output_parquet_path: Where to write the deduplicated parquet.
+        image_dir:           Image root used to resolve ``unique_name`` when a
+                             row has no ``filepath``.  Optional.
+
+    Returns:
+        The path to the written parquet file.
+    """
+    import os
+
+    import pandas as pd
+
+    keep_cols = (
+        "filepath", "unique_name", "image_path", "text", "caption",
+        "query_type", "dataset", "label", "weak_attribute",
+    )
+
+    df = pd.read_parquet(input_parquet)
+
+    if "filepath" not in df.columns and "unique_name" not in df.columns:
+        raise ValueError(
+            f"{input_parquet} has neither a 'filepath' nor a 'unique_name' "
+            f"column; found {list(df.columns)}"
+        )
+
+    out = df[[c for c in keep_cols if c in df.columns]].copy()
+
+    if "filepath" in out.columns:
+        out["filepath"] = out["filepath"].fillna("").astype(str).str.strip()
+    else:
+        out["filepath"] = ""
+
+    # Fall back to image_dir/unique_name for rows the upstream step left blank.
+    if image_dir and "unique_name" in out.columns:
+        names = out["unique_name"].fillna("").astype(str).str.strip()
+        missing = (out["filepath"] == "") & (names != "")
+        if missing.any():
+            out.loc[missing, "filepath"] = names[missing].map(
+                lambda n: os.path.abspath(os.path.join(image_dir, n)),
+            )
+
+    total = len(out)
+    out = out[out["filepath"] != ""]
+    dropped = total - len(out)
+    out = out.drop_duplicates(subset=["filepath"]).reset_index(drop=True)
+
+    out_dir = os.path.dirname(output_parquet_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    out.to_parquet(output_parquet_path, index=False)
+
+    print(
+        f"Prepared {len(out)} unique images from {total} rows in "
+        f"{input_parquet} ({dropped} rows had no filepath) -> "
+        f"{output_parquet_path}"
+    )
+    return output_parquet_path
+
+
+def export_clip_sample_contact_sheets(
+    weak_parquet: str,
+    mined_parquet: str,
+    output_dir: str,
+    source_pairs_file: str = "",
+    max_samples_per_group: int = 12,
+    max_total_samples: int = 96,
+    tile_size: int = 192,
+    host_path_map=None,
+) -> str:
+    """Export galleries and contact sheets with explicit mount-prefix aliases."""
+    import base64
+    import html
+    import io
+    import json
+    import os
+    import textwrap
+
+    import pandas as pd
+
+    def _iter_json_records(path):
+        if not path or not os.path.isfile(path):
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline()
+            second = f.readline()
+        compact = (
+            second.lstrip().startswith("{")
+            and second.rstrip().rstrip(",").endswith("}")
+        )
+        if compact:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s or s in ("[", "]"):
+                        continue
+                    if s.endswith(","):
+                        s = s[:-1]
+                    if s:
+                        yield json.loads(s)
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for row in json.load(f):
+                yield row
+
+    def _sample(df):
+        if df.empty:
+            return df
+        group_cols = [c for c in ("dataset", "query_type") if c in df.columns]
+        if not group_cols:
+            return df.head(max_total_samples).copy()
+        pieces = []
+        for _, group in df.groupby(group_cols, dropna=False, sort=True):
+            pieces.append(group.head(max_samples_per_group))
+        out = pd.concat(pieces, ignore_index=True) if pieces else df.head(0)
+        return out.head(max_total_samples).copy()
+
+    path_prefixes = sorted(
+        (
+            (str(container).rstrip("/"), str(host).rstrip("/"))
+            for container, host in (host_path_map or {}).items()
+        ),
+        key=lambda pair: len(pair[0]),
+        reverse=True,
+    )
+
+    def _mount_aliases(path):
+        path = str(path or "")
+        aliases = [path]
+        for container, host in path_prefixes:
+            if path == container or path.startswith(container + "/"):
+                aliases.append(host + path[len(container):])
+            if path == host or path.startswith(host + "/"):
+                aliases.append(container + path[len(host):])
+        return aliases
+
+    def _path_candidates(path, image_path="", unique_name=""):
+        path = str(path or "")
+        image_path = str(image_path or "")
+        unique_name = str(unique_name or "")
+        raw_candidates = [path]
+        if unique_name:
+            raw_candidates.append(os.path.join(os.path.dirname(path), unique_name))
+        if image_path:
+            raw_candidates.append(image_path)
+            base_dir = os.path.dirname(path)
+            dataset_root = os.path.dirname(base_dir)
+            raw_candidates.extend([
+                os.path.join(base_dir, image_path),
+                os.path.join(dataset_root, image_path),
+                os.path.join(dataset_root, "images", image_path),
+            ])
+        candidates = []
+        for raw in raw_candidates:
+            candidates.extend(_mount_aliases(raw))
+        seen = set()
+        for candidate in candidates:
+            if candidate and candidate not in seen:
+                seen.add(candidate)
+                yield candidate
+
+    def _resolve_path(path, image_path="", unique_name=""):
+        for candidate in _path_candidates(path, image_path, unique_name):
+            if os.path.isfile(candidate):
+                return candidate
+            if os.path.islink(candidate):
+                target = os.readlink(candidate)
+                if not os.path.isabs(target):
+                    target = os.path.abspath(
+                        os.path.join(os.path.dirname(candidate), target)
+                    )
+                for alias in _mount_aliases(target):
+                    if os.path.isfile(alias):
+                        return alias
+        return ""
+
+    def _add_resolution_columns(df):
+        df = df.copy()
+        if df.empty:
+            df["resolved_filepath"] = []
+            df["image_exists"] = []
+            return df
+        df["resolved_filepath"] = df.apply(
+            lambda row: _resolve_path(
+                row.get("filepath", ""),
+                row.get("image_path", ""),
+                row.get("unique_name", ""),
+            ),
+            axis=1,
+        )
+        df["image_exists"] = df["resolved_filepath"].astype(bool)
+        return df
+
+    def _thumbnail_data_uri(row, max_size=512):
+        path = str(row.get("filepath") or "")
+        resolved = str(row.get("resolved_filepath") or "") or _resolve_path(
+            path,
+            row.get("image_path", ""),
+            row.get("unique_name", ""),
+        )
+        if not resolved:
+            return ""
+        try:
+            from PIL import Image
+            img = Image.open(resolved).convert("RGB")
+            img.thumbnail((max_size, max_size))
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG", quality=85, optimize=True)
+            encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+            return f"data:image/jpeg;base64,{encoded}"
+        except Exception as exc:
+            print(f"Could not embed thumbnail for {path}: {exc}")
+            return ""
+
+    def _write_html(df, path, title):
+        cards = []
+        for _, row in df.iterrows():
+            fp = str(row.get("filepath") or "")
+            img_src = _thumbnail_data_uri(row)
+            label = " / ".join(
+                str(row.get(c) or "") for c in ("dataset", "query_type")
+                if c in row and str(row.get(c) or "")
+            )
+            caption = str(row.get("caption") or row.get("text") or "")
+            if img_src:
+                media = f"<img src='{img_src}' alt='sample'>"
+            else:
+                media = (
+                    "<div class='missing'>missing image<br>"
+                    f"{html.escape(fp)}</div>"
+                )
+            cards.append(
+                "<div class='card'>"
+                f"{media}"
+                f"<div class='meta'>{html.escape(label)}</div>"
+                f"<div class='name'>{html.escape(os.path.basename(fp))}</div>"
+                f"<div class='caption'>{html.escape(caption[:500])}</div>"
+                "</div>"
+            )
+        body = "\n".join(cards) if cards else "<p>No samples.</p>"
+        doc = f"""<!doctype html>
+<html><head><meta charset="utf-8"><title>{html.escape(title)}</title>
+<style>
+body {{ font-family: Arial, sans-serif; margin: 20px; }}
+.grid {{ display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 14px; }}
+.card {{ border: 1px solid #ddd; padding: 8px; }}
+.card img {{ width: 100%; height: 220px; object-fit: contain; background: #f6f6f6; }}
+.missing {{ width: 100%; height: 220px; display: flex; align-items: center; justify-content: center; text-align: center; background: #eee; color: #333; font-size: 12px; word-break: break-all; }}
+.meta {{ font-weight: 700; margin-top: 6px; }}
+.name {{ font-size: 12px; color: #555; word-break: break-all; }}
+.caption {{ font-size: 12px; margin-top: 6px; white-space: pre-wrap; }}
+</style></head><body><h1>{html.escape(title)}</h1><div class="grid">{body}</div></body></html>"""
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(doc)
+
+    def _write_png(df, path, title):
+        try:
+            from PIL import Image, ImageDraw, ImageFont
+        except Exception as exc:
+            print(f"Pillow unavailable; skipping PNG contact sheet: {exc}")
+            return False
+        if df.empty:
+            return False
+        cols = 4
+        label_h = 96
+        rows = (len(df) + cols - 1) // cols
+        sheet = Image.new("RGB", (cols * tile_size, rows * (tile_size + label_h)), "white")
+        draw = ImageDraw.Draw(sheet)
+        try:
+            font = ImageFont.load_default()
+        except Exception:
+            font = None
+        for idx, (_, row) in enumerate(df.iterrows()):
+            x = (idx % cols) * tile_size
+            y = (idx // cols) * (tile_size + label_h)
+            fp = str(row.get("filepath") or "")
+            resolved = str(row.get("resolved_filepath") or "") or _resolve_path(fp)
+            try:
+                img = Image.open(resolved).convert("RGB")
+                img.thumbnail((tile_size, tile_size))
+                ix = x + (tile_size - img.width) // 2
+                iy = y + (tile_size - img.height) // 2
+                sheet.paste(img, (ix, iy))
+            except Exception:
+                draw.rectangle([x, y, x + tile_size - 1, y + tile_size - 1], fill="#eeeeee", outline="#bbbbbb")
+                draw.text((x + 8, y + 8), "missing image", fill="black", font=font)
+            label = " / ".join(
+                str(row.get(c) or "") for c in ("dataset", "query_type")
+                if c in row and str(row.get(c) or "")
+            )
+            caption = str(row.get("caption") or row.get("text") or os.path.basename(fp))
+            wrapped = textwrap.wrap(f"{label} {caption}", width=34)[:5]
+            draw.text((x + 6, y + tile_size + 6), "\n".join(wrapped), fill="black", font=font)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        sheet.save(path)
+        print(f"Saved {title} contact sheet to {path}")
+        return True
+
+    os.makedirs(output_dir, exist_ok=True)
+    weak = pd.read_parquet(weak_parquet)
+    mined = pd.read_parquet(mined_parquet)
+
+    if "filepath" not in weak.columns:
+        weak = pd.DataFrame(columns=["filepath"])
+    if "filepath" not in mined.columns:
+        mined = pd.DataFrame(columns=["filepath"])
+
+    pair_by_name = {}
+    for row in _iter_json_records(source_pairs_file) or []:
+        name = str(row.get("unique_name") or "").strip()
+        if name and name not in pair_by_name:
+            pair_by_name[name] = row
+
+    mined = mined.copy()
+    mined["unique_name"] = mined["filepath"].map(os.path.basename)
+    if pair_by_name:
+        mined["dataset"] = mined["unique_name"].map(
+            lambda n: str(pair_by_name.get(n, {}).get("dataset") or "")
+        )
+        mined["query_type"] = mined["unique_name"].map(
+            lambda n: str(pair_by_name.get(n, {}).get("query_type") or "")
+        )
+        mined["caption"] = mined["unique_name"].map(
+            lambda n: str(pair_by_name.get(n, {}).get("caption") or "")
+        )
+        mined["image_path"] = mined["unique_name"].map(
+            lambda n: str(pair_by_name.get(n, {}).get("image_path") or "")
+        )
+
+    weak_sample = _add_resolution_columns(_sample(weak))
+    mined_sample = _add_resolution_columns(
+        _sample(mined.drop_duplicates(subset=["filepath"]))
+    )
+
+    weak_csv = os.path.join(output_dir, "weak_samples_visual.csv")
+    mined_csv = os.path.join(output_dir, "mined_samples_visual.csv")
+    weak_html = os.path.join(output_dir, "weak_samples_gallery.html")
+    mined_html = os.path.join(output_dir, "mined_samples_gallery.html")
+    weak_png = os.path.join(output_dir, "weak_samples_contact_sheet.png")
+    mined_png = os.path.join(output_dir, "mined_samples_contact_sheet.png")
+
+    weak_sample.to_csv(weak_csv, index=False)
+    mined_sample.to_csv(mined_csv, index=False)
+    _write_html(weak_sample, weak_html, "Weak IAA query samples")
+    _write_html(mined_sample, mined_html, "Mined augmented IAA samples")
+    weak_png_written = _write_png(weak_sample, weak_png, "weak samples")
+    mined_png_written = _write_png(mined_sample, mined_png, "mined samples")
+
+    summary_lines = [
+        "IAA visual sample export",
+        f"Weak sample rows: {len(weak_sample)} -> {weak_csv}",
+        f"Weak image files resolved: {int(weak_sample['image_exists'].sum())}/{len(weak_sample)}",
+        f"Mined sample rows: {len(mined_sample)} -> {mined_csv}",
+        f"Mined image files resolved: {int(mined_sample['image_exists'].sum())}/{len(mined_sample)}",
+        f"Weak gallery: {weak_html}",
+        f"Mined gallery: {mined_html}",
+        f"Weak PNG: {weak_png if weak_png_written else '(not written)'}",
+        f"Mined PNG: {mined_png if mined_png_written else '(not written)'}",
+    ]
+    summary_path = os.path.join(output_dir, "sample_export_summary.txt")
+    with open(summary_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(summary_lines) + "\n")
+    print("\n".join(summary_lines))
+    return output_dir
+
+
+def prepare_prev_clip_data_for_embedding(
+    prev_train_config_yaml: str,
+    output_parquet_path: str,
+    host_path_map=None,
+) -> str:
+    """Collect prior CLIP training data into a filepaths parquet.
+
+    ``dataset.train.datasets`` in the prior train config is the authoritative
+    record of what the last iteration trained on — under ``continual_dataset``
+    it accumulates one entry per iteration, so walking it captures the whole
+    history without reconstructing it here.
+
+    That config is written for the TAO container, so its paths are
+    container-absolute (``/results/...``).  When this runs on the host instead
+    of inside the container, pass ``host_path_map`` to translate those prefixes
+    for reading.  Emitted ``filepath`` values keep the config's own roots, since
+    the parquet is consumed by the image-embedding container.
+
+    Args:
+        prev_train_config_yaml: Path to the CLIP train config YAML
+                                from the previous training step.
+        output_parquet_path:    Where to write the union parquet.
+        host_path_map:          Container-prefix -> host-prefix mapping applied
+                                when opening ``image_list_file``, e.g.
+                                ``{"/results": "/abs/host/results"}``.  Omit
+                                when running inside the container.
+
+    Returns:
+        Path to ``output_parquet_path``.
+    """
+    import os
+
+    import pandas as pd
+    import yaml
+
+    path_map = sorted(
+        (host_path_map or {}).items(), key=lambda kv: len(kv[0]), reverse=True,
+    )
+
+    def _to_host(path):
+        """Rewrite a container path to its host equivalent, if mapped."""
+        for container_root, host_root in path_map:
+            if path == container_root or path.startswith(
+                container_root.rstrip("/") + "/"
+            ):
+                return os.path.join(
+                    host_root, os.path.relpath(path, container_root),
+                )
+        return path
+
+    entries = []
+    if prev_train_config_yaml and os.path.isfile(prev_train_config_yaml):
+        with open(prev_train_config_yaml, "r", encoding="utf-8") as f:
+            config_data = yaml.safe_load(f) or {}
+        dataset_cfg = config_data.get("dataset") or {}
+        train_data_cfg = dataset_cfg.get("train") or {}
+        entries = train_data_cfg.get("datasets") or []
+        if not entries:
+            entries = (config_data.get("train") or {}).get("datasets") or []
+    else:
+        print(
+            f"No prior train config at {prev_train_config_yaml!r}; "
+            "emitting empty previous-data parquet"
+        )
+
+    filepaths = []
+    for idx, entry in enumerate(entries):
+        entry_image_dir = entry.get("image_dir", "")
+        entry_image_list_file = entry.get("image_list_file", "")
+        if not entry_image_dir or not entry_image_list_file:
+            print(
+                f"train.datasets[{idx}] missing image_dir or "
+                "image_list_file; skipping"
+            )
+            continue
+        # Unfilled template entries carry "???" rather than a real path.
+        if "???" in (entry_image_dir, entry_image_list_file):
+            continue
+        host_image_list_file = _to_host(entry_image_list_file)
+        if not os.path.isfile(host_image_list_file):
+            print(
+                f"image_list_file {entry_image_list_file} from "
+                f"train.datasets[{idx}] missing "
+                f"(looked in {host_image_list_file}); skipping"
+            )
+            continue
+        before = len(filepaths)
+        with open(host_image_list_file, "r", encoding="utf-8") as lf:
+            for line in lf:
+                name = line.strip()
+                if name:
+                    filepaths.append(os.path.join(entry_image_dir, name))
+        print(
+            f"train.datasets[{idx}]: {len(filepaths) - before} images from "
+            f"{entry_image_list_file}"
+        )
+
+    filepaths = sorted(set(filepaths))
+
+    out_df = pd.DataFrame({"filepath": filepaths})
+    out_dir = os.path.dirname(output_parquet_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    out_df.to_parquet(output_parquet_path, index=False)
+    print(
+        f"Prepared {len(filepaths)} previous CLIP training samples -> "
+        f"{output_parquet_path}"
+    )
+    return output_parquet_path
+
+
+def create_tsne_visualization(
+    weak_embeddings_dir: str,
+    augmented_embeddings_dir: str,
+    previous_embeddings_dir: str,
+    output_plot_path: str,
+) -> str:
+    """Create a t-SNE scatter plot of weak, augmented, and previous data.
+
+    Args:
+        weak_embeddings_dir:      Directory containing ``embeddings.parquet``
+                                  for weak samples.
+        augmented_embeddings_dir: Directory containing one or more
+                                  ``*_embeddings.parquet`` files.
+        previous_embeddings_dir:  Directory containing ``embeddings.parquet``
+                                  for previous training data.
+        output_plot_path:         File path for the output PNG.
+
+    Returns:
+        The path to the saved plot, or empty string if no data.
+    """
+    import glob
+    import os
+
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    from sklearn.manifold import TSNE
+
+    def _read_embedding_parquet(path):
+        if not os.path.isfile(path):
+            return None
+        df = pd.read_parquet(path)
+        if df.empty or "embedding" not in df.columns:
+            return None
+        return np.stack(df["embedding"].values)
+
+    def _load_embeddings_from_dir(emb_dir, pattern="*.parquet"):
+        if not os.path.isdir(emb_dir):
+            print(f"No embeddings dir at {emb_dir}, skipping")
+            return np.empty(0), []
+        files = sorted(glob.glob(os.path.join(emb_dir, pattern)))
+        arrays, sources = [], []
+        for fp in files:
+            embs = _read_embedding_parquet(fp)
+            if embs is not None:
+                fname = os.path.basename(fp)
+                if fname.endswith("_embeddings.parquet"):
+                    source = fname[: -len("_embeddings.parquet")]
+                else:
+                    source = fname[: -len(".parquet")]
+                arrays.append(embs)
+                sources.extend([source] * len(embs))
+                print(f"  loaded {len(embs)} embeddings from {fname}")
+        if not arrays:
+            return np.empty(0), []
+        return np.concatenate(arrays, axis=0), sources
+
+    weak_embs, _ = _load_embeddings_from_dir(weak_embeddings_dir)
+    aug_embs, aug_sources = _load_embeddings_from_dir(augmented_embeddings_dir)
+    prev_embs, _ = _load_embeddings_from_dir(previous_embeddings_dir)
+
+    categories = [
+        ("Weak Samples", weak_embs, None),
+        ("Augmented Samples", aug_embs, aug_sources),
+        ("Previous Training Data", prev_embs, None),
+    ]
+    arrays, labels, sources = [], [], []
+    for name, embs, srcs in categories:
+        if embs.size > 0:
+            arrays.append(embs)
+            labels.extend([name] * len(embs))
+            sources.extend(srcs if srcs else [""] * len(embs))
+
+    if not arrays:
+        print("No embeddings found — skipping plot")
+        return ""
+
+    all_embs = np.concatenate(arrays, axis=0)
+    perplexity = min(30, max(1, len(all_embs) - 1))
+    coords = TSNE(
+        n_components=2, random_state=42, perplexity=perplexity,
+    ).fit_transform(all_embs)
+
+    labels_arr = np.array(labels)
+    sources_arr = np.array(sources)
+    color_map = {
+        "Weak Samples": "#e74c3c",
+        "Augmented Samples": "#2ecc71",
+        "Previous Training Data": "#3498db",
+    }
+    aug_marker_map = {"mined": "^", "omniverse": "s"}
+    fallback_markers = ["D", "P", "X", "*", "v", "<", ">"]
+
+    draw_order = (
+        "Previous Training Data",
+        "Weak Samples",
+        "Augmented Samples",
+    )
+    fig, ax = plt.subplots(figsize=(12, 8))
+    for category in draw_order:
+        mask = labels_arr == category
+        if not mask.any():
+            continue
+        if category == "Augmented Samples":
+            unique_sources = sorted(set(sources_arr[mask].tolist()))
+            for i, source in enumerate(unique_sources):
+                sub_mask = mask & (sources_arr == source)
+                marker = aug_marker_map.get(
+                    source, fallback_markers[i % len(fallback_markers)],
+                )
+                label = (
+                    f"{category} ({source}, n={sub_mask.sum()})"
+                    if source else f"{category} (n={sub_mask.sum()})"
+                )
+                ax.scatter(
+                    coords[sub_mask, 0], coords[sub_mask, 1],
+                    c=color_map[category],
+                    marker=marker,
+                    label=label,
+                    alpha=0.6, s=30,
+                    edgecolors="white", linewidths=0.5,
+                )
+        else:
+            ax.scatter(
+                coords[mask, 0], coords[mask, 1],
+                c=color_map[category],
+                label=f"{category} (n={mask.sum()})",
+                alpha=0.6, s=30,
+                edgecolors="white", linewidths=0.5,
+            )
+
+    ax.legend(fontsize=11, loc="best")
+    ax.set_title("t-SNE: Weak vs Augmented vs Previous Data", fontsize=14)
+    ax.set_xlabel("t-SNE 1")
+    ax.set_ylabel("t-SNE 2")
+    ax.grid(True, alpha=0.3)
+
+    os.makedirs(os.path.dirname(output_plot_path), exist_ok=True)
+    fig.savefig(output_plot_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+    print(f"t-SNE plot saved to {output_plot_path}")
+    return output_plot_path

--- a/skills/applications/tao-run-deft-iaa/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/init_deft_state.py
@@ -1,0 +1,589 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Initialize ${RESULTS_DIR}/deft_state.json for an IAA CLIP DEFT run.
+
+Why this exists: inline-dict writes drift from the canonical schema and can
+produce duplicate top-level keys — Python 3.12+ emits a `SyntaxWarning` for
+these and the loop's resume logic reads whichever copy parsing keeps, which is
+not stable across edits.
+
+This script builds the dict with literal-once keys and writes the JSON. Atomic
+write (tmp + os.replace). It refuses to reinitialize an existing
+deft_state.json — the resume path is supposed to read disk, not regenerate —
+and it appends nothing to loop_log.jsonl.
+
+CLI:
+
+    python scripts/init_deft_state.py \
+        --results-dir ~/workspace/results/run_20260805_090000 \
+        --workspace ~/workspace \
+        --dataset-root ~/workspace/data/iaa_v31_tao_ft \
+        --max-iterations 3 \
+        --metric-target 0.85 \
+        --platform docker \
+        # unpinned: illustrative CLI placeholder; executable default is release-managed below
+        --pyt-image nvcr.io/nvidia/tao/tao-toolkit:pyt \
+        # unpinned: illustrative CLI placeholder; executable default is release-managed below
+        --ds-image nvcr.io/nvidia/tao/tao-toolkit:ds \
+        --deft-config ~/workspace/specs/deft_config.yaml \
+        --tao-spec ~/workspace/specs/tao_spec.yaml
+
+On-disk layout recorded in `config.layout` follows the bundled IAA runtime
+conventions: baseline (zero-shot) evaluate artifacts live under
+${RESULTS_DIR}/zs/, iteration N artifacts under ${RESULTS_DIR}/iter_<N>/, and
+run-level shared artifacts under ${RESULTS_DIR}/iaa_splits/,
+${RESULTS_DIR}/embeddings/source/, and the two selection-history JSON files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+
+import yaml
+
+from metric_contract import validate_contract
+
+
+WORKFLOW = "tao-run-deft-iaa"
+PINNED_PYT_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"  # versions-key: images.tao_toolkit.pyt
+PINNED_DS_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services"  # versions-key: images.tao_toolkit.data_services
+RUN_SPEC_NAMES = (
+    "deft_config.yaml",
+    "tao_spec.yaml",
+    "text_embed_spec.yaml",
+    "image_embed_spec.yaml",
+    "mining_spec.yaml",
+    "approval.json",
+)
+
+_COMPLETED_STEP_VALUES = [
+    "dataset_setup",
+    "pool_embed",
+    "evaluate",
+    "gap_analysis",
+    "data_mining",
+    "history_select",
+    "visualize",
+    "train",
+    "loop_stop",
+]
+_STATUS_VALUES = ["pending", "in_progress", "complete", "failed"]
+
+
+def _parse_gpu_ids(raw: str, num_gpus: int) -> list[int]:
+    parts = [part.strip() for part in raw.split(",") if part.strip()]
+    if not parts:
+        raise ValueError('--gpu-ids must be a non-empty comma list, e.g. "0,1"')
+    try:
+        gpu_ids = [int(part) for part in parts]
+    except ValueError as exc:
+        raise ValueError(f"--gpu-ids must be a comma list of integers: {raw!r}") from exc
+    if any(gpu_id < 0 for gpu_id in gpu_ids):
+        raise ValueError(f"--gpu-ids must be non-negative device indices: {raw!r}")
+    if len(set(gpu_ids)) != len(gpu_ids):
+        raise ValueError(f"--gpu-ids contains duplicate device indices: {raw!r}")
+    if len(gpu_ids) != num_gpus:
+        raise ValueError(
+            f"--gpu-ids lists {len(gpu_ids)} device(s) but --num-gpus is {num_gpus}"
+        )
+    return gpu_ids
+
+
+def _resolve_dataset_root(root: pathlib.Path) -> pathlib.Path:
+    """Resolve the intended dataset root before dataset_setup materializes it."""
+    resolved = root.expanduser().resolve()
+    if resolved.exists() and not resolved.is_dir():
+        raise ValueError(f"--dataset-root exists but is not a directory: {resolved}")
+    return resolved
+
+
+def _workspace_child(path: pathlib.Path, workspace: pathlib.Path, name: str) -> pathlib.Path:
+    resolved = path.expanduser().resolve()
+    try:
+        relative = resolved.relative_to(workspace)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be under --workspace {workspace}: {resolved}") from exc
+    if relative == pathlib.Path("."):
+        raise ValueError(f"{name} must be a child of --workspace, not the workspace itself")
+    return resolved
+
+
+def _validate_metric_gate(
+    name: str, query_type: str, operator: str, target: float | None
+) -> dict:
+    """Reject malformed metric gates before they reach disk.
+
+    A missing --metric-target is legal: the gate then never passes and the
+    loop runs to --max-iterations. A present target must be a finite number,
+    and Rank-style metrics are fractions in [0, 1].
+    """
+    contract = validate_contract(
+        {
+            "metric_name": name,
+            "query_type": query_type,
+            "op": operator,
+            "target": target,
+        }
+    )
+    if target is not None and name.strip().lower().startswith("rank") and not 0.0 <= target <= 1.0:
+        raise ValueError(
+            f"--metric-target for {name} must be a fraction in [0, 1], got {target}"
+        )
+    return contract
+
+
+def _required_input_file(path: pathlib.Path, name: str) -> pathlib.Path:
+    expanded = path.expanduser()
+    resolved = expanded.resolve()
+    if not resolved.is_file():
+        raise ValueError(f"{name} must be an existing file: {path}")
+    if resolved.stat().st_size == 0:
+        raise ValueError(f"{name} must not be empty: {path}")
+    return resolved
+
+
+def _required_input_dir(path: pathlib.Path, name: str) -> pathlib.Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_dir():
+        raise ValueError(f"{name} must be an existing directory: {path}")
+    return resolved
+
+
+def _sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _validate_checksum_manifest(
+    manifest: pathlib.Path, archives: tuple[pathlib.Path, pathlib.Path]
+) -> None:
+    referenced: set[pathlib.Path] = set()
+    for line_number, raw in enumerate(manifest.read_text().splitlines(), 1):
+        line = raw.strip("\n")
+        if not line or line.lstrip().startswith("#"):
+            continue
+        match = re.fullmatch(r"[0-9A-Fa-f]{64} ([ *])(.+)", line)
+        if not match:
+            raise ValueError(
+                f"--checksums-file line {line_number} is not GNU SHA256 format"
+            )
+        filename = match.group(2)
+        if "\x00" in filename or filename.startswith("\\"):
+            raise ValueError(
+                "--checksums-file uses an unsupported escaped filename entry"
+            )
+        referenced.add((manifest.parent / filename).resolve())
+    missing = [str(path) for path in archives if path.resolve() not in referenced]
+    if missing:
+        raise ValueError(
+            "--checksums-file must bind both approved archives; missing "
+            + ", ".join(missing)
+        )
+
+
+def _python_tree_sha256(root: pathlib.Path) -> str:
+    files = sorted(path for path in root.rglob("*.py") if "__pycache__" not in path.parts)
+    if not files:
+        raise ValueError(f"bundled IAA runtime contains no Python files: {root}")
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _mapping(root: dict, key: str, source: str) -> dict:
+    value = root.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{source}.{key} must be an object")
+    return value
+
+
+def _load_run_config(args: argparse.Namespace) -> dict:
+    config_dir = args.deft_config.parent.resolve()
+    expected_config_dir = args.results_dir.resolve() / "config"
+    if config_dir != expected_config_dir:
+        raise ValueError(
+            f"prepared config directory must be {expected_config_dir}, got {config_dir}"
+        )
+    if args.tao_spec.parent.resolve() != config_dir:
+        raise ValueError("--deft-config and --tao-spec must share the run config directory")
+    spec_sha256: dict[str, str] = {}
+    for name in RUN_SPEC_NAMES:
+        spec_path = _required_input_file(config_dir / name, f"run config {name}")
+        spec_sha256[name] = _sha256(spec_path)
+    approval_path = config_dir / "approval.json"
+    approval = json.loads(approval_path.read_text())
+    expected_approval = {
+        "schema_version": "2",
+        "workflow": WORKFLOW,
+        "workspace": str(args.workspace.resolve()),
+        "results_dir": str(args.results_dir.resolve()),
+        "dataset_root": str(args.dataset_root.resolve()),
+        "iaa_deft_bundle_sha256": args.iaa_deft_bundle_sha256,
+        "images_archive": str(args.images_archive.resolve()),
+        "metadata_archive": str(args.metadata_archive.resolve()),
+        "checksums_file": (
+            str(args.checksums_file.resolve())
+            if args.checksums_file is not None
+            else None
+        ),
+        "requires_hf_token": args.requires_hf_token,
+        "max_iterations": args.max_iterations,
+        "metric_contract": args.metric_contract,
+        "pyt_image": args.pyt_image,
+        "ds_image": args.ds_image,
+    }
+    if approval != expected_approval:
+        raise ValueError(
+            "approval.json does not match the approved initialization inputs; "
+            "rerun config preparation in a fresh results directory"
+        )
+    deft = yaml.safe_load(args.deft_config.read_text())
+    tao = yaml.safe_load(args.tao_spec.read_text())
+    if not isinstance(deft, dict) or not isinstance(tao, dict):
+        raise ValueError("--deft-config and --tao-spec must have object roots")
+    iteration = _mapping(deft, "iteration", "deft_config")
+    experiment = _mapping(deft, "experiment", "deft_config")
+    mining = _mapping(deft, "mining", "deft_config")
+    history = _mapping(mining, "history_aware", "deft_config.mining")
+    training = _mapping(deft, "training", "deft_config")
+    gap = _mapping(deft, "gap_analysis", "deft_config")
+    train = _mapping(tao, "train", "tao_spec")
+    evaluate = _mapping(tao, "evaluate", "tao_spec")
+    if iteration.get("start") != 1:
+        raise ValueError("prepared deft_config iteration.start must be 1")
+    if iteration.get("end") != args.max_iterations:
+        raise ValueError(
+            "prepared deft_config iteration.end must equal --max-iterations"
+        )
+    if pathlib.Path(str(experiment.get("results_path", ""))).resolve() != args.results_dir.resolve():
+        raise ValueError("prepared deft_config experiment.results_path must equal --results-dir")
+    num_gpus = train.get("num_gpus")
+    gpu_ids = train.get("gpu_ids")
+    if not isinstance(num_gpus, int) or num_gpus < 1:
+        raise ValueError("prepared tao_spec train.num_gpus must be >= 1")
+    if not isinstance(gpu_ids, list):
+        raise ValueError("prepared tao_spec train.gpu_ids must be a list")
+    parsed_gpu_ids = _parse_gpu_ids(",".join(str(item) for item in gpu_ids), num_gpus)
+    if evaluate.get("num_gpus") != num_gpus or evaluate.get("gpu_ids") != gpu_ids:
+        raise ValueError("prepared TAO train/evaluate GPU shapes must match")
+    training_epochs = train.get("num_epochs")
+    if not isinstance(training_epochs, int) or training_epochs < 1:
+        raise ValueError("prepared tao_spec train.num_epochs must be >= 1")
+    if gap.get("metric_name") != args.metric_contract["metric_name"]:
+        raise ValueError(
+            "prepared gap_analysis.metric_name must match the immutable "
+            "metric contract"
+        )
+    replay = float(history.get("replay_fraction"))
+    if not 0.0 <= replay <= 1.0:
+        raise ValueError("prepared replay_fraction must be in [0, 1]")
+    boolean_fields = {
+        "history_aware.enabled": history.get("enabled"),
+        "training.continual_dataset": training.get("continual_dataset"),
+        "training.continual_model": training.get("continual_model"),
+        "experiment.visualize": experiment.get("visualize"),
+        "experiment.visualize_embeddings": experiment.get("visualize_embeddings"),
+    }
+    invalid_booleans = [name for name, value in boolean_fields.items() if not isinstance(value, bool)]
+    if invalid_booleans:
+        raise ValueError(
+            "prepared boolean fields are invalid: " + ", ".join(invalid_booleans)
+        )
+    for name, value in (
+        ("mining.topn", mining.get("topn")),
+        ("gap_analysis.target_query_count", gap.get("target_query_count")),
+    ):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"prepared {name} must be an integer >= 1")
+    if mining.get("knn_metric") not in {"cosine", "euclidean"}:
+        raise ValueError("prepared mining.knn_metric must be cosine or euclidean")
+    for key in ("train_config", "eval_config"):
+        if pathlib.Path(str(experiment.get(key, ""))).resolve() != args.tao_spec.resolve():
+            raise ValueError(
+                f"prepared deft_config experiment.{key} must equal --tao-spec"
+            )
+    return {
+        "config_dir": str(config_dir),
+        "approval_manifest": str(approval_path),
+        "spec_sha256": spec_sha256,
+        "deft_config_sha256": _sha256(args.deft_config),
+        "tao_spec_sha256": _sha256(args.tao_spec),
+        "training_epochs": training_epochs,
+        "num_gpus": num_gpus,
+        "gpu_ids": parsed_gpu_ids,
+        "history_aware": history.get("enabled"),
+        "replay_fraction": replay,
+        "mining_topn": int(mining.get("topn")),
+        "knn_metric": str(mining.get("knn_metric")),
+        "target_query_count": int(gap.get("target_query_count")),
+        "continual_dataset": training.get("continual_dataset"),
+        "continual_model": training.get("continual_model"),
+        "visualize": experiment.get("visualize"),
+        "visualize_embeddings": experiment.get("visualize_embeddings"),
+    }
+
+
+def build_state(args: argparse.Namespace) -> dict:
+    ws = args.workspace.expanduser().resolve()
+    rd = args.results_dir.expanduser().resolve()
+
+    state = {
+        "schema_version": "3",
+        "workflow": WORKFLOW,
+        "started_at": datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec="seconds"
+        ),
+        "results_dir": str(rd),
+        "max_iterations": args.max_iterations,
+        "current_iteration": 0,
+        "gate_met": False,
+        # The canonical contract shape record_metric_result.py and
+        # metric_contract.contract_from_state consume.
+        "metric_contract": dict(args.metric_contract),
+        "config": {
+            "workspace": str(ws),
+            "dataset_root": str(args.dataset_root),
+            "iaa_deft_bundle_sha256": args.iaa_deft_bundle_sha256,
+            "images_archive": str(args.images_archive),
+            "metadata_archive": str(args.metadata_archive),
+            "checksums_file": (
+                str(args.checksums_file) if args.checksums_file is not None else None
+            ),
+            "checksums_file_sha256": (
+                _sha256(args.checksums_file)
+                if args.checksums_file is not None
+                else None
+            ),
+            "requires_hf_token": args.requires_hf_token,
+            "platform": args.platform,
+            "pyt_image": args.pyt_image,
+            "ds_image": args.ds_image,
+            "deft_config": str(args.deft_config),
+            "tao_spec": str(args.tao_spec),
+            **args.run_config,
+            # Bundled IAA runtime conventions; iteration labels map to
+            # directories as baseline -> zs/ and iterN -> iter_<N>/.
+            "layout": {
+                "baseline_dir": str(rd / "zs"),
+                "iteration_dir_template": str(rd / "iter_{N}"),
+                "iaa_splits_dir": str(rd / "iaa_splits"),
+                "source_embeddings_dir": str(rd / "embeddings" / "source"),
+                "caption_selection_history": str(
+                    rd / "caption_selection_history.json"
+                ),
+                "mining_selection_history": str(
+                    rd / "mining_selection_history.json"
+                ),
+            },
+        },
+        "iterations": {"baseline": {"status": "pending"}},
+        "_completed_step_values": list(_COMPLETED_STEP_VALUES),
+        "_status_values": list(_STATUS_VALUES),
+    }
+    return state
+
+
+def write_atomic(path: pathlib.Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Initialize deft_state.json for an IAA CLIP DEFT run with a "
+            "guaranteed-unique key set. Refuses to reinitialize an existing "
+            "file."
+        ),
+    )
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--workspace", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--dataset-root",
+        required=True,
+        type=pathlib.Path,
+        help=(
+            "Intended iaa_v31_tao_ft directory. It may not exist until "
+            "baseline/dataset_setup materializes it."
+        ),
+    )
+    parser.add_argument("--images-archive", required=True, type=pathlib.Path)
+    parser.add_argument("--metadata-archive", required=True, type=pathlib.Path)
+    parser.add_argument("--checksums-file", type=pathlib.Path)
+    parser.add_argument(
+        "--requires-hf-token",
+        action="store_true",
+        help="Must match approval.json; token values are never persisted.",
+    )
+    parser.add_argument("--max-iterations", required=True, type=int)
+    parser.add_argument(
+        "--metric-name",
+        default="Rank-1",
+        help="Primary metric key gating the loop (default Rank-1).",
+    )
+    parser.add_argument(
+        "--metric-query-type",
+        default="medium",
+        help="Query split the gate reads the metric from (default medium).",
+    )
+    parser.add_argument(
+        "--metric-op",
+        default=">=",
+        choices=(">=", ">", "<=", "<"),
+        help="Success comparison operator.",
+    )
+    parser.add_argument(
+        "--metric-target",
+        type=float,
+        help=(
+            "Numeric success target. When absent the gate never passes and "
+            "the loop runs to --max-iterations."
+        ),
+    )
+    parser.add_argument("--platform", default="docker", choices=("docker",))
+    parser.add_argument(
+        "--pyt-image",
+        required=True,
+        help="TAO PyTorch container URI used for train/evaluate.",
+    )
+    parser.add_argument(
+        "--ds-image",
+        required=True,
+        help="TAO data-services container URI used for embedding/mining.",
+    )
+    parser.add_argument(
+        "--deft-config",
+        required=True,
+        type=pathlib.Path,
+        help="The run's iaa_deft loop config file.",
+    )
+    parser.add_argument(
+        "--tao-spec",
+        required=True,
+        type=pathlib.Path,
+        help="The run's TAO experiment spec file.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        args.metric_contract = _validate_metric_gate(
+            args.metric_name, args.metric_query_type, args.metric_op, args.metric_target
+        )
+        args.dataset_root = _resolve_dataset_root(args.dataset_root)
+        iaa_runtime = _required_input_dir(
+            pathlib.Path(__file__).resolve().parent / "iaa_deft",
+            "bundled IAA runtime",
+        )
+        args.iaa_deft_bundle_sha256 = _python_tree_sha256(iaa_runtime)
+        args.workspace = _required_input_dir(args.workspace, "--workspace")
+        if args.workspace == pathlib.Path(args.workspace.anchor):
+            raise ValueError("--workspace must not be a filesystem root")
+        args.results_dir = _workspace_child(
+            args.results_dir, args.workspace, "--results-dir"
+        )
+        args.dataset_root = _workspace_child(
+            args.dataset_root, args.workspace, "--dataset-root"
+        )
+        if (
+            args.results_dir in args.dataset_root.parents
+            or args.dataset_root in args.results_dir.parents
+        ):
+            raise ValueError(
+                "--results-dir and --dataset-root must not contain one another"
+            )
+        if args.dataset_root.parent == args.workspace:
+            raise ValueError(
+                "--dataset-root must be nested below a workspace data directory"
+            )
+        args.images_archive = _required_input_file(args.images_archive, "--images-archive")
+        args.metadata_archive = _required_input_file(args.metadata_archive, "--metadata-archive")
+        if args.checksums_file is not None:
+            args.checksums_file = _required_input_file(args.checksums_file, "--checksums-file")
+            _validate_checksum_manifest(
+                args.checksums_file,
+                (args.images_archive, args.metadata_archive),
+            )
+        args.deft_config = _required_input_file(args.deft_config, "--deft-config")
+        args.tao_spec = _required_input_file(args.tao_spec, "--tao-spec")
+        args.run_config = _load_run_config(args)
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        KeyError,
+        AttributeError,
+        yaml.YAMLError,
+    ) as exc:
+        print(f"init_deft_state: {exc}", file=sys.stderr)
+        return 2
+
+    positive_ints = {
+        "max_iterations": args.max_iterations,
+    }
+    invalid = {name: value for name, value in positive_ints.items() if value <= 0}
+    if invalid:
+        detail = ", ".join(f"{name}={value}" for name, value in invalid.items())
+        print(
+            f"init_deft_state: positive integers required ({detail})",
+            file=sys.stderr,
+        )
+        return 2
+    if args.pyt_image != PINNED_PYT_IMAGE or args.ds_image != PINNED_DS_IMAGE:
+        print(
+            "init_deft_state: --pyt-image and --ds-image must be the pinned "
+            "IAA workflow images",
+            file=sys.stderr,
+        )
+        return 2
+
+    out = args.results_dir.expanduser().resolve() / "deft_state.json"
+    if out.exists():
+        print(
+            f"init_deft_state: refusing to reinitialize {out}; deft_state.json "
+            "is written exactly once per run. Resume reads disk state — to "
+            "start over, choose a fresh --results-dir.",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        state = build_state(args)
+        write_atomic(out, state)
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        print(f"init_deft_state: {exc}", file=sys.stderr)
+        return 2
+    print(f"init_deft_state: wrote {out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/log_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/log_stage.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Append a stage entry to results/loop_log.jsonl.
+
+Disk-truth invariant: never trust in-memory seq across turns. Always re-read
+the last entry of the log to compute next_seq. Context compaction is invisible
+to this writer — there is no "compacted" flag and no detection branch. seq is
+strict and gap-free, starting at 0.
+
+`tokens` remains null because runtime-neutral stage scripts cannot measure an
+agent harness's context usage.
+
+Library usage:
+
+    from log_stage import append_stage
+    import time, pathlib
+
+    t0 = time.monotonic()
+    # ... run the stage ...
+    append_stage(
+        pathlib.Path(f"{RESULTS_DIR}/loop_log.jsonl"),
+        iteration="iter1",
+        stage="data_mining",
+        status="ok",
+        summary="mined 250 candidate pairs from 10 gap clusters",
+        duration_s=time.monotonic() - t0,
+    )
+
+This is an internal module. ``commit_stage.py`` is the only supported writer.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import math
+import pathlib
+
+_VALID_STATUSES = {"ok", "error", "skip"}
+_VALID_STAGES = {
+    "dataset_setup",
+    "pool_embed",
+    "evaluate",
+    "gap_analysis",
+    "data_mining",
+    "history_select",
+    "visualize",
+    "train",
+    "loop_stop",
+}
+
+
+def next_seq(log_path: pathlib.Path) -> int:
+    """Return seq for the next entry: last entry's seq + 1, or 0 if no log yet."""
+    if not isinstance(log_path, pathlib.Path):
+        raise TypeError(
+            f"log_path must be pathlib.Path, got {type(log_path).__name__}"
+        )
+    if not log_path.exists():
+        return 0
+    last = None
+    with log_path.open() as f:
+        for line in f:
+            if line.strip():
+                last = line
+    if last is None:
+        return 0
+    try:
+        prev_seq = json.loads(last)["seq"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        raise ValueError(
+            f"corrupt last line in {log_path}: {exc}; refusing to append"
+        ) from exc
+    if not isinstance(prev_seq, int) or isinstance(prev_seq, bool):
+        raise ValueError(
+            f"non-integer seq in last line of {log_path}: {prev_seq!r}"
+        )
+    return prev_seq + 1
+
+
+def append_stage(
+    log_path: pathlib.Path,
+    *,
+    iteration: str,
+    stage: str,
+    status: str,
+    summary: str,
+    duration_s: float | None = None,
+    tokens: int | None = None,
+) -> None:
+    """Append one stage event. Caller is responsible for measuring duration.
+
+    Raises:
+        TypeError: any argument has the wrong type.
+        ValueError: any argument is empty, out-of-range, or otherwise invalid.
+    """
+    if not isinstance(log_path, pathlib.Path):
+        raise TypeError(
+            f"log_path must be pathlib.Path, got {type(log_path).__name__}"
+        )
+    if not isinstance(iteration, str) or not iteration:
+        raise ValueError(f"iteration must be a non-empty string, got {iteration!r}")
+    if not isinstance(stage, str) or not stage:
+        raise ValueError(f"stage must be a non-empty string, got {stage!r}")
+    if stage not in _VALID_STAGES:
+        raise ValueError(
+            f"stage must be one of {sorted(_VALID_STAGES)}, got {stage!r}"
+        )
+    if status not in _VALID_STATUSES:
+        raise ValueError(
+            f"status must be one of {sorted(_VALID_STATUSES)}, got {status!r}"
+        )
+    if not isinstance(summary, str) or not summary:
+        raise ValueError(f"summary must be a non-empty string, got {summary!r}")
+    if duration_s is not None:
+        if isinstance(duration_s, bool) or not isinstance(duration_s, (int, float)):
+            raise TypeError(
+                f"duration_s must be a number or None, got "
+                f"{type(duration_s).__name__}"
+            )
+        if not math.isfinite(duration_s):
+            raise ValueError(f"duration_s must be finite, got {duration_s!r}")
+        if duration_s < 0:
+            raise ValueError(f"duration_s must be >= 0, got {duration_s}")
+        duration_s = float(duration_s)
+    if tokens is not None:
+        if not isinstance(tokens, int) or isinstance(tokens, bool):
+            raise TypeError(
+                f"tokens must be int or None, got {type(tokens).__name__}"
+            )
+        if tokens < 0:
+            raise ValueError(f"tokens must be >= 0, got {tokens}")
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry = {
+        "seq": next_seq(log_path),
+        "ts": datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        ),
+        "iteration": iteration,
+        "stage": stage,
+        "status": status,
+        "summary": summary,
+        "duration_s": duration_s,
+        "tokens": tokens,
+    }
+    with log_path.open("a") as f:
+        f.write(json.dumps(entry) + "\n")

--- a/skills/applications/tao-run-deft-iaa/scripts/metric_contract.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/metric_contract.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared parsing and comparison helpers for IAA DEFT metric contracts.
+
+A Image Attribute Augmentation (IAA) metric contract is a dict with the keys
+``metric_name``, ``query_type``, ``op`` and ``target``.  ``target`` may be
+``None``: that is a valid contract meaning "no gate; run to max_iterations",
+and a null-target contract never passes.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import Any, Iterable
+
+
+OPERATORS = {"<", "<=", ">", ">="}
+MINIMIZING_OPERATORS = {"<", "<="}
+_OPERATOR_ALIASES = {
+    "lt": "<",
+    "le": "<=",
+    "lte": "<=",
+    "gt": ">",
+    "ge": ">=",
+    "gte": ">=",
+}
+
+# Gate-able metrics from nvidia_iaa_metrics_aggregate.csv. All are
+# higher-is-better except Zero@5 (fraction of queries with zero hits in the
+# top five results), which is lower-is-better.
+METRIC_NAMES = ("mAP", "Rank-1", "Rank-5", "Separability", "Match@5", "Zero@5")
+LOWER_IS_BETTER_METRICS = {"Zero@5"}
+# The IAA aggregate evaluator emits one row for each of these three
+# gate-able splits. Broader caption categories remain valid gap-analysis input
+# filters, but they are not KPI rows in nvidia_iaa_metrics_aggregate.csv.
+QUERY_TYPES = ("easy", "medium", "hard")
+
+
+def normalize_operator(value: str) -> str:
+    operator = _OPERATOR_ALIASES.get(str(value).strip().lower(), str(value).strip())
+    if operator not in OPERATORS:
+        raise ValueError(
+            f"metric operator must be one of {sorted(OPERATORS)}, got {value!r}"
+        )
+    return operator
+
+
+def finite_number(value: Any, *, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a finite number, got {value!r}")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{field} must be finite, got {value!r}")
+    return result
+
+
+def compare(value: float, operator: str, target: float) -> bool:
+    operator = normalize_operator(operator)
+    if operator == "<":
+        return value < target
+    if operator == "<=":
+        return value <= target
+    if operator == ">":
+        return value > target
+    return value >= target
+
+
+def normalize_metric_name(value: Any) -> str:
+    """Return the canonical spelling of a known IAA metric name."""
+    text = str(value).strip()
+    canonical = {name.lower(): name for name in METRIC_NAMES}.get(text.lower())
+    if canonical is None:
+        raise ValueError(
+            f"metric_contract.metric_name must be one of {list(METRIC_NAMES)}, "
+            f"got {value!r}"
+        )
+    return canonical
+
+
+def normalize_query_type(value: Any) -> str:
+    """Return the canonical spelling of a known IAA query type."""
+    text = str(value).strip()
+    canonical = {name.lower(): name for name in QUERY_TYPES}.get(text.lower())
+    if canonical is None:
+        raise ValueError(
+            f"metric_contract.query_type must be one of {list(QUERY_TYPES)}, "
+            f"got {value!r}"
+        )
+    return canonical
+
+
+def metric_direction(metric_name: str) -> str:
+    """Return ``"lower"`` for lower-is-better metrics, else ``"higher"``."""
+    return "lower" if normalize_metric_name(metric_name) in LOWER_IS_BETTER_METRICS else "higher"
+
+
+def validate_contract(contract: dict[str, Any]) -> dict[str, Any]:
+    """Validate and normalize an IAA metric contract.
+
+    Unknown metric names, query types, and operators raise ``ValueError``.
+    An operator whose gate direction disagrees with the metric's natural
+    direction (e.g. ``Rank-1 <= x`` or ``Zero@5 >= x``) only warns: it is
+    unusual but a customer may legitimately request it.  A ``None`` target
+    is valid and means "no gate; run to max_iterations".
+    """
+    if not isinstance(contract, dict):
+        raise ValueError("metric_contract must be an object")
+    metric_name = normalize_metric_name(contract.get("metric_name"))
+    query_type = normalize_query_type(contract.get("query_type"))
+    operator = normalize_operator(str(contract.get("op", "")))
+    raw_target = contract.get("target")
+    target = (
+        None
+        if raw_target is None
+        else finite_number(raw_target, field="metric_contract.target")
+    )
+
+    minimizing = operator in MINIMIZING_OPERATORS
+    if metric_direction(metric_name) == "lower" and not minimizing:
+        warnings.warn(
+            f"{metric_name} is lower-is-better but op {operator!r} gates upward; "
+            "double-check the metric contract",
+            stacklevel=2,
+        )
+    elif metric_direction(metric_name) == "higher" and minimizing:
+        warnings.warn(
+            f"{metric_name} is higher-is-better but op {operator!r} gates downward; "
+            "double-check the metric contract",
+            stacklevel=2,
+        )
+
+    normalized = dict(contract)
+    normalized.update(
+        {
+            "metric_name": metric_name,
+            "query_type": query_type,
+            "op": operator,
+            "target": target,
+        }
+    )
+    return normalized
+
+
+def contract_from_state(state: dict[str, Any]) -> dict[str, Any]:
+    contract = state.get("metric_contract")
+    if contract is None:
+        raise ValueError("state.metric_contract is required")
+    return validate_contract(contract)
+
+
+def render_target(contract: dict[str, Any]) -> str:
+    contract = validate_contract(contract)
+    if contract["target"] is None:
+        return (
+            f"{contract['metric_name']} ({contract['query_type']}): "
+            "no gate; run to max_iterations"
+        )
+    return (
+        f"{contract['metric_name']} ({contract['query_type']}) "
+        f"{contract['op']} {contract['target']:g}"
+    )
+
+
+def result_from_iteration(
+    info: dict[str, Any], contract: dict[str, Any]
+) -> dict[str, Any] | None:
+    raw = info.get("metric_result")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("metric_result must be an object")
+    result = dict(raw)
+    result_metric = str(result.get("metric_name", "")).strip()
+    if result_metric.lower() != contract["metric_name"].lower():
+        raise ValueError(
+            f"metric_result.metric_name={result.get('metric_name')!r} does not "
+            f"match contract metric_name {contract['metric_name']!r}"
+        )
+    result["metric_name"] = contract["metric_name"]
+    result_query_type = str(result.get("query_type", "")).strip()
+    if result_query_type.lower() != contract["query_type"].lower():
+        raise ValueError(
+            f"metric_result.query_type={result.get('query_type')!r} does not "
+            f"match contract query_type {contract['query_type']!r}"
+        )
+    result["query_type"] = contract["query_type"]
+    result["value"] = finite_number(result.get("value"), field="metric_result.value")
+    return result
+
+
+def result_passes(
+    contract: dict[str, Any], result: dict[str, Any]
+) -> tuple[bool, list[str]]:
+    """Return (passed, failed-metric-names) for a result against a contract.
+
+    A null-target contract is ungated: it never passes (the loop runs to
+    max_iterations) and reports no failures.
+    """
+    value = finite_number(result.get("value"), field="metric_result.value")
+    if contract.get("target") is None:
+        return False, []
+    target = finite_number(contract.get("target"), field="metric_contract.target")
+    failures: list[str] = []
+    if not compare(value, contract["op"], target):
+        failures.append(contract["metric_name"])
+    return not failures, failures
+
+
+def pick_best(
+    candidates: Iterable[tuple[str, dict[str, Any], dict[str, Any]]],
+    contract: dict[str, Any],
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """Pick the best (label, info, result) candidate for the contract metric.
+
+    Ordering follows the approved comparison operator.  The contract is the
+    source of truth even when its direction is unusual for the metric.
+    """
+    materialized = list(candidates)
+    if not materialized:
+        raise ValueError("no metric-bearing candidates")
+    reverse = normalize_operator(contract["op"]) not in MINIMIZING_OPERATORS
+    return sorted(
+        materialized,
+        key=lambda item: float(item[2]["value"]),
+        reverse=reverse,
+    )[0]

--- a/skills/applications/tao-run-deft-iaa/scripts/parse_iaa_metrics.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/parse_iaa_metrics.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract one IAA metric from nvidia_iaa_metrics_aggregate.csv into JSON.
+
+TAO ``clip evaluate`` writes a CSV with one row per QueryType:
+
+    Dataset,QueryType,EasyAttribute,num_queries,gallery_size,avg_gt_per_query,\
+mAP,Rank-1,Rank-5,Separability,Match@5,Zero@5,First Pos
+
+This script selects the row for ``--query-type``, reads the ``--metric-name``
+column, optionally gates it against ``--target`` with ``--op``, and writes a
+metric_result.json consumed by record_metric_result.py.  Exit status is 0
+whenever the JSON is written successfully — even when the gate is not met —
+and nonzero only on structural errors (missing file/column/row, bad value).
+Pure stdlib on purpose so it runs under any provisioned interpreter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import pathlib
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from typing import Any
+
+WORKFLOW = "tao-run-deft-iaa"
+SCHEMA_VERSION = "1"
+OPERATORS = (">=", ">", "<=", "<")
+# Identity columns of the aggregate CSV; every other column is numeric and a
+# valid --metric-name.
+IDENTITY_COLUMNS = ("Dataset", "QueryType", "EasyAttribute")
+
+
+def _compare(value: float, operator: str, target: float) -> bool:
+    if operator == "<":
+        return value < target
+    if operator == "<=":
+        return value <= target
+    if operator == ">":
+        return value > target
+    if operator == ">=":
+        return value >= target
+    raise ValueError(f"metric operator must be one of {list(OPERATORS)}, got {operator!r}")
+
+
+def _load_rows(csv_path: pathlib.Path) -> tuple[list[str], list[dict[str, str]]]:
+    with csv_path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+    if not fieldnames:
+        raise ValueError(f"metrics CSV has no header row: {csv_path}")
+    if "QueryType" not in fieldnames:
+        raise ValueError(
+            f"metrics CSV is missing the QueryType column: {csv_path} "
+            f"(columns: {fieldnames})"
+        )
+    if not rows:
+        raise ValueError(f"metrics CSV has no data rows: {csv_path}")
+    return fieldnames, rows
+
+
+def _select_row(rows: list[dict[str, str]], query_type: str) -> dict[str, str]:
+    wanted = query_type.strip().lower()
+    matches = [
+        row
+        for row in rows
+        if str(row.get("QueryType", "")).strip().lower() == wanted
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        datasets = sorted(
+            {str(row.get("Dataset", "")).strip() or "<empty>" for row in matches}
+        )
+        raise ValueError(
+            f"query type {query_type!r} is ambiguous in metrics CSV: "
+            f"{len(matches)} matching rows (Dataset values: {datasets})"
+        )
+    available = sorted(
+        {str(row.get("QueryType", "")).strip() for row in rows} - {""}
+    )
+    raise ValueError(
+        f"query type {query_type!r} not found in metrics CSV; "
+        f"available query types: {available}"
+    )
+
+
+def _resolve_metric_column(fieldnames: list[str], metric_name: str) -> str:
+    numeric_columns = [name for name in fieldnames if name not in IDENTITY_COLUMNS]
+    lookup = {name.lower(): name for name in numeric_columns}
+    resolved = lookup.get(metric_name.strip().lower())
+    if resolved is None:
+        raise ValueError(
+            f"metric {metric_name!r} is not a numeric column of the metrics CSV; "
+            f"available metric columns: {numeric_columns}"
+        )
+    return resolved
+
+
+def _write_atomic(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def build_result(args: argparse.Namespace) -> dict[str, Any]:
+    csv_path = args.metrics_csv.expanduser()
+    if not csv_path.is_file():
+        raise ValueError(f"metrics CSV must be an existing file: {csv_path}")
+    csv_path = csv_path.resolve()
+
+    fieldnames, rows = _load_rows(csv_path)
+    metric_column = _resolve_metric_column(fieldnames, args.metric_name)
+    row = _select_row(rows, args.query_type)
+
+    raw_value = str(row.get(metric_column) or "").strip()
+    try:
+        value = float(raw_value)
+    except ValueError:
+        raise ValueError(
+            f"metric column {metric_column!r} for query type "
+            f"{row.get('QueryType')!r} is not numeric: {raw_value!r}"
+        ) from None
+    if not math.isfinite(value):
+        raise ValueError(
+            f"metric column {metric_column!r} for query type "
+            f"{row.get('QueryType')!r} must be finite, got {raw_value!r}"
+        )
+    if not re.fullmatch(r"baseline|iter[1-9][0-9]*", args.iter_label):
+        raise ValueError("--iter-label must be baseline or iterN (N >= 1)")
+
+    # A null target is a valid "no gate" contract: never passed, exit 0.
+    passed = False if args.target is None else _compare(value, args.op, args.target)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "workflow": WORKFLOW,
+        "iter_label": args.iter_label,
+        "metric_name": metric_column,
+        "query_type": str(row.get("QueryType", "")).strip(),
+        "value": value,
+        "op": args.op,
+        "target": args.target,
+        "passed": passed,
+        "source_csv": str(csv_path),
+        "row": dict(row),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--metrics-csv",
+        required=True,
+        type=pathlib.Path,
+        help="Path to nvidia_iaa_metrics_aggregate.csv",
+    )
+    parser.add_argument(
+        "--metric-name",
+        default="Rank-1",
+        help="Numeric column header to extract (default: Rank-1)",
+    )
+    parser.add_argument(
+        "--query-type",
+        default="medium",
+        help="QueryType row to select, case-insensitive (default: medium)",
+    )
+    parser.add_argument("--op", default=">=", choices=OPERATORS)
+    parser.add_argument(
+        "--target",
+        type=float,
+        default=None,
+        help="Gate target; omit for an ungated run (passed is always false)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=pathlib.Path,
+        help="Path to write metric_result.json",
+    )
+    parser.add_argument(
+        "--iter-label", required=True, help='"baseline" or "iter1", "iter2", ...'
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        result = build_result(args)
+        output_path = args.output.expanduser().resolve()
+        _write_atomic(output_path, result)
+    except (OSError, ValueError, csv.Error) as exc:
+        print(f"parse_iaa_metrics: {exc}", file=sys.stderr)
+        return 2
+    target = "none" if result["target"] is None else f"{result['target']:g}"
+    print(
+        f"metric={result['metric_name']} query_type={result['query_type']} "
+        f"value={result['value']:.6g} op={result['op']} target={target} "
+        f"passed={str(result['passed']).lower()} output={output_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Materialize one immutable, run-specific IAA DEFT configuration.
+
+The canonical templates remain unchanged under ``specs/``. This command copies
+them into ``RESULTS_DIR/config`` and applies only values approved in the
+pre-flight summary.  All paths written to the DEFT config are absolute host
+paths, so later tool calls do not depend on a previous ``cd`` or ``export``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+from typing import Any
+
+import yaml
+
+from metric_contract import validate_contract
+
+
+SPEC_NAMES = (
+    "deft_config.yaml",
+    "tao_spec.yaml",
+    "text_embed_spec.yaml",
+    "image_embed_spec.yaml",
+    "mining_spec.yaml",
+)
+PINNED_PYT_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"  # versions-key: images.tao_toolkit.pyt
+PINNED_DS_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services"  # versions-key: images.tao_toolkit.data_services
+
+
+def _bool(value: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in {"true", "1", "yes"}:
+        return True
+    if lowered in {"false", "0", "no"}:
+        return False
+    raise argparse.ArgumentTypeError(f"expected true or false, got {value!r}")
+
+
+def _gpu_ids(raw: str, count: int) -> list[int]:
+    try:
+        values = [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise ValueError("--gpu-ids must be a comma-separated integer list") from exc
+    if len(values) != count or len(set(values)) != len(values) or any(v < 0 for v in values):
+        raise ValueError(
+            "--gpu-ids must contain exactly --num-gpus distinct non-negative IDs"
+        )
+    return values
+
+
+def _workspace_child(path: pathlib.Path, workspace: pathlib.Path, name: str) -> pathlib.Path:
+    resolved = path.expanduser().resolve()
+    try:
+        relative = resolved.relative_to(workspace)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be under --workspace {workspace}: {resolved}") from exc
+    if relative == pathlib.Path("."):
+        raise ValueError(f"{name} must be a child of --workspace, not the workspace itself")
+    return resolved
+
+
+def _load_yaml(path: pathlib.Path) -> dict[str, Any]:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise ValueError(f"missing or empty template: {path}")
+    payload = yaml.safe_load(path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"YAML root must be an object: {path}")
+    return payload
+
+
+def _existing_path(path: pathlib.Path, name: str, *, directory: bool) -> pathlib.Path:
+    resolved = path.expanduser().resolve()
+    valid = resolved.is_dir() if directory else resolved.is_file()
+    if not valid or (not directory and resolved.stat().st_size == 0):
+        kind = "directory" if directory else "non-empty file"
+        raise ValueError(f"{name} must be an existing {kind}: {resolved}")
+    return resolved
+
+
+def _python_tree_sha256(root: pathlib.Path) -> str:
+    files = sorted(path for path in root.rglob("*.py") if "__pycache__" not in path.parts)
+    if not files:
+        raise ValueError(f"bundled IAA runtime contains no Python files: {root}")
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _atomic_yaml(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False, allow_unicode=True)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _copy_atomic(source: pathlib.Path, destination: pathlib.Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=destination.name + ".", suffix=".tmp", dir=str(destination.parent)
+    )
+    os.close(fd)
+    try:
+        shutil.copyfile(source, temporary)
+        os.replace(temporary, destination)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def materialize(args: argparse.Namespace) -> dict[str, Any]:
+    skill_root = pathlib.Path(__file__).resolve().parent.parent
+    templates = skill_root / "specs"
+    runtime_dir = skill_root / "scripts" / "iaa_deft"
+    runtime_sha256 = _python_tree_sha256(runtime_dir)
+    workspace = args.workspace.expanduser().resolve()
+    if not workspace.is_dir() or workspace == pathlib.Path(workspace.anchor):
+        raise ValueError(f"--workspace must be an existing non-root directory: {workspace}")
+    results_dir = _workspace_child(args.results_dir, workspace, "--results-dir")
+    dataset_root = _workspace_child(args.dataset_root, workspace, "--dataset-root")
+    images_archive = _existing_path(
+        args.images_archive, "--images-archive", directory=False
+    )
+    metadata_archive = _existing_path(
+        args.metadata_archive, "--metadata-archive", directory=False
+    )
+    checksums_file = (
+        _existing_path(args.checksums_file, "--checksums-file", directory=False)
+        if args.checksums_file is not None
+        else None
+    )
+    if dataset_root.parent == workspace:
+        raise ValueError(
+            "--dataset-root must be nested below a workspace data directory "
+            "(for example <workspace>/data/iaa_v31_tao_ft)"
+        )
+    if results_dir in dataset_root.parents or dataset_root in results_dir.parents:
+        raise ValueError("--results-dir and --dataset-root must not contain one another")
+    if (results_dir / "deft_state.json").exists():
+        raise ValueError(
+            "refusing to rewrite config for an initialized run; resume from "
+            "deft_state.json or choose a fresh --results-dir"
+        )
+    config_dir = results_dir / "config"
+
+    positive = {
+        "max_iterations": args.max_iterations,
+        "training_epochs": args.training_epochs,
+        "num_gpus": args.num_gpus,
+        "mining_topn": args.mining_topn,
+        "target_query_count": args.target_query_count,
+    }
+    invalid = {key: value for key, value in positive.items() if value < 1}
+    if invalid:
+        raise ValueError(
+            "positive integers required: "
+            + ", ".join(f"{key}={value}" for key, value in invalid.items())
+        )
+    if not 0.0 <= args.replay_fraction <= 1.0:
+        raise ValueError("--replay-fraction must be in [0, 1]")
+    if args.knn_metric not in {"cosine", "euclidean"}:
+        raise ValueError("--knn-metric must be cosine or euclidean")
+    gpu_ids = _gpu_ids(args.gpu_ids, args.num_gpus)
+    metric_contract = validate_contract(
+        {
+            "metric_name": args.metric_name,
+            "query_type": args.metric_query_type,
+            "op": args.metric_op,
+            "target": args.metric_target,
+        }
+    )
+
+    deft = _load_yaml(templates / "deft_config.yaml")
+    tao = _load_yaml(templates / "tao_spec.yaml")
+
+    deft["experiment"].update(
+        {
+            "results_path": str(results_dir),
+            "train_config": str(config_dir / "tao_spec.yaml"),
+            "eval_config": str(config_dir / "tao_spec.yaml"),
+            "visualize": args.visualize,
+            "visualize_embeddings": args.visualize_embeddings,
+        }
+    )
+    deft["iteration"].update({"start": 1, "end": args.max_iterations})
+    deft["training"].update(
+        {
+            "continual_model": args.continual_model,
+            "continual_dataset": args.continual_dataset,
+        }
+    )
+    deft["mining"].update(
+        {"topn": args.mining_topn, "knn_metric": args.knn_metric}
+    )
+    deft["mining"].setdefault("history_aware", {}).update(
+        {"enabled": args.history_aware, "replay_fraction": args.replay_fraction}
+    )
+    deft["gap_analysis"].update(
+        {
+            "metric_name": args.metric_name,
+            "target_query_count": args.target_query_count,
+        }
+    )
+    iaa = deft["iaa"]
+    iaa.update(
+        {
+            "pool_pairs_source_file": str(dataset_root / "train_pairs.json"),
+            "eval_pairs_source_file": str(dataset_root / "val_pairs.json"),
+            "train_image_dir": str(dataset_root / "images"),
+            "train_caption_dir": str(dataset_root / "captions"),
+            "source_image_dir": str(dataset_root / "images"),
+            "source_caption_dir": str(dataset_root / "captions"),
+            "eval_image_dir": str(dataset_root / "images"),
+            "eval_caption_dir": str(dataset_root / "captions"),
+        }
+    )
+    if iaa.get("train_pairs_source_file"):
+        iaa["train_pairs_source_file"] = str(dataset_root / "train_pairs.json")
+
+    tao["train"].update(
+        {
+            "num_epochs": args.training_epochs,
+            "num_gpus": args.num_gpus,
+            "gpu_ids": gpu_ids,
+        }
+    )
+    tao["evaluate"].update({"num_gpus": args.num_gpus, "gpu_ids": gpu_ids})
+
+    _atomic_yaml(config_dir / "deft_config.yaml", deft)
+    _atomic_yaml(config_dir / "tao_spec.yaml", tao)
+    for name in SPEC_NAMES[2:]:
+        _copy_atomic(templates / name, config_dir / name)
+    _atomic_json(
+        config_dir / "approval.json",
+        {
+            "schema_version": "2",
+            "workflow": "tao-run-deft-iaa",
+            "workspace": str(workspace),
+            "results_dir": str(results_dir),
+            "dataset_root": str(dataset_root),
+            "iaa_deft_bundle_sha256": runtime_sha256,
+            "images_archive": str(images_archive),
+            "metadata_archive": str(metadata_archive),
+            "checksums_file": str(checksums_file) if checksums_file else None,
+            "requires_hf_token": args.requires_hf_token,
+            "max_iterations": args.max_iterations,
+            "metric_contract": metric_contract,
+            "pyt_image": PINNED_PYT_IMAGE,
+            "ds_image": PINNED_DS_IMAGE,
+        },
+    )
+
+    return {
+        "config_dir": str(config_dir),
+        "deft_config": str(config_dir / "deft_config.yaml"),
+        "tao_spec": str(config_dir / "tao_spec.yaml"),
+        "max_iterations": args.max_iterations,
+        "training_epochs": args.training_epochs,
+        "num_gpus": args.num_gpus,
+        "gpu_ids": gpu_ids,
+        "requires_hf_token": args.requires_hf_token,
+        "iaa_deft_bundle_sha256": runtime_sha256,
+        "approval_manifest": str(config_dir / "approval.json"),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", required=True, type=pathlib.Path)
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--dataset-root", required=True, type=pathlib.Path)
+    parser.add_argument("--images-archive", required=True, type=pathlib.Path)
+    parser.add_argument("--metadata-archive", required=True, type=pathlib.Path)
+    parser.add_argument("--checksums-file", type=pathlib.Path)
+    parser.add_argument(
+        "--requires-hf-token",
+        action="store_true",
+        help="Approve forwarding the existing HF_TOKEN by environment name to model stages.",
+    )
+    parser.add_argument("--max-iterations", required=True, type=int)
+    parser.add_argument("--training-epochs", default=1, type=int)
+    parser.add_argument("--num-gpus", default=1, type=int)
+    parser.add_argument("--gpu-ids", default="0")
+    parser.add_argument("--mining-topn", default=25, type=int)
+    parser.add_argument("--knn-metric", default="cosine")
+    parser.add_argument("--target-query-count", default=10000, type=int)
+    parser.add_argument("--history-aware", default=True, type=_bool)
+    parser.add_argument("--replay-fraction", default=0.20, type=float)
+    parser.add_argument("--continual-dataset", default=True, type=_bool)
+    parser.add_argument("--continual-model", default=False, type=_bool)
+    parser.add_argument("--visualize", default=True, type=_bool)
+    parser.add_argument("--visualize-embeddings", default=True, type=_bool)
+    parser.add_argument("--metric-name", default="Rank-1")
+    parser.add_argument("--metric-query-type", default="medium")
+    parser.add_argument("--metric-op", default=">=", choices=(">=", ">", "<=", "<"))
+    parser.add_argument("--metric-target", type=float)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        report = materialize(args)
+    except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
+        print(f"prepare_deft_config: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/record_metric_result.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/record_metric_result.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate evaluator JSON and atomically commit an IAA DEFT evaluate result.
+
+The metric result JSON (written by parse_iaa_metrics.py) is validated against
+the contract stored in ``${RESULTS_DIR}/deft_state.json`` under
+``metric_contract.{metric_name,query_type,op,target}``; ``passed`` is
+recomputed from the contract before the result is committed to state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pathlib
+import re
+import sys
+import tempfile
+from typing import Any
+
+from metric_contract import (
+    contract_from_state,
+    normalize_operator,
+    result_from_iteration,
+    result_passes,
+)
+from parse_iaa_metrics import build_result
+
+EXPECTED_WORKFLOW = "tao-run-deft-iaa"
+EXPECTED_SCHEMA_VERSION = "1"
+
+
+def _required_file(value: pathlib.Path, *, name: str) -> pathlib.Path:
+    path = pathlib.Path(os.path.abspath(value.expanduser()))
+    if not path.is_absolute():
+        raise ValueError(f"{name} must be absolute")
+    if not path.is_file() or path.stat().st_size == 0:
+        raise ValueError(f"{name} must be an existing non-empty file: {path}")
+    if path.resolve() != path:
+        raise ValueError(f"{name} must not traverse a symlink: {path}")
+    return path
+
+
+def _required_dir(value: pathlib.Path, *, name: str) -> pathlib.Path:
+    path = pathlib.Path(os.path.abspath(value.expanduser()))
+    if not path.is_absolute():
+        raise ValueError(f"{name} must be absolute")
+    if not path.is_dir():
+        raise ValueError(f"{name} must be an existing directory: {path}")
+    if path.resolve() != path:
+        raise ValueError(f"{name} must not traverse a symlink: {path}")
+    return path
+
+
+def _write_atomic(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _validate_against_contract(
+    raw_result: dict[str, Any], contract: dict[str, Any]
+) -> dict[str, Any]:
+    schema_version = raw_result.get("schema_version")
+    if schema_version is not None and str(schema_version) != EXPECTED_SCHEMA_VERSION:
+        raise ValueError(
+            f"metric result schema_version must be {EXPECTED_SCHEMA_VERSION!r}, "
+            f"got {schema_version!r}"
+        )
+    workflow = raw_result.get("workflow")
+    if workflow is not None and workflow != EXPECTED_WORKFLOW:
+        raise ValueError(
+            f"metric result workflow must be {EXPECTED_WORKFLOW!r}, got {workflow!r}"
+        )
+    if raw_result.get("op") is not None:
+        result_op = normalize_operator(str(raw_result["op"]))
+        if result_op != contract["op"]:
+            raise ValueError(
+                f"metric result op {result_op!r} does not match contract op "
+                f"{contract['op']!r}"
+            )
+    result_target = raw_result.get("target")
+    contract_target = contract["target"]
+    if (result_target is None) != (contract_target is None):
+        raise ValueError(
+            f"metric result target {result_target!r} does not match contract "
+            f"target {contract_target!r}"
+        )
+    if result_target is not None and not math.isclose(
+        float(result_target), contract_target, rel_tol=1e-9, abs_tol=1e-12
+    ):
+        raise ValueError(
+            f"metric result target {result_target!r} does not match contract "
+            f"target {contract_target!r}"
+        )
+    # Checks metric_name/query_type against the contract and value finiteness.
+    result = result_from_iteration({"metric_result": raw_result}, contract)
+    if result is None:  # pragma: no cover - guarded by the provisional object
+        raise ValueError("metric result JSON is empty")
+    return result
+
+
+def commit(args: argparse.Namespace) -> dict[str, Any]:
+    if not re.fullmatch(r"baseline|iter[1-9][0-9]*", args.iter_label):
+        raise ValueError("iter label must be baseline or iterN (N >= 1)")
+    results_dir = _required_dir(args.results_dir, name="results dir")
+    state_path = _required_file(results_dir / "deft_state.json", name="deft state")
+    result_path = _required_file(args.metric_result, name="metric result JSON")
+    phase_dir = (
+        results_dir / "zs"
+        if args.iter_label == "baseline"
+        else results_dir / f"iter_{args.iter_label[4:]}"
+    )
+    expected_result_path = pathlib.Path(
+        os.path.abspath(phase_dir / "evaluate" / "metric_result.json")
+    )
+    if result_path != expected_result_path:
+        raise ValueError(
+            f"metric result for {args.iter_label} must be {expected_result_path}, "
+            f"got {result_path}"
+        )
+    metrics_path = _required_file(args.metrics_csv, name="metrics CSV")
+    expected_metrics_path = pathlib.Path(
+        os.path.abspath(
+            phase_dir / "evaluate" / "nvidia_iaa_metrics_aggregate.csv"
+        )
+    )
+    if metrics_path != expected_metrics_path:
+        raise ValueError(
+            f"metrics CSV for {args.iter_label} must be {expected_metrics_path}, "
+            f"got {metrics_path}"
+        )
+
+    state = json.loads(state_path.read_text())
+    if not isinstance(state, dict):
+        raise ValueError("deft_state.json root must be an object")
+    contract = contract_from_state(state)
+    raw_result = json.loads(result_path.read_text())
+    if not isinstance(raw_result, dict):
+        raise ValueError("metric result JSON root must be an object")
+    result = _validate_against_contract(raw_result, contract)
+    if raw_result.get("iter_label") != args.iter_label:
+        raise ValueError(
+            f"metric result iter_label={raw_result.get('iter_label')!r} does not "
+            f"match {args.iter_label!r}"
+        )
+    try:
+        recorded_source = pathlib.Path(
+            os.path.abspath(
+                pathlib.Path(str(raw_result.get("source_csv", ""))).expanduser()
+            )
+        )
+    except (OSError, ValueError) as exc:
+        raise ValueError("metric result source_csv is invalid") from exc
+    if recorded_source != metrics_path:
+        raise ValueError(
+            f"metric result source_csv must be {metrics_path}, got {recorded_source}"
+        )
+    recomputed = build_result(
+        argparse.Namespace(
+            metrics_csv=metrics_path,
+            metric_name=contract["metric_name"],
+            query_type=contract["query_type"],
+            op=contract["op"],
+            target=contract["target"],
+            iter_label=args.iter_label,
+        )
+    )
+    if not math.isclose(
+        float(result["value"]), float(recomputed["value"]), rel_tol=1e-12, abs_tol=1e-12
+    ):
+        raise ValueError(
+            f"metric result value {result['value']} disagrees with source CSV "
+            f"value {recomputed['value']}"
+        )
+    result.update(recomputed)
+    result["evidence_path"] = str(result_path)
+    # The contract in deft_state.json is authoritative: recompute passed
+    # rather than trusting the evaluator JSON (a null target never passes).
+    passed, _ = result_passes(contract, result)
+    result["passed"] = passed
+
+    iterations = state.get("iterations")
+    if not isinstance(iterations, dict):
+        raise ValueError("state.iterations must be an object")
+    phase = iterations.setdefault(args.iter_label, {"status": "in_progress"})
+    if not isinstance(phase, dict):
+        raise ValueError(f"state.iterations.{args.iter_label} must be an object")
+    phase.update(
+        {
+            "status": "complete",
+            "stage_completed": "evaluate",
+            "metric_result": result,
+        }
+    )
+
+    _write_atomic(state_path, state)
+    return result
+
+
+if __name__ == "__main__":
+    print("record_metric_result: internal module; use commit_stage.py", file=sys.stderr)
+    raise SystemExit(2)

--- a/skills/applications/tao-run-deft-iaa/scripts/recover_commit.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/recover_commit.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Roll back one interrupted IAA DEFT state/log commit from its journal."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+
+MARKER_NAME = ".deft_commit_transaction.json"
+
+
+def _atomic_text(path: pathlib.Path, value: str) -> None:
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(value)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def recover(results_dir: pathlib.Path) -> tuple[str, str]:
+    results = results_dir.expanduser().resolve()
+    state_path = results / "deft_state.json"
+    log_path = results / "loop_log.jsonl"
+    marker_path = results / MARKER_NAME
+    if not marker_path.is_file():
+        raise ValueError(f"no interrupted transaction journal found: {marker_path}")
+    marker_text = marker_path.read_text()
+    payload = json.loads(marker_text)
+    if not isinstance(payload, dict):
+        raise ValueError("transaction journal root must be an object")
+    if (
+        payload.get("schema_version") != "1"
+        or payload.get("workflow") != "tao-run-deft-iaa"
+        or pathlib.Path(str(payload.get("results_dir", ""))).resolve() != results
+    ):
+        raise ValueError("transaction journal does not belong to this IAA DEFT run")
+    original_state = payload.get("original_state_text")
+    original_log = payload.get("original_log_text")
+    if not isinstance(original_state, str):
+        raise ValueError("transaction journal lacks original_state_text")
+    try:
+        state_payload = json.loads(original_state)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"journal original state is invalid JSON: {exc}") from exc
+    if (
+        not isinstance(state_payload, dict)
+        or state_payload.get("workflow") != "tao-run-deft-iaa"
+        or pathlib.Path(str(state_payload.get("results_dir", ""))).resolve() != results
+    ):
+        raise ValueError("journal original state does not belong to this run")
+    if original_log is not None and not isinstance(original_log, str):
+        raise ValueError("transaction journal original_log_text must be string or null")
+
+    _atomic_text(state_path, original_state)
+    if original_log is None:
+        try:
+            log_path.unlink()
+        except FileNotFoundError:
+            pass
+    else:
+        _atomic_text(log_path, original_log)
+    marker_path.unlink()
+
+    audit = pathlib.Path(__file__).resolve().parent / "audit_deft_run.py"
+    completed = subprocess.run(
+        [sys.executable, str(audit), "--results-dir", str(results)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = (completed.stdout + completed.stderr).strip()
+    match = re.search(r"DEFT_RUN_STATUS=(\S+)", output)
+    restored_status = match.group(1) if match else "UNKNOWN"
+    if completed.returncode != 0 or restored_status not in {"IN_PROGRESS", "FAILED"}:
+        # Keep recovery repeatable when the restored canonical pair is not
+        # accepted. The journal remains the explicit mutation barrier.
+        _atomic_text(marker_path, marker_text)
+        raise ValueError(
+            "rollback restored the saved pair but its audit was not a valid "
+            "nonterminal state; the recovery journal was retained:\n"
+            + output
+        )
+    target = f"{payload.get('iteration')}/{payload.get('stage')}"
+    return target, output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+    try:
+        target, output = recover(args.results_dir)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        print(f"recover_commit: {exc}", file=sys.stderr)
+        return 2
+    print(f"recovered interrupted transaction for {target}")
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/render_deft_report.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/render_deft_report.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render a deterministic IAA DEFT HTML report from audited disk state.
+
+The HTML rendering layer is deterministic and performs no workload actions.
+It uses ``audit_deft_run`` first, so invoke it with the IAA runtime that
+provides YAML and parquet validation dependencies. It does not infer completed
+work from prose or directory names. A loop-end render additionally requires a
+terminal ``loop_stop`` event, including terminal FAILED runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import os
+import pathlib
+import re
+import sys
+import tempfile
+import warnings
+from typing import Any, Iterable
+
+import audit_deft_run
+import metric_contract
+
+
+REPORT_NAME = "DEFT_Loop_Report.html"
+_SENSITIVE_KEY_PARTS = (
+    "password",
+    "secret",
+    "token",
+    "credential",
+    "api_key",
+    "apikey",
+    "access_key",
+    "private_key",
+    "ngc_key",
+    "hf_token",
+)
+
+
+class ReportError(ValueError):
+    """A report cannot be rendered safely from the available evidence."""
+
+
+_ACCEPTED_AUDIT_STATUSES = frozenset({"IN_PROGRESS", "FAILED", "COMPLETE"})
+
+
+def _audited_report(results_dir: pathlib.Path) -> dict[str, Any]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        report = audit_deft_run.audit(results_dir, require_complete=False)
+    if not isinstance(report, dict):
+        raise ReportError("audit returned a non-object report")
+
+    status = report.get("status")
+    errors = report.get("errors")
+    if not isinstance(errors, list):
+        raise ReportError("audit report has an invalid errors field")
+    if status not in _ACCEPTED_AUDIT_STATUSES:
+        detail = "; ".join(str(item) for item in errors[:3])
+        if status == "INVALID":
+            raise ReportError(
+                f"audit rejected the run: {detail or 'invalid disk state'}"
+            )
+        raise ReportError(f"audit returned unsupported status {status!r}")
+    if errors:
+        detail = "; ".join(str(item) for item in errors[:3])
+        raise ReportError(f"audit returned errors with status {status}: {detail}")
+    if not isinstance(report.get("terminal"), bool):
+        raise ReportError("audit report has an invalid terminal field")
+    log_entries = report.get("log_entries")
+    if (
+        isinstance(log_entries, bool)
+        or not isinstance(log_entries, int)
+        or log_entries < 0
+    ):
+        raise ReportError("audit report has an invalid log_entries field")
+    if not isinstance(report.get("warnings"), list):
+        raise ReportError("audit report has an invalid warnings field")
+    return report
+
+
+def _canonical_snapshot(results_dir: pathlib.Path) -> tuple[bytes, bool, bytes]:
+    state_bytes = (results_dir / "deft_state.json").read_bytes()
+    log_path = results_dir / "loop_log.jsonl"
+    log_exists = log_path.exists()
+    log_bytes = log_path.read_bytes() if log_exists else b""
+    return state_bytes, log_exists, log_bytes
+
+
+def _parse_snapshot(
+    snapshot: tuple[bytes, bool, bytes]
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    state_bytes, _, log_bytes = snapshot
+    try:
+        state = json.loads(state_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReportError(f"deft_state.json is invalid JSON: {exc}") from exc
+    if not isinstance(state, dict):
+        raise ReportError("deft_state.json root must be an object")
+
+    entries: list[dict[str, Any]] = []
+    try:
+        lines = log_bytes.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise ReportError(f"loop_log.jsonl is not UTF-8: {exc}") from exc
+    for line_number, raw in enumerate(lines, 1):
+        if not raw.strip():
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ReportError(
+                f"loop_log.jsonl line {line_number} is invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(entry, dict):
+            raise ReportError(
+                f"loop_log.jsonl line {line_number} must be a JSON object"
+            )
+        entries.append(entry)
+    return state, entries
+
+
+def _iteration_sort_key(label: str) -> tuple[int, int, str]:
+    if label == "baseline":
+        return (0, 0, label)
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    if match:
+        return (1, int(match.group(1)), label)
+    return (2, 0, label)
+
+
+def _phase_dir(results_dir: pathlib.Path, label: str) -> pathlib.Path | None:
+    if label == "baseline":
+        return results_dir / "zs"
+    match = re.fullmatch(r"iter([1-9][0-9]*)", label)
+    if match:
+        return results_dir / f"iter_{match.group(1)}"
+    return None
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        return f"{value:.6g}" if math.isfinite(value) else str(value)
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return str(value)
+
+
+def _format_duration(value: Any) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "—"
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds < 0:
+        return "—"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, remainder = divmod(int(round(seconds)), 60)
+    if minutes < 60:
+        return f"{minutes}m {remainder:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes:02d}m"
+
+
+def _format_delta(value: float, reference: float | None) -> str:
+    if reference is None:
+        return "—"
+    return f"{value - reference:+.6g}"
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
+def _redact_config(value: Any) -> Any:
+    """Return a recursively redacted copy of untrusted configuration data."""
+
+    if isinstance(value, dict):
+        return {
+            key: "[redacted]" if _is_sensitive_key(str(key)) else _redact_config(child)
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_config(child) for child in value]
+    return value
+
+
+def _flatten_config(value: Any, prefix: str = "") -> list[tuple[str, str]]:
+    if isinstance(value, dict):
+        rows: list[tuple[str, str]] = []
+        for key in sorted(value, key=str):
+            name = f"{prefix}.{key}" if prefix else str(key)
+            if _is_sensitive_key(str(key)):
+                rows.append((name, "[redacted]"))
+            else:
+                rows.extend(_flatten_config(value[key], name))
+        return rows
+    if isinstance(value, list):
+        if not value:
+            return [(prefix or "config", "[]")]
+        rows: list[tuple[str, str]] = []
+        for index, child in enumerate(value):
+            name = f"{prefix}[{index}]" if prefix else f"config[{index}]"
+            rows.extend(_flatten_config(child, name))
+        return rows
+    return [(prefix or "config", _format_value(value))]
+
+
+def _metric_rows(
+    state: dict[str, Any],
+    entries: list[dict[str, Any]],
+    contract: dict[str, Any],
+) -> tuple[list[dict[str, Any]], str | None]:
+    successful_evaluates = {
+        str(entry.get("iteration"))
+        for entry in entries
+        if entry.get("stage") == "evaluate" and entry.get("status") == "ok"
+    }
+    iterations = state.get("iterations", {})
+    rows: list[dict[str, Any]] = []
+    if not isinstance(iterations, dict):
+        return rows, None
+    for label in sorted(iterations, key=_iteration_sort_key):
+        if label not in successful_evaluates:
+            continue
+        info = iterations[label]
+        if not isinstance(info, dict):
+            continue
+        result = metric_contract.result_from_iteration(info, contract)
+        if result is None:
+            continue
+        passed, _ = metric_contract.result_passes(contract, result)
+        rows.append(
+            {
+                "label": label,
+                "value": float(result["value"]),
+                "passed": passed,
+                "evidence_path": result.get("evidence_path"),
+            }
+        )
+    if not rows:
+        return rows, None
+    minimizing = contract["op"] in metric_contract.MINIMIZING_OPERATORS
+    best = min(rows, key=lambda row: row["value"]) if minimizing else max(
+        rows, key=lambda row: row["value"]
+    )
+    return rows, str(best["label"])
+
+
+def _run_status(
+    audit_report: dict[str, Any],
+    state: dict[str, Any],
+    contract: dict[str, Any],
+    metric_rows: list[dict[str, Any]],
+) -> tuple[str, str]:
+    audited = str(audit_report.get("status", "UNKNOWN"))
+    reason = state.get("loop_stop_reason")
+    if audited == "FAILED" or reason == "hard_stop":
+        return "FAILED", "The audited run ended at a hard stop."
+    if not audit_report.get("terminal"):
+        return "IN PROGRESS", str(audit_report.get("next_action", "continue workflow"))
+    if reason == "kpi_met" or any(row["passed"] for row in metric_rows):
+        return "MET", "The approved metric contract passed."
+    if contract.get("target") is None:
+        return "COMPLETE", "The iteration budget completed without a KPI target."
+    return "TARGET NOT MET", "The iteration budget completed before the target passed."
+
+
+def _state_as_of(state: dict[str, Any], entries: list[dict[str, Any]]) -> str:
+    if entries and isinstance(entries[-1].get("ts"), str):
+        return str(entries[-1]["ts"])
+    return _format_value(state.get("started_at"))
+
+
+def _resolve_path(value: str, *, base: pathlib.Path) -> pathlib.Path:
+    candidate = pathlib.Path(value).expanduser()
+    if not candidate.is_absolute():
+        candidate = base / candidate
+    return candidate.resolve()
+
+
+def _collect_paths(
+    value: Any,
+    prefix: str = "",
+    *,
+    base: pathlib.Path,
+) -> list[tuple[str, pathlib.Path]]:
+    paths: list[tuple[str, pathlib.Path]] = []
+    if isinstance(value, dict):
+        for key in sorted(value, key=str):
+            child = value[key]
+            name = f"{prefix}.{key}" if prefix else str(key)
+            paths.extend(_collect_paths(child, name, base=base))
+    elif isinstance(value, str):
+        field = prefix.rsplit(".", 1)[-1]
+        path_fields = getattr(audit_deft_run, "PATH_FIELDS", set())
+        if field in path_fields or field in {"evidence_path", "stats_json"}:
+            paths.append((prefix or "path", _resolve_path(value, base=base)))
+    return paths
+
+
+def _dedupe_paths(
+    paths: Iterable[tuple[str, pathlib.Path]],
+) -> list[tuple[str, pathlib.Path]]:
+    unique: list[tuple[str, pathlib.Path]] = []
+    seen: set[str] = set()
+    for label, path in paths:
+        rendered = str(path)
+        if rendered in seen:
+            continue
+        seen.add(rendered)
+        unique.append((label, path))
+    return unique
+
+
+def _path_html(
+    label: str, path: pathlib.Path, *, exists_override: bool | None = None
+) -> str:
+    expanded = path.expanduser()
+    exists = expanded.exists() if exists_override is None else exists_override
+    display = html.escape(str(expanded))
+    name = html.escape(label)
+    state = "exists" if exists else "missing"
+    css_class = "path-ok" if exists else "path-missing"
+    if expanded.is_absolute():
+        try:
+            target = html.escape(expanded.resolve().as_uri(), quote=True)
+            display = f'<a href="{target}"><code>{display}</code></a>'
+        except (OSError, ValueError):
+            display = f"<code>{display}</code>"
+    else:
+        display = f"<code>{display}</code>"
+    return f"<li><span class=\"field\">{name}</span>: {display} <span class=\"{css_class}\">{state}</span></li>"
+
+
+def _table(headers: list[str], rows: list[list[str]], *, empty: str) -> str:
+    if not rows:
+        return f'<p class="empty">{html.escape(empty)}</p>'
+    head = "".join(f"<th>{html.escape(header)}</th>" for header in headers)
+    body = "".join(
+        "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>"
+        for row in rows
+    )
+    return f"<div class=\"table-wrap\"><table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table></div>"
+
+
+def _render_html(
+    *,
+    results_dir: pathlib.Path,
+    trigger: str,
+    state: dict[str, Any],
+    entries: list[dict[str, Any]],
+    audit_report: dict[str, Any],
+) -> tuple[str, str, str | None]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        contract = metric_contract.contract_from_state(state)
+        metric_rows, best_label = _metric_rows(state, entries, contract)
+    status, status_detail = _run_status(audit_report, state, contract, metric_rows)
+    status_class = {
+        "FAILED": "failed",
+        "MET": "success",
+        "IN PROGRESS": "progress",
+        "TARGET NOT MET": "neutral",
+        "COMPLETE": "success",
+    }.get(status, "neutral")
+
+    state_as_of = _state_as_of(state, entries)
+    target = "none" if contract["target"] is None else _format_value(contract["target"])
+    config_rows = [
+        ["workflow", html.escape(_format_value(state.get("workflow")))],
+        ["started_at", html.escape(_format_value(state.get("started_at")))],
+        ["results_dir", f"<code>{html.escape(str(results_dir))}</code>"],
+        ["max_iterations", html.escape(_format_value(state.get("max_iterations")))],
+        ["current_iteration", html.escape(_format_value(state.get("current_iteration")))],
+        ["loop_stop_reason", html.escape(_format_value(state.get("loop_stop_reason")))],
+    ]
+    for name, value in _flatten_config(_redact_config(state.get("config", {}))):
+        config_rows.append([html.escape(name), html.escape(value)])
+
+    baseline_value = next(
+        (row["value"] for row in metric_rows if row["label"] == "baseline"), None
+    )
+    previous: float | None = None
+    kpi_rows: list[list[str]] = []
+    for row in metric_rows:
+        evidence = row.get("evidence_path")
+        evidence_html = "—"
+        if isinstance(evidence, str) and evidence:
+            evidence_path = _resolve_path(evidence, base=results_dir)
+            evidence_html = _path_html("metric", evidence_path)[4:-5]
+        gate = "no target" if contract["target"] is None else (
+            "met" if row["passed"] else "not met"
+        )
+        marker = " <strong class=\"best\">best</strong>" if row["label"] == best_label else ""
+        kpi_rows.append(
+            [
+                html.escape(str(row["label"])) + marker,
+                html.escape(_format_value(row["value"])),
+                html.escape(_format_delta(row["value"], baseline_value)),
+                html.escape(_format_delta(row["value"], previous)),
+                html.escape(gate),
+                evidence_html,
+            ]
+        )
+        previous = row["value"]
+
+    notes: list[str] = []
+    iteration_rows: list[list[str]] = []
+    iterations = state.get("iterations", {})
+    if isinstance(iterations, dict):
+        for label in sorted(iterations, key=_iteration_sort_key):
+            info = iterations[label]
+            if not isinstance(info, dict):
+                continue
+            artifact_paths = _collect_paths(info, base=results_dir)
+            phase = _phase_dir(results_dir, label)
+            if phase is not None:
+                summary_path = phase / "iteration_summary.json"
+                if summary_path.exists():
+                    artifact_paths.append(("iteration_summary", summary_path))
+            artifact_paths = _dedupe_paths(artifact_paths)
+            if artifact_paths:
+                items = "".join(_path_html(name, path) for name, path in artifact_paths)
+                artifacts_html = (
+                    f"<details><summary>{len(artifact_paths)} evidence path(s)</summary>"
+                    f"<ul class=\"paths\">{items}</ul></details>"
+                )
+            else:
+                artifacts_html = "—"
+            metric = next(
+                (row for row in metric_rows if row["label"] == label), None
+            )
+            metric_text = _format_value(metric["value"]) if metric else "—"
+            iteration_rows.append(
+                [
+                    html.escape(label),
+                    html.escape(_format_value(info.get("status"))),
+                    html.escape(_format_value(info.get("stage_completed"))),
+                    html.escape(metric_text),
+                    artifacts_html,
+                ]
+            )
+
+    timeline_rows = [
+        [
+            html.escape(_format_value(entry.get("seq"))),
+            html.escape(_format_value(entry.get("iteration"))),
+            html.escape(_format_value(entry.get("stage"))),
+            html.escape(_format_value(entry.get("status"))),
+            html.escape(_format_duration(entry.get("duration_s"))),
+            html.escape(_format_value(entry.get("summary"))),
+        ]
+        for entry in entries
+    ]
+
+    canonical_paths = [
+        ("deft_state", results_dir / "deft_state.json"),
+        ("loop_log", results_dir / "loop_log.jsonl"),
+        ("report", results_dir / REPORT_NAME),
+    ]
+    canonical_html = "".join(
+        _path_html(name, path, exists_override=True if name == "report" else None)
+        for name, path in canonical_paths
+    )
+    warning_items = [str(item) for item in audit_report.get("warnings", [])]
+    warning_items.extend(notes)
+    warnings_html = ""
+    if warning_items:
+        warnings_html = (
+            "<section><h2>Warnings</h2><ul>"
+            + "".join(f"<li>{html.escape(item)}</li>" for item in warning_items)
+            + "</ul></section>"
+        )
+
+    selection_direction = "lowest" if contract["op"] in metric_contract.MINIMIZING_OPERATORS else "highest"
+    best_summary = (
+        f"{html.escape(best_label)} ({selection_direction} value under operator "
+        f"{html.escape(contract['op'])})"
+        if best_label
+        else "none yet"
+    )
+
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>IAA DEFT Loop Report</title>
+<style>
+:root {{ color-scheme: light dark; --bg:#f5f7fa; --card:#fff; --text:#17202a; --muted:#5d6d7e; --line:#d5dbe3; --accent:#2563eb; --good:#137333; --bad:#b42318; --warn:#8a4b08; }}
+@media (prefers-color-scheme:dark) {{ :root {{ --bg:#111827; --card:#1f2937; --text:#f3f4f6; --muted:#b8c0cc; --line:#465164; --accent:#8ab4ff; --good:#76d58a; --bad:#ff8f87; --warn:#ffd080; }} }}
+* {{ box-sizing:border-box; }} body {{ margin:0; background:var(--bg); color:var(--text); font:14px/1.45 system-ui,-apple-system,sans-serif; }}
+main {{ max-width:1180px; margin:0 auto; padding:24px; }} h1 {{ margin:0 0 4px; }} h2 {{ margin:0 0 12px; font-size:18px; }}
+section {{ background:var(--card); border:1px solid var(--line); border-radius:10px; margin:14px 0; padding:16px; }}
+.banner {{ border-left:7px solid var(--accent); }} .banner.failed {{ border-left-color:var(--bad); }} .banner.success {{ border-left-color:var(--good); }} .banner.neutral {{ border-left-color:var(--warn); }}
+.status {{ font-size:22px; font-weight:750; }} .muted,.empty {{ color:var(--muted); }} .meta {{ display:flex; gap:16px; flex-wrap:wrap; margin-top:8px; }}
+.table-wrap {{ overflow:auto; }} table {{ width:100%; border-collapse:collapse; }} th,td {{ border-bottom:1px solid var(--line); padding:8px; text-align:left; vertical-align:top; }} th {{ color:var(--muted); font-weight:650; white-space:nowrap; }}
+code {{ overflow-wrap:anywhere; }} a {{ color:var(--accent); }} ul.paths {{ margin:8px 0 0; padding-left:20px; }} .field,.best {{ font-weight:700; }} .best,.path-ok {{ color:var(--good); }} .path-missing {{ color:var(--bad); font-weight:650; }}
+footer {{ color:var(--muted); margin:18px 2px; }}
+</style>
+</head>
+<body><main>
+<section class="banner {status_class}">
+  <h1>IAA DEFT Loop Report</h1>
+  <div class="status">{html.escape(status)}</div>
+  <div>{html.escape(status_detail)}</div>
+  <div class="meta"><span>trigger: <code>{html.escape(trigger)}</code></span><span>audit: <code>{html.escape(str(audit_report.get('status')))}</code></span><span>state as of: <code>{html.escape(state_as_of)}</code></span></div>
+</section>
+<section><h2>Run contract</h2>
+  <p><strong>{html.escape(contract['metric_name'])}</strong> ({html.escape(contract['query_type'])}) {html.escape(contract['op'])} {html.escape(target)}. Best: {best_summary}.</p>
+  {_table(["Field", "Value"], config_rows, empty="No run configuration recorded.")}
+</section>
+<section><h2>KPI trend</h2>
+  {_table(["Iteration", "Value", "Δ baseline", "Δ previous", "Gate", "Evidence"], kpi_rows, empty="No successfully committed evaluate result yet.")}
+</section>
+<section><h2>Iterations and evidence</h2>
+  {_table(["Iteration", "Status", "Last stage", "KPI", "Artifacts"], iteration_rows, empty="No iteration state recorded.")}
+</section>
+<section><h2>Stage timeline</h2>
+  {_table(["Seq", "Iteration", "Stage", "Status", "Duration", "Summary"], timeline_rows, empty="No stage events committed yet.")}
+</section>
+<section><h2>Canonical evidence</h2><ul class="paths">{canonical_html}</ul></section>
+{warnings_html}
+<footer>Rendered from audited <code>deft_state.json</code> and <code>loop_log.jsonl</code>. No report value is completion evidence by itself.</footer>
+</main></body></html>
+"""
+    return document, status, best_label
+
+
+def _write_atomic(path: pathlib.Path, content: str) -> int:
+    encoded = content.encode("utf-8")
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+    return len(encoded)
+
+
+def render(results_dir: pathlib.Path, trigger: str) -> tuple[pathlib.Path, int, str, str | None]:
+    results_dir = results_dir.expanduser().resolve()
+    _audited_report(results_dir)
+    snapshot = _canonical_snapshot(results_dir)
+    state, entries = _parse_snapshot(snapshot)
+    audit_report = _audited_report(results_dir)
+    if _canonical_snapshot(results_dir) != snapshot:
+        raise ReportError("canonical state changed during audit; rerun the renderer")
+    if len(entries) != audit_report["log_entries"]:
+        raise ReportError("audit log count does not match the stable snapshot")
+    if trigger == "loop-end" and not audit_report["terminal"]:
+        raise ReportError("loop-end render requires a terminal loop_stop event")
+    if trigger == "iteration-complete":
+        completed_labels = {
+            str(entry.get("iteration"))
+            for entry in entries
+            if entry.get("stage") == "evaluate"
+            and entry.get("status") == "ok"
+            and re.fullmatch(r"iter[1-9][0-9]*", str(entry.get("iteration")))
+        }
+        iterations = state.get("iterations")
+        if not completed_labels or not isinstance(iterations, dict) or not any(
+            isinstance(iterations.get(label), dict)
+            and iterations[label].get("status") == "complete"
+            for label in completed_labels
+        ):
+            raise ReportError(
+                "iteration-complete render requires a successfully committed "
+                "iterN/evaluate stage"
+            )
+
+    document, status, best_label = _render_html(
+        results_dir=results_dir,
+        trigger=trigger,
+        state=state,
+        entries=entries,
+        audit_report=audit_report,
+    )
+    if _canonical_snapshot(results_dir) != snapshot:
+        raise ReportError("canonical state changed while rendering; rerun the renderer")
+    output = results_dir / REPORT_NAME
+    size = _write_atomic(output, document)
+    return output, size, status, best_label
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--trigger",
+        required=True,
+        choices=("iteration-complete", "loop-end"),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        output, size, status, best_label = render(args.results_dir, args.trigger)
+    except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
+        print(f"render_deft_report: {exc}", file=sys.stderr)
+        return 2
+    best = best_label or "none"
+    print(
+        f"render_deft_report: wrote {output.name} "
+        f"({size} bytes, status={status}, best={best})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
@@ -1,0 +1,566 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run one IAA DEFT Docker command with persistent mounts and status evidence.
+
+This wrapper reconstructs every value from ``deft_state.json`` on each call;
+it never relies on a previous shell export.  It records the Docker exit code
+and log path atomically and never places credential values in argv or status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import getpass
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+from command_contract import (
+    command_sha256,
+    expected_container_command,
+    expected_hf_forwarding,
+    expected_fresh_outputs,
+    expected_image_kind,
+    expected_stage_directory,
+)
+
+
+RUN_SPEC_NAMES = (
+    "deft_config.yaml",
+    "tao_spec.yaml",
+    "text_embed_spec.yaml",
+    "image_embed_spec.yaml",
+    "mining_spec.yaml",
+    "approval.json",
+)
+PINNED_IMAGES = {
+    "pyt": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt",  # versions-key: images.tao_toolkit.pyt
+    "ds": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services",  # versions-key: images.tao_toolkit.data_services
+}
+
+
+def _atomic_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _under(path: pathlib.Path, root: pathlib.Path, name: str) -> pathlib.Path:
+    resolved = path.expanduser().resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be under {root}: {resolved}") from exc
+    return resolved
+
+
+def _fresh_output_path(
+    path: pathlib.Path, root: pathlib.Path, name: str
+) -> pathlib.Path:
+    """Resolve an output lexically so unlink never follows a final symlink."""
+    raw = path.expanduser()
+    if not raw.is_absolute():
+        raw = pathlib.Path.cwd() / raw
+    absolute = pathlib.Path(os.path.abspath(raw))
+    try:
+        absolute.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be under {root}: {absolute}") from exc
+    parent = absolute.parent
+    try:
+        parent.resolve().relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{name} parent must remain under {root}: {parent}") from exc
+    if parent.resolve() != parent:
+        raise ValueError(f"{name} parent must not traverse a symlink: {parent}")
+    if absolute.is_symlink():
+        raise ValueError(f"{name} must not be a symlink: {absolute}")
+    return absolute
+
+
+def _load_state(results_dir: pathlib.Path) -> dict[str, Any]:
+    path = results_dir / "deft_state.json"
+    if not path.is_file():
+        raise ValueError(f"state file not found: {path}")
+    payload = json.loads(path.read_text())
+    if (
+        not isinstance(payload, dict)
+        or payload.get("workflow") != "tao-run-deft-iaa"
+        or payload.get("schema_version") != "3"
+    ):
+        raise ValueError(f"invalid IAA DEFT state: {path}")
+    if pathlib.Path(str(payload.get("results_dir", ""))).resolve() != results_dir:
+        raise ValueError("state.results_dir does not match --results-dir")
+    return payload
+
+
+def _workspace_child(path: pathlib.Path, workspace: pathlib.Path, name: str) -> pathlib.Path:
+    resolved = path.expanduser().resolve()
+    try:
+        relative = resolved.relative_to(workspace)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be under workspace {workspace}: {resolved}") from exc
+    if relative == pathlib.Path("."):
+        raise ValueError(f"{name} must be a child of workspace, not workspace itself")
+    return resolved
+
+
+def _validated_runtime_paths(
+    results_dir: pathlib.Path, config: dict[str, Any]
+) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path]:
+    workspace = pathlib.Path(str(config.get("workspace", ""))).expanduser().resolve()
+    if not workspace.is_dir() or workspace == pathlib.Path(workspace.anchor):
+        raise ValueError(f"state workspace must be an existing non-root directory: {workspace}")
+    _workspace_child(results_dir, workspace, "state results_dir")
+    dataset_root = _workspace_child(
+        pathlib.Path(str(config.get("dataset_root", ""))), workspace, "state dataset_root"
+    )
+    if not dataset_root.is_dir():
+        raise ValueError(f"state dataset_root is not an existing directory: {dataset_root}")
+    if results_dir in dataset_root.parents or dataset_root in results_dir.parents:
+        raise ValueError("state results_dir and dataset_root must not contain one another")
+    if dataset_root.parent == workspace:
+        raise ValueError("state dataset_root must be nested below a workspace data directory")
+    if dataset_root.parent == pathlib.Path(dataset_root.anchor):
+        raise ValueError("refusing to mount a filesystem root as the dataset parent")
+
+    config_dir = pathlib.Path(str(config.get("config_dir", ""))).expanduser().resolve()
+    expected_config_dir = results_dir / "config"
+    if config_dir != expected_config_dir or not config_dir.is_dir():
+        raise ValueError(
+            f"state config_dir must be the existing run config directory {expected_config_dir}"
+        )
+    expected_hashes = config.get("spec_sha256")
+    if not isinstance(expected_hashes, dict) or set(expected_hashes) != set(RUN_SPEC_NAMES):
+        raise ValueError("state config.spec_sha256 must bind all immutable run config files")
+    for name in RUN_SPEC_NAMES:
+        path = config_dir / name
+        if not path.is_file() or path.stat().st_size == 0:
+            raise ValueError(f"run spec is missing or empty: {path}")
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if expected_hashes.get(name) != actual:
+            raise ValueError(f"run spec changed after approval: {path}")
+    if pathlib.Path(str(config.get("deft_config", ""))).resolve() != config_dir / "deft_config.yaml":
+        raise ValueError("state deft_config path does not match the immutable run config")
+    if pathlib.Path(str(config.get("tao_spec", ""))).resolve() != config_dir / "tao_spec.yaml":
+        raise ValueError("state tao_spec path does not match the immutable run config")
+    if config.get("platform") != "docker":
+        raise ValueError("state platform must be docker")
+    return workspace, dataset_root, config_dir
+
+
+def _reject_sensitive_argv(command: list[str]) -> None:
+    secret_values = [
+        value for name in ("NGC_KEY", "HF_TOKEN")
+        if (value := os.environ.get(name))
+    ]
+    sensitive_markers = ("password=", "token=", "api_key=", "apikey=")
+    sensitive_flags = {
+        "--password",
+        "--password-stdin",
+        "--token",
+        "--api-key",
+        "--api_key",
+        "--apikey",
+        "-p",
+    }
+    for item in command:
+        lowered = item.lower()
+        if lowered in sensitive_flags or any(marker in lowered for marker in sensitive_markers):
+            raise ValueError(
+                "container command must not carry credentials in argv; use "
+                "the wrapper's explicit environment forwarding option"
+            )
+        if any(secret in item for secret in secret_values):
+            raise ValueError("container command argv contains a credential value")
+
+
+def _docker_gpu_args(config: dict[str, Any]) -> list[str]:
+    """Return the exact immutable Docker device request from approved state."""
+    gpu_ids = config.get("gpu_ids")
+    num_gpus = config.get("num_gpus")
+    valid_ids = (
+        isinstance(gpu_ids, list)
+        and bool(gpu_ids)
+        and all(
+            isinstance(gpu_id, int)
+            and not isinstance(gpu_id, bool)
+            and gpu_id >= 0
+            for gpu_id in gpu_ids
+        )
+        and len(set(gpu_ids)) == len(gpu_ids)
+    )
+    if not valid_ids or num_gpus != len(gpu_ids):
+        raise ValueError(
+            "state.config.gpu_ids must be a non-empty unique integer list "
+            "matching state.config.num_gpus"
+        )
+    device_ids = ",".join(str(gpu_id) for gpu_id in gpu_ids)
+    # Docker parses --gpus as CSV. Literal double quotes keep a multi-device
+    # selector together when argv is passed directly without a shell.
+    return ["--gpus", f'"device={device_ids}"']
+
+
+def _container_is_running(container_name: str) -> bool:
+    """Read Docker state without mutating a possibly orphaned container."""
+    inspected = subprocess.run(
+        [
+            "docker",
+            "container",
+            "inspect",
+            "--format",
+            "{{.State.Running}}",
+            container_name,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if inspected.returncode == 0:
+        value = inspected.stdout.strip().lower()
+        if value not in {"true", "false"}:
+            raise ValueError(
+                f"Docker returned an unrecognized state for {container_name}: {value!r}"
+            )
+        return value == "true"
+    combined = (inspected.stdout + inspected.stderr).lower()
+    if "no such object" in combined or "no such container" in combined:
+        return False
+    raise ValueError(
+        f"cannot inspect prior container {container_name}; Docker said: "
+        f"{(inspected.stderr or inspected.stdout).strip() or 'unknown error'}"
+    )
+
+
+def _launch_label(name: str, stage_dir: pathlib.Path, results_dir: pathlib.Path) -> str:
+    if name == "pool_embed":
+        return "baseline"
+    relative = stage_dir.relative_to(results_dir)
+    if relative.parts and relative.parts[0] == "zs":
+        return "baseline"
+    if relative.parts:
+        match = re.fullmatch(r"iter_([1-9][0-9]*)", relative.parts[0])
+        if match:
+            return f"iter{match.group(1)}"
+    raise ValueError(
+        f"cannot derive baseline/iterN command scope from --stage-dir {stage_dir}"
+    )
+
+
+def _load_existing_status(path: pathlib.Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"existing command status is invalid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"existing command status root must be an object: {path}")
+    return payload
+
+
+def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
+    results_dir = args.results_dir.expanduser().resolve()
+    state = _load_state(results_dir)
+    config = state.get("config")
+    if not isinstance(config, dict):
+        raise ValueError("state.config must be an object")
+    image_key = "pyt_image" if args.image == "pyt" else "ds_image"
+    image = str(config.get(image_key, "")).strip()
+    if image != PINNED_IMAGES[args.image]:
+        raise ValueError(
+            f"state.config.{image_key} must be the pinned {args.image} image"
+        )
+    workspace, dataset_root, config_dir = _validated_runtime_paths(
+        results_dir, config
+    )
+    patches_dir = pathlib.Path(__file__).resolve().parent.parent / "patches"
+    if not patches_dir.is_dir():
+        raise ValueError(f"container compatibility patches are missing: {patches_dir}")
+
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", args.name):
+        raise ValueError("--name must contain only lowercase letters, digits, ._- characters")
+    _reject_sensitive_argv(args.command)
+    stage_dir = _under(args.stage_dir, results_dir, "--stage-dir")
+    label = _launch_label(args.name, stage_dir, results_dir)
+    if label.startswith("iter"):
+        number = int(label[4:])
+        maximum = state.get("max_iterations")
+        if (
+            not isinstance(maximum, int)
+            or isinstance(maximum, bool)
+            or not 1 <= number <= maximum
+        ):
+            raise ValueError(
+                f"container iteration {number} is outside approved range 1..{maximum}"
+            )
+    expected_stage = expected_stage_directory(args.name, label, results_dir)
+    if stage_dir != expected_stage:
+        raise ValueError(
+            f"--stage-dir for {args.name} must be {expected_stage}, got {stage_dir}"
+        )
+    expected_command = expected_container_command(args.name, label, config)
+    if args.command != expected_command:
+        raise ValueError(
+            f"container argv for {args.name} does not match the immutable workflow command"
+        )
+    expected_kind = expected_image_kind(args.name)
+    if args.image != expected_kind:
+        raise ValueError(
+            f"--image for {args.name} must be {expected_kind}, got {args.image}"
+        )
+    required_hf = expected_hf_forwarding(args.name, config)
+    if bool(args.pass_hf_token) != required_hf:
+        raise ValueError(
+            f"--pass-hf-token for {args.name} must be {required_hf} per immutable approval"
+        )
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    log_path = stage_dir / f"{args.name}.log"
+    status_path = stage_dir / f"{args.name}.status.json"
+    cidfile_path = stage_dir / f"{args.name}.cid"
+    lock_path = stage_dir / f"{args.name}.launch.lock"
+    identity = hashlib.sha256(
+        f"{results_dir}\0{stage_dir.relative_to(results_dir)}\0{args.name}".encode()
+    ).hexdigest()[:20]
+    container_name = f"tao-deft-{identity}"
+
+    fresh_outputs: list[str] = []
+    for raw in args.fresh_output:
+        output = _fresh_output_path(raw, results_dir, "--fresh-output")
+        if output.exists() and not output.is_file():
+            raise ValueError(f"--fresh-output must name a file, not a directory: {output}")
+        fresh_outputs.append(str(output))
+    expected_outputs = [
+        str(path) for path in expected_fresh_outputs(args.name, label, results_dir)
+    ]
+    if fresh_outputs != expected_outputs:
+        raise ValueError(
+            f"--fresh-output for {args.name} must be {expected_outputs}, "
+            f"got {fresh_outputs}"
+        )
+
+    cache_dir = workspace / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    data_mount = dataset_root.parent
+    command = [
+        "docker",
+        "run",
+        *_docker_gpu_args(config),
+        "--rm",
+        "--name",
+        container_name,
+        "--cidfile",
+        str(cidfile_path),
+        "--ipc=host",
+        "--user",
+        f"{os.getuid()}:{os.getgid()}",
+        "--env",
+        f"USER={getpass.getuser()}",
+        "--env",
+        f"LOGNAME={getpass.getuser()}",
+        "--env",
+        "HOME=/tmp",
+        "--env",
+        "PYTHONPATH=/patches",
+        "--env",
+        "HF_HOME=/cache/huggingface",
+        "--env",
+        "XDG_CACHE_HOME=/cache",
+        "--volume",
+        f"{results_dir}:/results",
+        "--volume",
+        f"{data_mount}:/data:ro",
+        "--volume",
+        f"{data_mount}:{data_mount}:ro",
+        "--volume",
+        f"{config_dir}:/specs:ro",
+        "--volume",
+        f"{patches_dir}:/patches:ro",
+        "--volume",
+        f"{cache_dir}:/cache",
+    ]
+    # ``--env HF_TOKEN`` copies the already-exported value without exposing it
+    # in the process list, status JSON, or transcript.  Public models need none.
+    if args.pass_hf_token:
+        if not os.environ.get("HF_TOKEN"):
+            raise ValueError("--pass-hf-token requires HF_TOKEN in the process environment")
+        command.extend(["--env", "HF_TOKEN"])
+    command.extend([image, *args.command])
+
+    with lock_path.open("a+") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise ValueError(
+                f"another wrapper process owns this stage launch: {lock_path}"
+            ) from exc
+
+        existing = _load_existing_status(status_path)
+        prior_attempt = 0
+        if existing is not None:
+            raw_attempt = existing.get("attempt", 1)
+            if (
+                not isinstance(raw_attempt, int)
+                or isinstance(raw_attempt, bool)
+                or raw_attempt < 1
+            ):
+                raise ValueError(f"existing command status has invalid attempt: {status_path}")
+            prior_attempt = raw_attempt
+        if existing is not None and existing.get("status") == "running":
+            prior_name = existing.get("container_name")
+            if prior_name != container_name:
+                raise ValueError(
+                    "existing running status lacks the deterministic container identity; "
+                    f"inspect and recover manually before replacing {status_path}"
+                )
+            if _container_is_running(container_name):
+                raise ValueError(
+                    f"prior container {container_name} is still running; wait for it to "
+                    "exit, then rerun the same command (the wrapper never auto-kills it)"
+                )
+        if prior_attempt >= 2:
+            raise ValueError(
+                f"attempt budget exhausted for {args.name} (attempt={prior_attempt}); "
+                "commit a terminal stage error and hard-stop instead of retrying"
+            )
+
+        try:
+            cidfile_path.unlink()
+        except FileNotFoundError:
+            pass
+        started_ns = time.time_ns()
+        started_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+        # Invalidate any previous successful attempt *before* deleting outputs
+        # or launching Docker. A deterministic container name plus the launch
+        # lock prevents two attempts from concurrently writing those outputs.
+        running_payload = {
+            "schema_version": "1",
+            "workflow": "tao-run-deft-iaa",
+            "kind": "container",
+            "name": args.name,
+            "attempt": prior_attempt + 1,
+            "image_kind": args.image,
+            "image": image,
+            "command": list(args.command),
+            "command_sha256": command_sha256(list(args.command)),
+            "passed_hf_token": bool(args.pass_hf_token),
+            "container_name": container_name,
+            "cidfile": str(cidfile_path),
+            "started_at": started_at,
+            "started_ns": started_ns,
+            "finished_at": None,
+            "status": "running",
+            "exit_code": None,
+            "log_path": str(log_path),
+            "fresh_outputs": fresh_outputs,
+        }
+        _atomic_json(status_path, running_payload)
+        for raw in fresh_outputs:
+            try:
+                pathlib.Path(raw).unlink()
+            except FileNotFoundError:
+                pass
+        with log_path.open("wb") as log:
+            completed = subprocess.run(
+                command, stdout=log, stderr=subprocess.STDOUT, check=False
+            )
+        returncode = completed.returncode
+        artifact_error = None
+        if returncode == 0:
+            for raw in fresh_outputs:
+                output = pathlib.Path(raw)
+                if (
+                    output.is_symlink()
+                    or not output.is_file()
+                    or output.stat().st_size == 0
+                ):
+                    artifact_error = f"fresh output is missing, empty, or a symlink: {output}"
+                    break
+                if output.stat().st_mtime_ns < started_ns:
+                    artifact_error = f"fresh output predates this launch: {output}"
+                    break
+        if artifact_error is not None:
+            returncode = 3
+            with log_path.open("ab") as log:
+                log.write(
+                    ("\nrun_deft_container: " + artifact_error + "\n").encode("utf-8")
+                )
+        finished_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+        payload = {
+            **running_payload,
+            "finished_at": finished_at,
+            "status": "ok" if returncode == 0 else "error",
+            "exit_code": returncode,
+            "docker_exit_code": completed.returncode,
+            "artifact_error": artifact_error,
+        }
+        _atomic_json(status_path, payload)
+        return status_path, log_path, returncode
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--image", required=True, choices=("pyt", "ds"))
+    parser.add_argument("--stage-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--name", required=True)
+    parser.add_argument(
+        "--pass-hf-token",
+        action="store_true",
+        help="Forward the existing HF_TOKEN by environment name; off by default.",
+    )
+    parser.add_argument(
+        "--fresh-output",
+        action="append",
+        default=[],
+        type=pathlib.Path,
+        help="Delete this exact results-scoped file before launch; repeatable.",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        print("run_deft_container: command after -- is required", file=sys.stderr)
+        return 2
+    try:
+        status, log, returncode = run(args)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        print(f"run_deft_container: {exc}", file=sys.stderr)
+        return 2
+    outcome = "ok" if returncode == 0 else "error"
+    print(
+        f"container={outcome} exit_code={returncode} status={status} log={log}",
+        file=sys.stderr,
+    )
+    return returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
@@ -1,0 +1,930 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic host-side adapters for the IAA DEFT stages.
+
+Container work remains in ``run_deft_container.py``.  This command exposes the
+canonical Python calls as bounded subcommands so an agent never has to invent
+inline Python or rediscover function signatures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import time
+from typing import Any
+
+from checkpoint_contract import METADATA_RELPATH, validate_best_checkpoint
+from command_contract import (
+    command_sha256,
+    expected_container_command,
+    expected_hf_forwarding,
+    expected_image_kind,
+)
+
+
+def _atomic_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _state(results: pathlib.Path) -> dict[str, Any]:
+    state_path = results / "deft_state.json"
+    if not state_path.is_file():
+        raise ValueError(f"state file not found: {state_path}")
+    payload = json.loads(state_path.read_text())
+    if (
+        not isinstance(payload, dict)
+        or payload.get("workflow") != "tao-run-deft-iaa"
+        or payload.get("schema_version") != "3"
+    ):
+        raise ValueError(f"invalid IAA DEFT state: {state_path}")
+    if pathlib.Path(str(payload.get("results_dir", ""))).resolve() != results:
+        raise ValueError("state.results_dir does not match --results-dir")
+    return payload
+
+
+def _python_tree_sha256(root: pathlib.Path) -> str:
+    files = sorted(path for path in root.rglob("*.py") if "__pycache__" not in path.parts)
+    if not files:
+        raise ValueError(f"bundled IAA runtime contains no Python files: {root}")
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _config(path: pathlib.Path, results: pathlib.Path):
+    import iaa_deft
+    from iaa_deft.config import IaaDeftConfig
+
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise ValueError(f"DEFT config not found: {resolved}")
+    state = _state(results)
+    state_config = state.get("config")
+    if not isinstance(state_config, dict):
+        raise ValueError("state.config must be an object")
+    source = pathlib.Path(__file__).resolve().parent / "iaa_deft"
+    origin = pathlib.Path(str(getattr(iaa_deft, "__file__", ""))).resolve()
+    try:
+        origin.relative_to(source)
+    except ValueError as exc:
+        raise ValueError(
+            f"imported iaa_deft at {origin} is outside bundled runtime {source}"
+        ) from exc
+    if _python_tree_sha256(source) != state_config.get("iaa_deft_bundle_sha256"):
+        raise ValueError("bundled IAA runtime changed after initialization")
+    expected = pathlib.Path(str(state_config.get("deft_config", ""))).resolve()
+    if resolved != expected or expected != results / "config" / "deft_config.yaml":
+        raise ValueError(
+            f"--deft-config must be the immutable state config {expected}, got {resolved}"
+        )
+    hashes = state_config.get("spec_sha256")
+    expected_digest = hashes.get("deft_config.yaml") if isinstance(hashes, dict) else None
+    actual_digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    if not expected_digest or actual_digest != expected_digest:
+        raise ValueError("approved DEFT config hash does not match state")
+    return IaaDeftConfig(str(resolved))
+
+
+def _results(path: pathlib.Path) -> pathlib.Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_dir():
+        raise ValueError(f"results directory not found: {resolved}")
+    return resolved
+
+
+def _iter_dir(results: pathlib.Path, number: int) -> pathlib.Path:
+    if number < 1:
+        raise ValueError("iteration number must be >= 1")
+    maximum = _state(results).get("max_iterations")
+    if not isinstance(maximum, int) or isinstance(maximum, bool) or number > maximum:
+        raise ValueError(
+            f"iteration number {number} is outside the approved range 1..{maximum}"
+        )
+    return results / f"iter_{number}"
+
+
+def _require(paths: list[pathlib.Path]) -> None:
+    missing = [str(path) for path in paths if not path.is_file() or path.stat().st_size == 0]
+    if missing:
+        raise ValueError("stage did not produce required file(s): " + ", ".join(missing))
+
+
+def _training_checkpoint(cfg, number: int) -> str:
+    if not cfg.continual_model or number == 1:
+        return cfg.init_checkpoint
+    return f"/results/iter_{number - 1}/pretrained/model_state.pth"
+
+
+def dataset_materialize(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.data_mining import (
+        convert_clip_image_list_to_parquet,
+        materialize_iaa_eval_split,
+        materialize_iaa_pool_split,
+    )
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    splits = results / "iaa_splits"
+    eval_list = splits / "eval_list.txt"
+    eval_pairs = splits / "eval_pairs.json"
+    val_list = splits / "val_list.txt"
+    pool_list = splits / "aug_pool_list.txt"
+    pool_pairs = splits / "aug_pool_pairs.json"
+    source_pool = results / "embeddings" / "source" / "source_pool.parquet"
+
+    materialize_iaa_eval_split(
+        eval_pairs_source_file=cfg.iaa_eval_pairs_source_file,
+        eval_image_list_file=str(eval_list),
+        eval_pairs_file=str(eval_pairs),
+        query_types=cfg.iaa_query_types,
+        val_image_list_file=str(val_list),
+        val_sample_size=cfg.iaa_val_sample_size,
+    )
+    materialize_iaa_pool_split(
+        pool_pairs_source_file=cfg.iaa_pool_pairs_source_file,
+        aug_pool_image_list_file=str(pool_list),
+        aug_pool_pairs_file=str(pool_pairs),
+        augmented_suffix=cfg.iaa_augmented_suffix,
+        query_types=cfg.iaa_query_types,
+        max_aug_pool_rows=cfg.iaa_max_aug_pool_rows,
+        mining_pool_mode=cfg.iaa_mining_pool_mode,
+    )
+    convert_clip_image_list_to_parquet(
+        image_list_file=str(pool_list),
+        image_dir=cfg.iaa_source_image_dir,
+        output_parquet=str(source_pool),
+        caption_dir=cfg.iaa_source_caption_dir,
+        caption_file_suffix=".txt",
+        pairs_file=str(pool_pairs),
+    )
+    _require([eval_list, eval_pairs, val_list, pool_list, pool_pairs, source_pool])
+    return {
+        "iaa_splits_dir": str(splits),
+        "eval_list": str(eval_list),
+        "eval_pairs": str(eval_pairs),
+        "val_list": str(val_list),
+        "pool_list": str(pool_list),
+        "pool_pairs": str(pool_pairs),
+        "source_pool_parquet": str(source_pool),
+    }
+
+
+def gap_analysis(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.analyze_gaps import analyze_clip_inference_gaps
+    from iaa_deft.utils import resolve_prev_eval_dir
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    current = _iter_dir(results, args.iter_num)
+    gaps = current / "gaps" / "kpi_gaps.parquet"
+    previous_eval = resolve_prev_eval_dir(
+        base_experiment_path=str(results),
+        iter_num=args.iter_num,
+        train_ann_path="",
+        eval_subdir="evaluate",
+    )
+    analyze_clip_inference_gaps(
+        results_dir=previous_eval,
+        gaps_parquet=str(gaps),
+        kpi_image_dir=cfg.iaa_eval_image_dir,
+        logs_dir=str(current / "logs"),
+        kpi_caption_dir=cfg.iaa_eval_caption_dir,
+        caption_file_suffix=".txt",
+        kpi_pairs_file=str(results / "iaa_splits" / "eval_pairs.json"),
+        metric_name=cfg.gap_metric_name,
+        queries_per_slice=cfg.queries_per_slice,
+        min_num_queries=cfg.min_gap_num_queries,
+        query_types=cfg.gap_query_types,
+        weak_attribute_topk=cfg.weak_attribute_topk,
+        target_query_count=cfg.target_query_count,
+        caption_diversity_enabled=cfg.caption_diversity_enabled,
+        caption_history_file=str(results / "caption_selection_history.json"),
+        iter_num=args.iter_num,
+        total_iters=_state(results)["max_iterations"],
+        continual_dataset="true" if cfg.continual_dataset else "false",
+        caption_history_policy=cfg.caption_history_policy,
+        caption_coverage_target=cfg.caption_coverage_target,
+        min_unique_texts_per_attribute=cfg.min_unique_texts_per_attribute,
+        max_unique_texts_per_attribute=cfg.max_unique_texts_per_attribute,
+        max_rows_per_unique_text=cfg.max_rows_per_unique_text,
+        max_rows_per_image_path=cfg.max_rows_per_image_path,
+        recent_exclude_iters=cfg.recent_exclude_iters,
+        replay_fraction_when_noncontinual=cfg.replay_fraction_when_noncontinual,
+    )
+    _require([gaps])
+    return {"gaps_parquet": str(gaps), "previous_eval_dir": str(previous_eval)}
+
+
+def mining_postprocess(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.data_mining import (
+        convert_mined_parquet_to_clip_image_list,
+        summarize_knn_mining,
+    )
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    current = _iter_dir(results, args.iter_num)
+    target = current / "embeddings" / "target" / "embeddings.parquet"
+    mined = current / "mining" / "mined_samples.parquet"
+    mining_dir = current / "mining"
+    history_enabled = cfg.history_aware_enabled == "true"
+    candidates = mining_dir / "history_candidates" if history_enabled else mining_dir
+    candidate_list = candidates / "mined_image_list.txt"
+    candidate_pairs = candidates / "mined_pairs.json"
+    candidate_manifest = candidates / "mined_dataset.json"
+    source_embeddings = results / "embeddings" / "source" / "embeddings.parquet"
+
+    summarize_knn_mining(
+        mined_parquet=str(mined),
+        target_parquet=str(target),
+        output_dir=str(mining_dir),
+        topn=cfg.mining_topn,
+    )
+    convert_mined_parquet_to_clip_image_list(
+        mined_parquet=str(mined),
+        image_dir=cfg.iaa_source_image_dir,
+        caption_dir=cfg.iaa_source_caption_dir,
+        caption_file_suffix=".txt",
+        output_image_list_file=str(candidate_list),
+        manifest_path=str(candidate_manifest),
+        source_pairs_file=str(results / "iaa_splits" / "aug_pool_pairs.json"),
+        output_pairs_file=str(candidate_pairs),
+        target_query_count=0 if history_enabled else cfg.target_query_count,
+        caption_expansion_enabled=cfg.caption_expansion_enabled,
+        caption_expansion_mode=cfg.caption_expansion_mode,
+        caption_expansion_max_pairs_per_image_path=cfg.caption_expansion_max_pairs_per_image_path,
+        caption_expansion_max_expanded_pair_fraction=cfg.caption_expansion_max_expanded_pair_fraction,
+        caption_expansion_dedupe_normalized_caption=cfg.caption_expansion_dedupe_normalized_caption,
+        caption_expansion_count_expanded_pairs_toward_target=cfg.caption_expansion_count_expanded_pairs_toward_target,
+        source_embedding_shards_dir=str(results / "embeddings" / "source"),
+        write_detailed_csv="false" if history_enabled else "true",
+        source_embeddings_parquet=str(source_embeddings),
+        target_embeddings_parquet=str(target),
+    )
+    _require([target, mined, candidate_list, candidate_pairs, candidate_manifest])
+    return {
+        "target_embeddings_parquet": str(target),
+        "mined_parquet": str(mined),
+        "candidate_pairs": str(candidate_pairs),
+    }
+
+
+def history_select(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.data_mining import track_cumulative_mined_unique_names
+    from iaa_deft.history_aware_mining import select_history_aware_mined_pairs
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    mining = _iter_dir(results, args.iter_num) / "mining"
+    output_list = mining / "mined_image_list.txt"
+    output_pairs = mining / "mined_pairs.json"
+    manifest = mining / "mined_dataset.json"
+    cumulative = mining / "cumulative_mined_unique_names.json"
+    if cfg.history_aware_enabled == "true":
+        candidates = mining / "history_candidates"
+        select_history_aware_mined_pairs(
+            candidate_pairs_file=str(candidates / "mined_pairs.json"),
+            candidate_manifest_file=str(candidates / "mined_dataset.json"),
+            output_image_list_file=str(output_list),
+            output_pairs_file=str(output_pairs),
+            manifest_path=str(manifest),
+            history_file=str(results / "mining_selection_history.json"),
+            source_pool_image_list_file=str(results / "iaa_splits" / "aug_pool_list.txt"),
+            iter_num=args.iter_num,
+            target_query_count=cfg.target_query_count,
+            continual_dataset="true" if cfg.continual_dataset else "false",
+            replay_fraction=cfg.history_aware_replay_fraction,
+            resume="true" if args.resume else "false",
+        )
+    track_cumulative_mined_unique_names(
+        mined_pairs_file=str(output_pairs),
+        base_experiment_path=str(results),
+        iter_num=args.iter_num,
+        output_file=str(cumulative),
+    )
+    _require([output_list, output_pairs, manifest, cumulative])
+
+    eval_names = {
+        pathlib.Path(line.strip()).name
+        for line in (results / "iaa_splits" / "eval_list.txt").read_text().splitlines()
+        if line.strip()
+    }
+    mined_names = {
+        pathlib.Path(line.strip()).name
+        for line in output_list.read_text().splitlines()
+        if line.strip()
+    }
+    overlap = sorted(eval_names & mined_names)
+    if overlap:
+        raise ValueError(
+            f"eval leakage: {len(overlap)} mined basename(s) overlap eval split; "
+            f"first={overlap[0]}"
+        )
+    return {
+        "mined_image_list": str(output_list),
+        "mined_pairs": str(output_pairs),
+        "mined_manifest": str(manifest),
+        "cumulative_names": str(cumulative),
+        "history_file": str(results / "mining_selection_history.json"),
+    }
+
+
+def visualize_prepare(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.utils import resolve_prev_clip_train_config
+    from iaa_deft.visualization import (
+        export_clip_sample_contact_sheets,
+        prepare_clip_images_for_embedding,
+        prepare_prev_clip_data_for_embedding,
+    )
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    current = _iter_dir(results, args.iter_num)
+    gaps = current / "gaps" / "kpi_gaps.parquet"
+    mined = current / "mining" / "mined_samples.parquet"
+    samples = current / "visualization" / "samples"
+    outputs: dict[str, Any] = {}
+    if cfg.visualize:
+        if samples.exists():
+            shutil.rmtree(samples)
+        export_clip_sample_contact_sheets(
+            weak_parquet=str(gaps),
+            mined_parquet=str(mined),
+            output_dir=str(samples),
+            source_pairs_file=str(current / "mining" / "mined_pairs.json"),
+            max_samples_per_group=cfg.viz_max_samples_per_group,
+            max_total_samples=cfg.viz_max_total_samples,
+            tile_size=cfg.viz_tile_size,
+            host_path_map={
+                "/results": str(results),
+                "/data": str(pathlib.Path(cfg.iaa_source_image_dir).parent.parent),
+            },
+        )
+        if not samples.is_dir() or not any(samples.iterdir()):
+            raise ValueError(f"contact-sheet output is empty: {samples}")
+        outputs["samples_dir"] = str(samples)
+    if cfg.visualize_embeddings:
+        weak_input = current / "embeddings" / "viz_weak" / "input.parquet"
+        mined_input = current / "mining" / "mined_unique_images.parquet"
+        prepare_clip_images_for_embedding(
+            input_parquet=str(gaps),
+            output_parquet_path=str(weak_input),
+            image_dir=cfg.iaa_eval_image_dir,
+        )
+        prepare_clip_images_for_embedding(
+            input_parquet=str(mined),
+            output_parquet_path=str(mined_input),
+            image_dir=cfg.iaa_source_image_dir,
+        )
+        _require([weak_input, mined_input])
+        outputs.update(
+            {"weak_input_parquet": str(weak_input), "mined_input_parquet": str(mined_input)}
+        )
+        has_previous = args.iter_num > 1 or bool(cfg.iaa_train_pairs_source_file)
+        if cfg.continual_dataset and has_previous:
+            previous_config = resolve_prev_clip_train_config(
+                base_experiment_path=str(results),
+                iter_num=args.iter_num,
+                continual_dataset=cfg.continual_dataset,
+                base_template=cfg.train_config,
+                train_image_list_file="",
+            )
+            previous_pool = current / "embeddings" / "previous" / "prev_pool.parquet"
+            prepare_prev_clip_data_for_embedding(
+                prev_train_config_yaml=previous_config,
+                output_parquet_path=str(previous_pool),
+                host_path_map={"/results": str(results), "/data": str(pathlib.Path(cfg.iaa_source_image_dir).parent.parent)},
+            )
+            _require([previous_pool])
+            outputs["previous_input_parquet"] = str(previous_pool)
+    return outputs
+
+
+def visualize_finish(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.visualization import create_tsne_visualization
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    current = _iter_dir(results, args.iter_num)
+    if not cfg.visualize_embeddings:
+        return {"visualize_embeddings": False}
+    output = current / "visualization" / "tsne_plot.png"
+    try:
+        output.unlink()
+    except FileNotFoundError:
+        pass
+    create_tsne_visualization(
+        weak_embeddings_dir=str(current / "embeddings" / "viz_weak"),
+        augmented_embeddings_dir=str(current / "embeddings" / "augmented"),
+        previous_embeddings_dir=str(current / "embeddings" / "previous"),
+        output_plot_path=str(output),
+    )
+    _require([output])
+    return {"tsne_plot": str(output)}
+
+
+def train_config(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.utils import create_clip_train_config, resolve_prev_clip_train_config
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    current = _iter_dir(results, args.iter_num)
+    previous = resolve_prev_clip_train_config(
+        base_experiment_path=str(results),
+        iter_num=args.iter_num,
+        continual_dataset=cfg.continual_dataset,
+        base_template=cfg.train_config,
+        train_image_list_file="",
+    )
+    output = current / "specs" / "train_config.yaml"
+    create_clip_train_config(
+        base_config_yaml=previous,
+        new_config_yaml=str(output),
+        output_dir=f"/results/iter_{args.iter_num}",
+        checkpoint_path=_training_checkpoint(cfg, args.iter_num),
+        sweep_args=cfg.sweep_args_str,
+        mined_image_dir=cfg.iaa_source_image_dir,
+        mined_caption_dir=cfg.iaa_source_caption_dir,
+        mined_image_list_file=f"/results/iter_{args.iter_num}/mining/mined_image_list.txt",
+        caption_file_suffix=".txt",
+        train_image_dir=cfg.iaa_train_image_dir,
+        train_caption_dir=cfg.iaa_train_caption_dir,
+        train_image_list_file="",
+        train_pairs_file="",
+        mined_pairs_file=f"/results/iter_{args.iter_num}/mining/mined_pairs.json",
+        val_image_list_file="/results/iaa_splits/val_list.txt",
+        val_image_dir=cfg.iaa_eval_image_dir,
+        val_caption_dir=cfg.iaa_eval_caption_dir,
+        continual_dataset=cfg.continual_dataset,
+    )
+    _require([output])
+    return {"train_config": str(output), "checkpoint_input": _training_checkpoint(cfg, args.iter_num)}
+
+
+def publish_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.utils import get_current_checkpoint, normalize_clip_pretrained_checkpoint
+
+    results = _results(args.results_dir)
+    _config(args.deft_config, results)
+    state_config = _state(results).get("config")
+    if not isinstance(state_config, dict):
+        raise ValueError("state.config must be an object")
+    current = _iter_dir(results, args.iter_num)
+    train_dir = current / "train"
+    command_status = pathlib.Path(os.path.abspath(args.train_command_status.expanduser()))
+    expected_status = train_dir / "train.status.json"
+    if command_status != expected_status:
+        raise ValueError(
+            f"--train-command-status must be {expected_status}, got {command_status}"
+        )
+    if (
+        not command_status.is_file()
+        or command_status.stat().st_size == 0
+        or command_status.is_symlink()
+        or command_status.resolve() != command_status
+    ):
+        raise ValueError(f"train command status is missing or unsafe: {command_status}")
+    payload = json.loads(command_status.read_text())
+    expected_command = expected_container_command(
+        "train", f"iter{args.iter_num}", state_config
+    )
+    attempt = payload.get("attempt") if isinstance(payload, dict) else None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != "1"
+        or payload.get("workflow") != "tao-run-deft-iaa"
+        or payload.get("kind") != "container"
+        or payload.get("name") != "train"
+        or payload.get("status") != "ok"
+        or payload.get("exit_code") != 0
+        or payload.get("docker_exit_code") != 0
+        or payload.get("artifact_error") is not None
+        or payload.get("image_kind") != expected_image_kind("train")
+        or payload.get("image") != state_config.get("pyt_image")
+        or payload.get("command") != expected_command
+        or payload.get("command_sha256") != command_sha256(expected_command)
+        or payload.get("passed_hf_token")
+        is not expected_hf_forwarding("train", state_config)
+        or not isinstance(attempt, int)
+        or isinstance(attempt, bool)
+        or not 1 <= attempt <= 2
+        or not isinstance(payload.get("finished_at"), str)
+        or not payload.get("finished_at", "").strip()
+    ):
+        raise ValueError("--train-command-status does not prove the approved train command")
+    started_ns = payload.get("started_ns")
+    if not isinstance(started_ns, int) or isinstance(started_ns, bool) or started_ns < 1:
+        raise ValueError("train command status started_ns must be a positive integer")
+    log_path = pathlib.Path(str(payload.get("log_path", "")))
+    if (
+        not log_path.is_absolute()
+        or not log_path.is_file()
+        or log_path.stat().st_size == 0
+        or log_path.is_symlink()
+        or log_path.resolve() != log_path
+    ):
+        raise ValueError("train command status log_path is missing or unsafe")
+    try:
+        log_path.relative_to(train_dir)
+    except ValueError as exc:
+        raise ValueError("train command status log_path must be inside train/") from exc
+    train_tao_status = train_dir / "status.json"
+    fresh = {
+        str(pathlib.Path(str(item)).resolve())
+        for item in payload.get("fresh_outputs", [])
+        if isinstance(item, str)
+    }
+    if str(train_tao_status.resolve()) not in fresh:
+        raise ValueError("train command status does not bind train/status.json")
+    if (
+        not train_tao_status.is_file()
+        or train_tao_status.stat().st_size == 0
+        or train_tao_status.is_symlink()
+        or train_tao_status.resolve() != train_tao_status
+        or train_tao_status.stat().st_mtime_ns < started_ns
+    ):
+        raise ValueError("TAO train status is missing, unsafe, empty, or stale")
+    if "Train finished successfully." not in train_tao_status.read_text(errors="replace"):
+        raise ValueError("TAO train status lacks 'Train finished successfully.'")
+
+    best = train_dir / "best" / "clip_best_val_t2i_mAP.pth"
+    metadata = train_dir / METADATA_RELPATH
+    normalized = current / "pretrained" / "model_state.pth"
+    for directory in (train_dir, best.parent, normalized.parent):
+        if directory.resolve() != directory:
+            raise ValueError(
+                f"checkpoint output directory must not traverse a symlink: {directory}"
+            )
+    for output in (best, metadata, normalized):
+        try:
+            output.unlink()
+        except FileNotFoundError:
+            pass
+    published = pathlib.Path(get_current_checkpoint(str(train_dir)))
+    if pathlib.Path(os.path.abspath(published)) != best:
+        raise ValueError(f"checkpoint publisher returned {published}, expected {best}")
+    provenance = validate_best_checkpoint(best, train_dir, started_ns=started_ns)
+    normalize_clip_pretrained_checkpoint(str(best), str(normalized))
+    _require([best, metadata, normalized])
+    if normalized.is_symlink() or normalized.resolve() != normalized:
+        raise ValueError(f"normalized checkpoint must not traverse a symlink: {normalized}")
+    return {
+        "best_ckpt": str(best),
+        "best_ckpt_metadata": provenance["best_ckpt_metadata"],
+        "pretrained_state": str(normalized),
+    }
+
+
+def eval_config(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.utils import create_clip_eval_config
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    if args.iter_label == "baseline":
+        host_dir = results / "zs"
+        container_dir = "/results/zs"
+        checkpoint = cfg.init_checkpoint
+    else:
+        number = int(args.iter_label[4:])
+        host_dir = _iter_dir(results, number)
+        container_dir = f"/results/iter_{number}"
+        checkpoint = f"{container_dir}/train/best/clip_best_val_t2i_mAP.pth"
+    output = host_dir / "specs" / "eval_config.yaml"
+    create_clip_eval_config(
+        base_config_yaml=cfg.eval_config,
+        new_config_yaml=str(output),
+        output_dir=container_dir,
+        checkpoint_path=checkpoint,
+        eval_image_dir=cfg.iaa_eval_image_dir,
+        eval_caption_dir=cfg.iaa_eval_caption_dir,
+        eval_image_list_file="/results/iaa_splits/eval_list.txt",
+        caption_file_suffix=".txt",
+    )
+    _require([output])
+    return {"eval_config": str(output), "checkpoint": checkpoint}
+
+
+def iteration_summary(args: argparse.Namespace) -> dict[str, Any]:
+    from iaa_deft.data_mining import write_iteration_summary
+
+    results = _results(args.results_dir)
+    cfg = _config(args.deft_config, results)
+    current = _iter_dir(results, args.iter_num)
+    output = pathlib.Path(
+        write_iteration_summary(
+            experiment_dir=str(current),
+            iter_num=args.iter_num,
+            gaps_parquet=str(current / "gaps" / "kpi_gaps.parquet"),
+            mined_parquet=str(current / "mining" / "mined_samples.parquet"),
+            mined_pairs_file=str(current / "mining" / "mined_pairs.json"),
+            training_checkpoint=_training_checkpoint(cfg, args.iter_num),
+            next_checkpoint_path=f"/results/iter_{args.iter_num}/train/best/clip_best_val_t2i_mAP.pth",
+        )
+    ).resolve()
+    _require([output])
+    return {"iteration_summary": str(output)}
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="stage", required=True)
+
+    def common(name: str, *, iteration: bool = False) -> argparse.ArgumentParser:
+        child = sub.add_parser(name)
+        child.add_argument("--results-dir", required=True, type=pathlib.Path)
+        child.add_argument("--deft-config", required=True, type=pathlib.Path)
+        if iteration:
+            child.add_argument("--iter-num", required=True, type=int)
+        return child
+
+    common("dataset-materialize")
+    common("gap-analysis", iteration=True)
+    common("mining-postprocess", iteration=True)
+    history = common("history-select", iteration=True)
+    history.add_argument("--resume", action="store_true")
+    common("visualize-prepare", iteration=True)
+    common("visualize-finish", iteration=True)
+    common("train-config", iteration=True)
+    publish = common("publish-checkpoint", iteration=True)
+    publish.add_argument(
+        "--train-command-status", required=True, type=pathlib.Path
+    )
+    evaluate = common("eval-config")
+    evaluate.add_argument("--iter-label", required=True)
+    common("iteration-summary", iteration=True)
+    return parser
+
+
+HANDLERS = {
+    "dataset-materialize": dataset_materialize,
+    "gap-analysis": gap_analysis,
+    "mining-postprocess": mining_postprocess,
+    "history-select": history_select,
+    "visualize-prepare": visualize_prepare,
+    "visualize-finish": visualize_finish,
+    "train-config": train_config,
+    "publish-checkpoint": publish_checkpoint,
+    "eval-config": eval_config,
+    "iteration-summary": iteration_summary,
+}
+
+_STAGE_OUTPUT_KEYS = {
+    "dataset-materialize": {
+        "eval_list",
+        "eval_pairs",
+        "val_list",
+        "pool_list",
+        "pool_pairs",
+        "source_pool_parquet",
+    },
+    "gap-analysis": {"gaps_parquet"},
+    "mining-postprocess": {"candidate_pairs"},
+    "history-select": {
+        "mined_image_list",
+        "mined_pairs",
+        "mined_manifest",
+        "cumulative_names",
+        "history_file",
+    },
+    "visualize-prepare": {
+        "samples_dir",
+        "weak_input_parquet",
+        "mined_input_parquet",
+        "previous_input_parquet",
+    },
+    "visualize-finish": {"tsne_plot"},
+    "train-config": {"train_config"},
+    "publish-checkpoint": {
+        "best_ckpt",
+        "best_ckpt_metadata",
+        "pretrained_state",
+    },
+    "eval-config": {"eval_config"},
+    "iteration-summary": {"iteration_summary"},
+}
+
+
+def _status_directory(args: argparse.Namespace, results: pathlib.Path) -> pathlib.Path:
+    if args.stage == "dataset-materialize":
+        return results / "dataset_setup"
+    if args.stage == "eval-config":
+        return (
+            results / "zs" / "specs"
+            if args.iter_label == "baseline"
+            else results / f"iter_{int(args.iter_label[4:])}" / "specs"
+        )
+    number = getattr(args, "iter_num", None)
+    if not isinstance(number, int):
+        raise ValueError(f"cannot derive host status directory for {args.stage}")
+    current = _iter_dir(results, number)
+    if args.stage == "gap-analysis":
+        return current / "gaps"
+    if args.stage in {"mining-postprocess", "history-select"}:
+        return current / "mining"
+    if args.stage in {"visualize-prepare", "visualize-finish"}:
+        return current / "visualization"
+    if args.stage == "train-config":
+        return current / "specs"
+    if args.stage == "publish-checkpoint":
+        return current / "train"
+    if args.stage == "iteration-summary":
+        return current
+    raise ValueError(f"cannot derive host status directory for {args.stage}")
+
+
+def _result_paths(
+    report: dict[str, Any], results: pathlib.Path, stage: str
+) -> list[str]:
+    paths: list[str] = []
+    output_keys = _STAGE_OUTPUT_KEYS.get(stage)
+    if output_keys is None:
+        raise ValueError(f"no output contract for host stage {stage}")
+    for key in output_keys:
+        value = report.get(key)
+        if not isinstance(value, str):
+            continue
+        candidate = pathlib.Path(value).expanduser()
+        if not candidate.is_absolute():
+            continue
+        absolute = pathlib.Path(os.path.abspath(candidate))
+        resolved = absolute.resolve()
+        try:
+            resolved.relative_to(results)
+        except ValueError:
+            continue
+        if absolute.exists():
+            # Preserve the lexical canonical output (not a symlink target) in
+            # evidence while using the resolved path only for containment.
+            paths.append(str(absolute))
+    return sorted(set(paths))
+
+
+def _execute_stage(
+    args: argparse.Namespace, results: pathlib.Path, status_dir: pathlib.Path
+) -> int:
+    status_dir.mkdir(parents=True, exist_ok=True)
+    status_path = status_dir / f"{args.stage}.host.status.json"
+    log_path = status_dir / f"{args.stage}.host.log"
+    lock_path = status_dir / f"{args.stage}.host.launch.lock"
+    with lock_path.open("a+") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print(
+                f"run_iaa_stage[{args.stage}]: another process owns {lock_path}",
+                file=sys.stderr,
+            )
+            return 2
+
+        prior_attempt = 0
+        if status_path.exists():
+            try:
+                existing = json.loads(status_path.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                print(
+                    f"run_iaa_stage[{args.stage}]: existing status is unreadable: {exc}",
+                    file=sys.stderr,
+                )
+                return 2
+            if not isinstance(existing, dict) or existing.get("name") != args.stage:
+                print(
+                    f"run_iaa_stage[{args.stage}]: existing status has the wrong identity",
+                    file=sys.stderr,
+                )
+                return 2
+            raw_attempt = existing.get("attempt", 1)
+            if (
+                not isinstance(raw_attempt, int)
+                or isinstance(raw_attempt, bool)
+                or raw_attempt < 1
+            ):
+                print(
+                    f"run_iaa_stage[{args.stage}]: existing status has invalid attempt",
+                    file=sys.stderr,
+                )
+                return 2
+            prior_attempt = raw_attempt
+            # Acquiring the process-held flock proves no earlier adapter still
+            # owns this stable stage, even if its last status remained running.
+            if prior_attempt >= 2:
+                print(
+                    f"run_iaa_stage[{args.stage}]: attempt budget exhausted "
+                    f"(attempt={prior_attempt}); hard-stop instead of retrying",
+                    file=sys.stderr,
+                )
+                return 2
+
+        started_ns = time.time_ns()
+        started_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+        base_status = {
+            "schema_version": "1",
+            "workflow": "tao-run-deft-iaa",
+            "kind": "host",
+            "name": args.stage,
+            "attempt": prior_attempt + 1,
+            "pid": os.getpid(),
+            "resume": bool(
+                args.stage == "history-select" and getattr(args, "resume", False)
+            ),
+            "started_at": started_at,
+            "started_ns": started_ns,
+            "log_path": str(log_path),
+            "fresh_outputs": [],
+        }
+        _atomic_json(
+            status_path,
+            {
+                **base_status,
+                "finished_at": None,
+                "status": "running",
+                "exit_code": None,
+            },
+        )
+        try:
+            with (
+                log_path.open("w") as log,
+                contextlib.redirect_stdout(log),
+                contextlib.redirect_stderr(log),
+            ):
+                report = HANDLERS[args.stage](args)
+                log.write(json.dumps(report, sort_keys=True) + "\n")
+        except Exception as exc:  # adapters convert operational failures to evidence
+            finished_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+            with log_path.open("a") as log:
+                log.write(f"{type(exc).__name__}: {exc}\n")
+            _atomic_json(
+                status_path,
+                {
+                    **base_status,
+                    "finished_at": finished_at,
+                    "status": "error",
+                    "exit_code": 2,
+                },
+            )
+            print(f"run_iaa_stage[{args.stage}]: {exc}", file=sys.stderr)
+            return 2
+        fresh_outputs = _result_paths(report, results, args.stage)
+        finished_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+        _atomic_json(
+            status_path,
+            {
+                **base_status,
+                "finished_at": finished_at,
+                "status": "ok",
+                "exit_code": 0,
+                "fresh_outputs": fresh_outputs,
+            },
+        )
+        report = dict(report)
+        report["host_status"] = str(status_path)
+        report["host_log"] = str(log_path)
+        print(json.dumps(report, sort_keys=True))
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.stage == "eval-config" and args.iter_label != "baseline":
+        if not args.iter_label.startswith("iter") or not args.iter_label[4:].isdigit() or int(args.iter_label[4:]) < 1:
+            print("run_iaa_stage: --iter-label must be baseline or iterN", file=sys.stderr)
+            return 2
+    try:
+        results = _results(args.results_dir)
+        status_dir = _status_directory(args, results)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        print(f"run_iaa_stage[{args.stage}]: {exc}", file=sys.stderr)
+        return 2
+    return _execute_stage(args, results, status_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-iaa/skill-card.md
+++ b/skills/applications/tao-run-deft-iaa/skill-card.md
@@ -1,0 +1,63 @@
+## Description: <br>
+Run the full, self-contained DEFT improvement loop for NVIDIA TAO CLIP / SigLIP2 Image Attribute Augmentation (IAA) models: zero-shot evaluation, per-attribute gap analysis, text-embedding k-NN mining, history-aware selection, continual-dataset retraining, and re-evaluation against an approved retrieval metric. Customers provide the IAA data export, not an implementation source checkout. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 AND CC-BY-4.0 <br>
+
+## Use Case: <br>
+Developers and engineers use this skill to execute or resume the IAA DEFT workflow on local NVIDIA Docker. The workflow establishes a zero-shot baseline, analyzes weak attributes, mines a caption pool, selects samples without reusing evaluation data, retrains, and repeats until the approved metric target passes or the finite iteration budget is exhausted. A target-free run executes its approved budget and reports the best result. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: GPU/container cost, interrupted multi-stage runs, stale artifacts, data leakage, or incorrect metric evidence can make an iterative result unreliable. <br>
+Mitigation: The skill uses one explicit approval boundary before side effects, a bounded loop, deterministic config and container wrappers, exact argv/digest and fresh-output evidence, current-attempt checkpoint provenance, evaluation-split leakage checks, immutable metric contracts, journaled canonical state commits, fail-closed audits, and bounded recovery. Credential files are never opened or sourced, and credential values are never printed or persisted. <br>
+
+## Reference(s): <br>
+- [Pipeline and State](references/pipeline-and-state.md) <br>
+- [Pre-Flight Checks](references/preflight.md) <br>
+- [CLIP Train / Evaluate](references/clip-train-eval.md) <br>
+- [IAA Metric Contract](references/metric-contract.md) <br>
+- [Data Layout](references/data-layout.md) <br>
+- [Gap Analysis](references/gap-analysis.md) <br>
+- [Mining and Selection](references/mining.md) <br>
+- [Visualization](references/visualization.md) <br>
+- [Scripts and Stage Adapters](references/scripts-and-agents.md) <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Shell commands, HTML report, JSON state, JSONL event log, metrics and model artifacts] <br>
+**Output Format:** [Markdown guidance and deterministic on-disk artifacts] <br>
+**Output Parameters:** [Approved IAA DEFT run configuration and iteration budget] <br>
+**Other Properties Related to Output:** [`deft_state.json` and `loop_log.jsonl` are canonical; `DEFT_Loop_Report.html` is rendered deterministically after a successful completion audit] <br>
+
+## Evaluation Agents Used: <br>
+- Codex (implementation review and local validation) <br>
+
+## Evaluation Tasks: <br>
+- Static validation: compile all bundled Python scripts, syntax-check the shell wrapper and metadata, and run the repository skill validator. <br>
+- Synthetic state-machine smoke: render and initialize immutable inputs, complete a two-iteration max-budget path, require the completion audit, and render the report twice deterministically. <br>
+- Branch/recovery checks: exercise disabled and enabled visualization, optional checksum evidence, nonterminal failure to terminal hard-stop, journaled state/log recovery, orphan-container overlap rejection, and persisted two-attempt limits. <br>
+- Negative-path checks: reject cross-iteration artifacts, zero-row mining, false KPI stops, duplicate metric rows, unsupported KPI query types, stale/unbound outputs, command tampering, stale or cross-iteration checkpoint targets, symlink chains/escapes, and malformed state/log labels. <br>
+
+## Evaluation Metrics Used: <br>
+- Python and shell syntax success. <br>
+- Deterministic transition, artifact-binding, metric-binding, and completion-audit behavior on a synthetic fixture. <br>
+- Expected rejection of tested invalid inputs and transitions. <br>
+
+## Evaluation Results: <br>
+Repository/static checks and the synthetic two-iteration, visualization, checksum, hard-stop, authenticated-forwarding, recovery, retry-bound, checkpoint-contract, deterministic-report, and clean bundled-runtime import tests passed. The listed invalid evidence, transition, provenance, and path cases were rejected as expected. The checkpoint contract was also checked against a real IAA reference-run relative-symlink artifact shape. A live end-to-end run through the revised wrapper was not performed as part of this review. <br>
+
+## Skill Version(s): <br>
+0.3.3 (source: frontmatter) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). <br>

--- a/skills/applications/tao-run-deft-iaa/specs/deft_config.yaml
+++ b/skills/applications/tao-run-deft-iaa/specs/deft_config.yaml
@@ -1,0 +1,66 @@
+experiment:
+  name: "iaa_deft"
+  results_path: "results"
+  train_config: "specs/tao_spec.yaml"
+  eval_config: "specs/tao_spec.yaml"
+  visualize: true
+  visualize_embeddings: true
+
+iteration:
+  start: 1
+  end: 2
+
+training:
+  init_checkpoint: ""
+  continual_model: false
+  continual_dataset: true
+  num_nodes: 1
+
+mining:
+  topn: 25
+  knn_metric: "cosine"
+  knn_batch_size: 32
+  history_aware:
+    enabled: true
+    replay_fraction: 0.20
+  recovery:
+    caption_expansion:
+      enabled: false
+      mode: "nearest"
+      max_pairs_per_image_path: 2
+      max_expanded_pair_fraction: 0.25
+      dedupe_normalized_caption: true
+      count_expanded_pairs_toward_target: "auto"
+
+gap_analysis:
+  metric_name: "Rank-1"
+  weak_attribute_topk: 4
+  target_query_count: 10000
+  queries_per_slice: 256
+  query_types: "easy,medium"
+  caption_diversity:
+    enabled: true
+    history_file: "caption_selection_history.json"
+    history_policy: "prefer_unseen"
+    coverage_target: 1.0
+    min_unique_texts_per_attribute: 8
+    max_rows_per_unique_text: 1
+    max_rows_per_image_path: 1
+
+iaa:
+  # train_pairs_source_file: "data/iaa_v31_tao_ft/train_pairs.json"
+  pool_pairs_source_file: "data/iaa_v31_tao_ft/train_pairs.json"
+  eval_pairs_source_file: "data/iaa_v31_tao_ft/val_pairs.json"
+  train_image_dir: "data/iaa_v31_tao_ft/images"
+  train_caption_dir: "data/iaa_v31_tao_ft/captions"
+  source_image_dir: "data/iaa_v31_tao_ft/images"
+  source_caption_dir: "data/iaa_v31_tao_ft/captions"
+  eval_image_dir: "data/iaa_v31_tao_ft/images"
+  eval_caption_dir: "data/iaa_v31_tao_ft/captions"
+  seed_exclude_datasets: "CUHK_PEDES,ICFG_PEDES"
+  augmented_suffix: "_Aug"
+  query_types: "easy,medium,hard,natural_caption,original_captions"
+  mining_pool_mode: "real"
+  max_seed_rows: 0
+  max_aug_pool_rows: 0
+  val_sample_size: 512

--- a/skills/applications/tao-run-deft-iaa/specs/image_embed_spec.yaml
+++ b/skills/applications/tao-run-deft-iaa/specs/image_embed_spec.yaml
@@ -1,0 +1,5 @@
+input_parquet: ???
+output_parquet: ???
+model: "SigLIP"
+model_path: "google/siglip2-so400m-patch16-256"
+batch_size: 64

--- a/skills/applications/tao-run-deft-iaa/specs/mining_spec.yaml
+++ b/skills/applications/tao-run-deft-iaa/specs/mining_spec.yaml
@@ -1,0 +1,8 @@
+source_parquet: ???
+target_parquet: ???
+output_parquet: ???
+topn: 5
+knn_metric: euclidean
+source_embed_column_name: embedding
+target_embed_column_name: embedding
+filter_by_label: "false"

--- a/skills/applications/tao-run-deft-iaa/specs/tao_spec.yaml
+++ b/skills/applications/tao-run-deft-iaa/specs/tao_spec.yaml
@@ -1,0 +1,95 @@
+results_dir: ???
+
+train:
+  num_epochs: 1
+  checkpoint_interval: 1
+  validation_interval: 1
+  resume_training_checkpoint_path: null
+  grad_checkpointing: false
+  grad_clip_norm: null
+  precision: fp16
+  distributed_strategy: "ddp"
+  pretrained_model_path: null
+  loss_type: siglip  # siglip or clip
+  siglip_loss_dist_impl: "gather"
+  siglip_loss_mask_mode: none  # none or attribute_match_ignore
+  triplet_loss_weight: 0.5  # set > 0 to enable triplet loss
+  triplet_margin: 0.2
+  # Set num_gpus/gpu_ids to the shape approved in the Pre-Flight Summary;
+  # per-GPU batch_size is fixed, so world size multiplies the effective batch.
+  num_gpus: 1
+  num_nodes: 1
+  gpu_ids: [0]
+  optim:
+    optimizer_type: adamw  # adamw, lamb, or sgd
+    vision_lr: 1.0e-7
+    text_lr: 1.0e-7
+    weight_decay: 1.0e-4
+    betas: [0.9, 0.95]
+    eps: 1.0e-6
+    warmup_steps: 5
+    scheduler: "cosine"
+  validation_interval: 1  # Run validation every N epochs
+  val_check_interval: null  # Or run validation every N steps (takes precedence if set)
+  # validate_before_training: false  # run full validation before the first training step
+  # profiler: none  # none, simple, advanced, or pytorch
+  # profiler_dir: null  # Defaults to train.results_dir/profiler
+  # profiler_filename: null  # Rank suffix is appended automatically
+  # profiler_wait: 1  # PyTorch profiler schedule wait steps
+  # profiler_warmup: 1  # PyTorch profiler schedule warmup steps
+  # profiler_active: 3  # PyTorch profiler schedule active steps
+  # profiler_repeat: 1  # Set 0 to repeat indefinitely
+  # profiler_record_shapes: false
+  # profiler_profile_memory: false
+  # profiler_with_stack: false
+
+dataset:
+  seed: 42
+  train:
+    type: custom  # custom or wds
+    balance_query_types: false  # true + per-dataset train_pairs.json balances query types
+    unique_caption_per_batch: false  # enforce unique captions when balance_query_types is true
+    include_attribute_metadata: false  # include optional image/text attribute tensors in batches
+    datasets:
+    - image_dir: ???
+      caption_dir: ???
+      caption_file_suffix: .txt
+      image_list_file: null  # Optional: text file listing image filenames
+      train_pairs_file: null  # Optional per dataset block; required for that block when balance_query_types is true
+    batch_size: 32
+    num_workers: 16
+  val:
+    datasets: []  # Same format as train.datasets
+    metadata_match_eval: false  # use attribute metadata for text-to-image validation positives
+    batch_size: 64
+    num_workers: 4
+
+model:
+  type: "siglip2-so400m-patch16-256"  # siglip2-so400m-patch16-256, c-radio_v3-h, etc.
+
+evaluate:
+  checkpoint: google/siglip2-so400m-patch16-256
+  batch_size: 32
+  num_workers: 8
+  num_gpus: 1
+  gpu_ids: [0]
+
+inference:
+  checkpoint: siglip2-so400m-patch16-256
+  batch_size: 32
+  num_workers: 8
+  num_gpus: 1
+  gpu_ids: [0]
+
+export:
+  checkpoint: ???
+  onnx_file: ???
+  encoder_type: combined  # combined or separate
+  input_height: 256
+  input_width: 256
+  batch_size: 1
+  opset_version: 17
+  # NOTE: NaFlex models (e.g. siglip2-so400m-patch16-naflex) are not supported
+  # for ONNX/TRT export due to dynamic patch embeddings that cannot be traced
+  # to a static graph. Use a fixed-resolution SigLIP2 variant instead
+  # (e.g. siglip2-so400m-patch16-384).

--- a/skills/applications/tao-run-deft-iaa/specs/text_embed_spec.yaml
+++ b/skills/applications/tao-run-deft-iaa/specs/text_embed_spec.yaml
@@ -1,0 +1,5 @@
+input_parquet: ???
+output_parquet: ???
+model: "SigLIP2"
+model_path: "google/siglip2-so400m-patch16-256"
+batch_size: 64


### PR DESCRIPTION
## Summary

- add the self-contained `tao-run-deft-iaa` workflow for Image Attribute Augmentation (IAA): dataset preparation, zero-shot evaluation, bounded mining/training iterations, validation, resume, and deterministic reporting
- add AOI-style bounded archive discovery under explicit or conventional IAA input roots, with a two-level cap, symlink rejection, provenance reporting, and explicit ambiguity handling
- register `tao-deft-iaa` as shorthand for the canonical workflow and preserve its fixed local-Docker platform contract
- add focused planning evaluations and Docker GPU-device scoping tests

## Why

Customers receive the IAA dataset archives, not the development notebook or a source checkout. Direct-only discovery can miss normal nested export/drop layouts, while a broad recursive home or repository scan can surface unrelated tutorial data with unclear provenance. The new intake searches only semantically selected IAA/input subtrees, reports exactly where candidates came from, and never widens the search automatically.

## User impact

A user can invoke `tao-deft-iaa` without understanding internal stage scripts or notebook implementation details. The intake identifies one required `images_raw.tar` / `meta.tar.gz` pair, distinguishes archive-only and mixed development locations, filters resume state by exact IAA workflow identity, and asks one consolidated question for the required iteration/time bound and any real ambiguity.

No AOI application files or shared launcher files are changed.

## Validation

Passed:

- `./scripts/validate-skills.sh`
- `./scripts/validate-skills.sh --quick`
- `python3 scripts/stamp_versions.py --check`
- `python3 -m pytest -q scripts/tests/test_iaa_deft_container.py` — 5 passed
- AST parsing of all 22 bundled IAA Python files
- JSON parsing and renamed runtime/entry-point import checks
- repository scan confirming no standalone PAS identifiers or PAS-named files remain in the final PR content
- `git diff --check`

A broad `python3 -m pytest -q` attempt on the earlier revision was interrupted because the repository's `plugins/tao-skill-bank` symlink caused recursive duplicate collection. Before interruption it recorded 3,179 passes, 14 skips, and repeated failures only in two unchanged virtualenv process-group cancellation tests. No live Docker/GPU IAA end-to-end run was performed for this PR.
