### PR TITLE
[TAO-2511][Feature] Support frozen DINOv3 backbones in DEFT AOI

### DIFF
--- a/scripts/tests/test_downstream_backbone_drift.py
+++ b/scripts/tests/test_downstream_backbone_drift.py
@@ -3,11 +3,10 @@
 
 """Drift guard for DINOv3 backbone options in downstream skill schemas (bug 6465432).
 
-DINOv3 backbones are registered as selectable backbones for the segformer and
-visual_changenet dense tasks (tao-pytorch/tao-core config backbone ``type``
-valid_options). The committed skill schemas for those two models are generated
-from the tao-core configs; this guards against them falling behind the source
-again (as all 11 did in the 7.1.0 report).
+DINOv3 backbones are selectable for SegFormer and Visual ChangeNet. The shared
+variants must remain in both generated schema sets; ViT-7B is currently a
+Visual ChangeNet option only. This guards the committed skill schemas against
+falling behind the tao-core config source again.
 """
 import json
 from pathlib import Path
@@ -20,8 +19,7 @@ SCHEMA_GLOBS = [
     "skills/models/tao-train-visual-changenet/schemas/*.schema.json",
 ]
 
-# The DINOv3 backbones registered for dense downstream tasks in tao-pytorch.
-# 7B is intentionally excluded - not a registered downstream backbone.
+# DINOv3 backbones shared by both dense downstream tasks.
 DINOV3_DOWNSTREAM_BACKBONES = [
     "vit_small_dinov3",
     "vit_small_plus_dinov3",
@@ -30,6 +28,7 @@ DINOV3_DOWNSTREAM_BACKBONES = [
     "vit_huge_plus_dinov3",
 ]
 
+VISUAL_CHANGENET_DINOV3_BACKBONES = DINOV3_DOWNSTREAM_BACKBONES + ["vit_7b_dinov3"]
 
 def _schema_files():
     """Return the committed segformer/visual_changenet skill schema paths."""
@@ -64,5 +63,8 @@ def test_downstream_schemas_exist():
 def test_dinov3_backbones_present(schema_path):
     enum = _find_backbone_enum(json.loads(schema_path.read_text()))
     assert enum is not None, f"{schema_path}: no backbone type enum found"
-    missing = [b for b in DINOV3_DOWNSTREAM_BACKBONES if b not in enum]
+    expected = DINOV3_DOWNSTREAM_BACKBONES
+    if "tao-train-visual-changenet" in schema_path.parts:
+        expected = VISUAL_CHANGENET_DINOV3_BACKBONES
+    missing = [backbone for backbone in expected if backbone not in enum]
     assert not missing, f"{schema_path.name} backbone enum missing DINOv3 options: {missing}"

--- a/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
+++ b/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
@@ -36,6 +36,9 @@ commit if either is absent. Never hand-edit either file.
   },
   "iteration":      "iter1",
   "backbone":       "/abs/path/to/c_radio_v2_b.ckpt",
+  "backbone_container_path": "/data/pretrained_models/c_radio_v2_b.ckpt",
+  "backbone_type":  "c_radio_v2_vit_base_patch16_224",
+  "backbone_frozen": false,
   "images_dir":     "/abs/path/to/workspace/images",
   "training_spec":  "/abs/path/to/baseline_spec.yaml"
 }
@@ -49,6 +52,9 @@ commit if either is absent. Never hand-edit either file.
 | `metric_result` | Best measured value, recomputed pass state, evidence, constraints, and optional diagnostics |
 | `iteration` | Which iteration won (`baseline`, `iter1`, …) |
 | `backbone` | Absolute path to the backbone `.ckpt` (mount this into the container) |
+| `backbone_container_path` | Exact container destination matching the generated inference spec |
+| `backbone_type` | Visual ChangeNet backbone type used by training |
+| `backbone_frozen` | Whether the backbone was frozen during task-level training |
 | `images_dir` | Path the model was evaluated against. Useful default for re-running on KPI data. |
 | `training_spec` | Path to the training YAML used. Read this if you need fields the JSON doesn't expose. |
 
@@ -85,12 +91,16 @@ cp ${RESULTS_DIR}/best_model_inference_spec.yaml /tmp/my_inference.yaml
 TAO_PYT_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
 
 # 4. Run inference. Mount paths from best_model.json into the container.
+HANDOFF="${RESULTS_DIR}/best_model.json"
+BACKBONE=$(jq -er '.backbone | strings | select(length > 0)' "$HANDOFF")
+BACKBONE_CONTAINER_PATH=$(jq -er '.backbone_container_path | strings | select(startswith("/"))' "$HANDOFF")
+
 docker run --pull=never --rm --gpus all --shm-size=8g \
     --user "$(id -u):$(id -g)" \
     -v <your_csv_dir>:/data/infer \
-    -v $(jq -r .images_dir ${RESULTS_DIR}/best_model.json):/data/images \
-    -v $(jq -r .checkpoint ${RESULTS_DIR}/best_model.json):/model/best.pth \
-    -v $(jq -r .backbone ${RESULTS_DIR}/best_model.json):/data/pretrained_models/C-RADIOv2_B.pth \
+    -v "$(jq -er .images_dir "$HANDOFF"):/data/images:ro" \
+    -v "$(jq -er .checkpoint "$HANDOFF"):/model/best.pth:ro" \
+    -v "${BACKBONE}:${BACKBONE_CONTAINER_PATH}:ro" \
     -v /tmp/my_inference.yaml:/specs/inference.yaml \
     -v <output_dir>:/results \
     "$TAO_PYT_IMAGE" \

--- a/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
+++ b/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
@@ -20,13 +20,17 @@ Read `IMAGES_DIR` from `deft_state.json::config.images_dir`; for a new
 workspace it is `<workspace>/images` (legacy `<workspace>/kpi/images` is only a
 Pre-Flight fallback).
 
+`STAGED` is the host file returned by `stage_backbone.py`.
+`BACKBONE_CONTAINER_PATH` is the matching container path written into the
+training spec. Use this resolved pair for every train, evaluate, and inference launch.
+
 ```
 -v <workspace>:/data/workspace                                  # combined iter CSVs + staged images
 -v ${RESULTS_DIR}:/results                                      # canonical run root; never /results/iterN
 -v ${IMAGES_DIR}:/data/datasets/NV_PCB_Siamese/images            # canonical real-image root from state
 -v <workspace>/train/base:/data/datasets/NV_PCB_Siamese/csv      # training_set.csv, validation_set.csv
 -v <workspace>/kpi:/data/datasets/NV_PCB_Siamese/kpi             # testing_set.csv
--v <workspace>/augmentation/backbone/c_radio_v2_b.safetensors:/data/pretrained_models/C-RADIOv2_B.safetensors  # C-RADIO backbone file
+-v "${STAGED}:${BACKBONE_CONTAINER_PATH}:ro"                    # selected backbone file
 ```
 
 ## Spec Key Paths (container-side)
@@ -198,7 +202,9 @@ Pre-Flight **must stage the backbone locally** before launch. The HuggingFace re
 
 ```bash
 STAGED=$(<skill_root>/scripts/deft_python.sh <skill_root>/scripts/stage_backbone.py --workspace <workspace>)
-# STAGED -> <workspace>/augmentation/backbone/c_radio_v2_b.safetensors
+BACKBONE_CONTAINER_PATH="/data/pretrained_models/$(basename "$STAGED")"
+# Rewrite model.backbone.pretrained_backbone_path in the baseline and derived
+# specs to exactly ${BACKBONE_CONTAINER_PATH}.
 ```
 
 Equivalent manual recipe (only if running the script is not possible):
@@ -214,18 +220,19 @@ shutil.copy(src, dst)
 PY
 ```
 
-Then mount as a single file in the train docker invocation:
+Then mount that exact host/container pair in every train, evaluate, and inference
+Docker invocation:
 
 ```bash
--v <workspace>/augmentation/backbone/c_radio_v2_b.safetensors:/data/pretrained_models/C-RADIOv2_B.safetensors
+-v "${STAGED}:${BACKBONE_CONTAINER_PATH}:ro"
 ```
 
-And set the spec field to the container-side path:
+Set the spec field to the same container-side path:
 
 ```yaml
 model:
   backbone:
-    pretrained_backbone_path: /data/pretrained_models/C-RADIOv2_B.safetensors
+    pretrained_backbone_path: /data/pretrained_models/<staged-backbone-filename>
 ```
 
 If `HF_TOKEN` is unset or the workspace already has a staged file, Pre-Flight uses the staged file as-is and skips the download. If neither is available, Pre-Flight **hard stops** — there is no working URL fallback in this TAO version, so silently falling through would just produce the FileNotFoundError above after the container starts.

--- a/skills/applications/tao-run-deft-aoi/scripts/prepare_inference_spec.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/prepare_inference_spec.py
@@ -139,6 +139,67 @@ def _build_inference_spec(
     return spec
 
 
+def _resolve_backbone(
+    train_spec: dict[str, Any],
+    state: dict[str, Any],
+) -> tuple[str, str, str, bool]:
+    """Resolve the host backbone while preserving the legacy AOI mount."""
+    backbone_config = train_spec.get("model", {}).get("backbone", {})
+    container_path = backbone_config.get("pretrained_backbone_path")
+    backbone_type = str(backbone_config.get("type", ""))
+    backbone_frozen = bool(backbone_config.get("freeze_backbone", False))
+    if not isinstance(container_path, str) or not container_path.strip():
+        raise ValueError(
+            "training spec has no model.backbone.pretrained_backbone_path"
+        )
+
+    configured = pathlib.Path(container_path)
+    if configured.suffix not in {".ckpt", ".pth", ".safetensors"}:
+        raise ValueError(f"unsupported pretrained backbone file: {container_path}")
+
+    if configured.is_file():
+        host_path = configured
+    else:
+        backbone_dir = pathlib.Path(state["config"]["backbone_weight_dir"])
+        host_path = backbone_dir / configured.name
+
+        # Existing AOI mounts may rename the single staged C-RADIO file between
+        # host and container. Require the normalized alias; never substitute an
+        # unrelated sole checkpoint. DINO profiles must resolve exactly.
+        if not host_path.is_file() and "dinov3" not in backbone_type:
+            candidates = [
+                path
+                for suffix in (".ckpt", ".pth", ".safetensors")
+                for path in sorted(backbone_dir.glob(f"*{suffix}"))
+                if path.is_file() and path.stat().st_size > 0
+            ]
+            configured_stem = "".join(
+                char for char in configured.stem.casefold() if char.isalnum()
+            )
+            aliases = [
+                path
+                for path in candidates
+                if "".join(
+                    char for char in path.stem.casefold() if char.isalnum()
+                ) == configured_stem
+            ]
+            if len(aliases) == 1:
+                host_path = aliases[0]
+
+    if not host_path.is_file() or host_path.stat().st_size <= 0:
+        raise FileNotFoundError(
+            "the exact pretrained backbone referenced by the training spec is "
+            f"not staged: {host_path}"
+        )
+
+    return (
+        str(host_path.resolve()),
+        container_path,
+        backbone_type,
+        backbone_frozen,
+    )
+
+
 def prepare(results_dir: pathlib.Path) -> dict[str, pathlib.Path]:
     """Write best_model.json and best_model_inference_spec.yaml.
 
@@ -157,13 +218,9 @@ def prepare(results_dir: pathlib.Path) -> dict[str, pathlib.Path]:
         raise FileNotFoundError(f"training spec not found: {train_spec_path}")
     train_spec = yaml.safe_load(train_spec_path.read_text())
 
-    backbone_dir = pathlib.Path(state["config"]["backbone_weight_dir"])
-    backbone_files = (
-        sorted(backbone_dir.glob("*.ckpt"))
-        + sorted(backbone_dir.glob("*.pth"))
-        + sorted(backbone_dir.glob("*.safetensors"))
+    backbone, backbone_container_path, backbone_type, backbone_frozen = (
+        _resolve_backbone(train_spec, state)
     )
-    backbone = str(backbone_files[0]) if backbone_files else str(backbone_dir)
 
     threshold = best.get("threshold")
     handoff = {
@@ -173,6 +230,9 @@ def prepare(results_dir: pathlib.Path) -> dict[str, pathlib.Path]:
         "metric_result": metric_result,
         "iteration": iter_label,
         "backbone": backbone,
+        "backbone_container_path": backbone_container_path,
+        "backbone_type": backbone_type,
+        "backbone_frozen": backbone_frozen,
         "images_dir": state["config"]["images_dir"],
         "training_spec": str(train_spec_path),
     }
@@ -183,6 +243,9 @@ def prepare(results_dir: pathlib.Path) -> dict[str, pathlib.Path]:
         train_spec=train_spec,
         threshold=threshold,
     )
+    inference_spec["model"]["backbone"][
+        "pretrained_backbone_path"
+    ] = backbone_container_path
 
     json_path = results_dir / "best_model.json"
     yaml_path = results_dir / "best_model_inference_spec.yaml"

--- a/skills/applications/tao-run-deft-aoi/scripts/stage_backbone.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/stage_backbone.py
@@ -16,13 +16,18 @@ workspace staging path. Idempotent: if a staged file already exists it is
 reused and no download happens. Hard-fails (non-zero exit) when it cannot
 produce a staged file, so Pre-Flight can hard-stop on the same signal.
 
-The default repo `nvidia/C-RADIOv2-B` ships only `model.safetensors` (no
-`.pth`). HF_TOKEN is read from the environment when present (required for gated
-repos / rate limits).
+The default remains `nvidia/C-RADIOv2-B`. Pass `--backbone-type` for one of the
+supported DINOv3 variants; those profiles fetch the matching timm-format
+`model.safetensors` from Hugging Face. HF_TOKEN is read from the environment
+when present (required for gated repos / rate limits).
 
 CLI:
 
     python scripts/stage_backbone.py --workspace ~/workspace
+
+    # Frozen DINOv3 backbone:
+    python scripts/stage_backbone.py --workspace ~/workspace \
+        --backbone-type vit_large_dinov3
 
     # or an explicit destination / different repo:
     python scripts/stage_backbone.py \
@@ -35,13 +40,55 @@ caller can capture it: STAGED=$(python scripts/stage_backbone.py --workspace ...
 
 import argparse
 import os
+import pathlib
 import shutil
 import sys
 
+import yaml
 
-DEFAULT_REPO_ID = "nvidia/C-RADIOv2-B"
-DEFAULT_FILENAME = "model.safetensors"
-DEFAULT_STAGE_NAME = "c_radio_v2_b.safetensors"
+
+DEFAULT_BACKBONE_TYPE = "c_radio_v2_vit_base_patch16_224"
+# Values are (Hugging Face repo id, repo filename, workspace stage filename).
+BACKBONE_PROFILES = {
+    DEFAULT_BACKBONE_TYPE: (
+        "nvidia/C-RADIOv2-B",
+        "model.safetensors",
+        "c_radio_v2_b.safetensors",
+    ),
+    "vit_small_dinov3": (
+        "timm/vit_small_patch16_dinov3.lvd1689m",
+        "model.safetensors",
+        "vit_small_dinov3.safetensors",
+    ),
+    "vit_small_plus_dinov3": (
+        "timm/vit_small_plus_patch16_dinov3.lvd1689m",
+        "model.safetensors",
+        "vit_small_plus_dinov3.safetensors",
+    ),
+    "vit_base_dinov3": (
+        "timm/vit_base_patch16_dinov3.lvd1689m",
+        "model.safetensors",
+        "vit_base_dinov3.safetensors",
+    ),
+    "vit_large_dinov3": (
+        "timm/vit_large_patch16_dinov3.lvd1689m",
+        "model.safetensors",
+        "vit_large_dinov3.safetensors",
+    ),
+    "vit_huge_plus_dinov3": (
+        "timm/vit_huge_plus_patch16_dinov3.lvd1689m",
+        "model.safetensors",
+        "vit_huge_plus_dinov3.safetensors",
+    ),
+    "vit_7b_dinov3": (
+        "timm/vit_7b_patch16_dinov3.lvd1689m",
+        "model.safetensors",
+        "vit_7b_dinov3.safetensors",
+    ),
+}
+DEFAULT_REPO_ID, DEFAULT_FILENAME, DEFAULT_STAGE_NAME = (
+    BACKBONE_PROFILES[DEFAULT_BACKBONE_TYPE]
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -55,12 +102,18 @@ def parse_args() -> argparse.Namespace:
         "--dest",
         help="Explicit destination file path. Overrides --workspace.",
     )
-    p.add_argument("--repo-id", default=DEFAULT_REPO_ID, help="HuggingFace repo id.")
-    p.add_argument("--filename", default=DEFAULT_FILENAME, help="File to download from the repo.")
+    p.add_argument(
+        "--backbone-type",
+        choices=sorted(BACKBONE_PROFILES),
+        help="Visual ChangeNet backbone profile. When omitted, read "
+        "<workspace>/specs/baseline_spec.yaml, then default to the existing "
+        "C-RADIOv2-B profile.",
+    )
+    p.add_argument("--repo-id", help="Override the profile's Hugging Face repo id.")
+    p.add_argument("--filename", help="Override the profile's repo filename.")
     p.add_argument(
         "--stage-name",
-        default=DEFAULT_STAGE_NAME,
-        help="Filename to use under <workspace>/augmentation/backbone/.",
+        help="Override the profile's filename under <workspace>/augmentation/backbone/.",
     )
     p.add_argument(
         "--force",
@@ -70,17 +123,136 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
+def _baseline_backbone(args: argparse.Namespace) -> dict:
+    """Read the workspace baseline backbone configuration when present."""
+    workspace = getattr(args, "workspace", None)
+    if not workspace:
+        return {}
+    spec_path = (
+        pathlib.Path(workspace).expanduser()
+        / "specs"
+        / "baseline_spec.yaml"
+    )
+    if not spec_path.is_file():
+        return {}
+    spec = yaml.safe_load(spec_path.read_text()) or {}
+    return spec.get("model", {}).get("backbone", {})
+
+
+def resolve_backbone_type(args: argparse.Namespace) -> str:
+    """Resolve an explicit profile or infer it from the baseline spec."""
+    backbone = _baseline_backbone(args)
+    baseline_type = str(backbone.get("type", "")).strip()
+    backbone_type = (
+        getattr(args, "backbone_type", None)
+        or baseline_type
+        or DEFAULT_BACKBONE_TYPE
+    )
+
+    if backbone_type not in BACKBONE_PROFILES:
+        sys.exit(f"stage_backbone: unsupported backbone type: {backbone_type}")
+
+    if baseline_type and baseline_type != backbone_type:
+        sys.exit(
+            "stage_backbone: --backbone-type does not match baseline spec: "
+            f"{backbone_type} != {baseline_type}"
+        )
+
+    if (
+        "dinov3" in backbone_type
+        and baseline_type == backbone_type
+        and not bool(backbone.get("freeze_backbone", False))
+    ):
+        sys.exit(
+            "stage_backbone: DINOv3 must set "
+            "model.backbone.freeze_backbone: true for DEFT."
+        )
+
+    return backbone_type
+
+
+def _has_source_override(args: argparse.Namespace) -> bool:
+    """Return whether standalone source/destination overrides were supplied."""
+    return any(
+        getattr(args, name, None)
+        for name in ("dest", "repo_id", "filename")
+    )
+
+
+def resolve_configured_checkpoint(args: argparse.Namespace) -> str | None:
+    """Resolve a converted DINOv3 checkpoint configured in the baseline spec."""
+    workspace = getattr(args, "workspace", None)
+    if _has_source_override(args) or not workspace:
+        return None
+
+    backbone = _baseline_backbone(args)
+    backbone_type = resolve_backbone_type(args)
+    configured_path = backbone.get("pretrained_backbone_path")
+    if (
+        "dinov3" not in backbone_type
+        or str(backbone.get("type", "")).strip() != backbone_type
+        or not isinstance(configured_path, str)
+        or not configured_path.strip()
+    ):
+        return None
+
+    configured = pathlib.Path(configured_path).expanduser()
+    candidates = (
+        configured,
+        pathlib.Path(workspace).expanduser()
+        / "augmentation"
+        / "backbone"
+        / configured.name,
+    )
+    for candidate in candidates:
+        if candidate.is_file() and candidate.stat().st_size > 0:
+            return str(candidate.resolve())
+    sys.exit(
+        "stage_backbone: configured DINOv3 checkpoint is not staged: "
+        f"{candidates[-1]}"
+    )
+
+
+def resolve_source(args: argparse.Namespace) -> tuple[str, str, str]:
+    """Resolve profile defaults with optional explicit source overrides."""
+    if not getattr(args, "backbone_type", None) and _has_source_override(args):
+        # Preserve the standalone custom-repo/destination escape hatch. The
+        # workspace baseline is authoritative only for DEFT-managed staging.
+        backbone_type = DEFAULT_BACKBONE_TYPE
+    else:
+        backbone_type = resolve_backbone_type(args)
+    repo_id, filename, stage_name = BACKBONE_PROFILES[backbone_type]
+    return (
+        getattr(args, "repo_id", None) or repo_id,
+        getattr(args, "filename", None) or filename,
+        getattr(args, "stage_name", None) or stage_name,
+    )
+
+
 def resolve_dest(args: argparse.Namespace) -> str:
+    configured = resolve_configured_checkpoint(args)
+    if configured:
+        return configured
     if args.dest:
         return os.path.abspath(os.path.expanduser(args.dest))
     if not args.workspace:
         sys.exit("stage_backbone: one of --dest or --workspace is required.")
     ws = os.path.abspath(os.path.expanduser(args.workspace))
-    return os.path.join(ws, "augmentation", "backbone", args.stage_name)
+    _, _, stage_name = resolve_source(args)
+    return os.path.join(ws, "augmentation", "backbone", stage_name)
 
 
 def main() -> int:
     args = parse_args()
+    configured = resolve_configured_checkpoint(args)
+    if configured:
+        print(
+            "stage_backbone: reusing configured converted checkpoint.",
+            file=sys.stderr,
+        )
+        print(configured)
+        return 0
+    repo_id, filename, _ = resolve_source(args)
     dest = resolve_dest(args)
 
     # Idempotent: reuse an existing non-empty staged file unless --force.
@@ -108,10 +280,10 @@ def main() -> int:
 
     token = os.environ.get("HF_TOKEN") or None
     try:
-        src = hf_hub_download(repo_id=args.repo_id, filename=args.filename, token=token)
+        src = hf_hub_download(repo_id=repo_id, filename=filename, token=token)
     except Exception as exc:  # network, auth, missing file — all are hard stops
         sys.exit(
-            f"stage_backbone: failed to download {args.filename} from {args.repo_id}: {exc}\n"
+            f"stage_backbone: failed to download {filename} from {repo_id}: {exc}\n"
             "Staging is mandatory — there is no working URL fallback. Set HF_TOKEN if the "
             "repo is gated, or pre-stage the file at the destination path manually."
         )
@@ -122,7 +294,7 @@ def main() -> int:
     if not (os.path.isfile(dest) and os.path.getsize(dest) > 0):
         sys.exit(f"stage_backbone: copy produced no file at {dest}.")
 
-    print(f"stage_backbone: staged {args.repo_id}/{args.filename} -> {dest} "
+    print(f"stage_backbone: staged {repo_id}/{filename} -> {dest} "
           f"({os.path.getsize(dest)} bytes).", file=sys.stderr)
     print(dest)
     return 0

--- a/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
@@ -9,6 +9,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 
 
 SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -19,6 +20,8 @@ for module_name in (
     "finalize_run",
     "init_deft_state",
     "metric_contract",
+    "prepare_inference_spec",
+    "stage_backbone",
     "render_report",
 ):
     sys.modules.pop(module_name, None)
@@ -31,6 +34,8 @@ import metric_contract  # noqa: E402
 import render_report  # noqa: E402
 import deft_exec  # noqa: E402
 import finalize_run  # noqa: E402
+import prepare_inference_spec  # noqa: E402
+import stage_backbone  # noqa: E402
 import resolve_mining_pool  # noqa: E402
 
 
@@ -43,9 +48,12 @@ class ReportRenderingTests(unittest.TestCase):
             checkpoint = results / "iter1/train/model.pth"
             checkpoint.parent.mkdir(parents=True)
             checkpoint.write_bytes(b"checkpoint")
-            backbone = results / "backbone/model.safetensors"
+            # The existing AOI host filename intentionally differs from the
+            # container-side filename in baseline_spec.yaml.
+            backbone = results / "backbone/c_radio_v2_b.safetensors"
             backbone.parent.mkdir(parents=True)
             backbone.write_bytes(b"backbone")
+            (backbone.parent / "vit_large_dinov3.safetensors").write_bytes(b"decoy")
             training_spec = SKILL_ROOT / "references/baseline_spec.yaml"
             state["config"].update(
                 {
@@ -77,6 +85,17 @@ class ReportRenderingTests(unittest.TestCase):
                 committed["final_artifacts"]["best_model_json"],
                 str((results / "best_model.json").resolve()),
             )
+            handoff = json.loads((results / "best_model.json").read_text())
+            self.assertEqual(handoff["backbone"], str(backbone.resolve()))
+            self.assertEqual(
+                handoff["backbone_container_path"],
+                "/data/pretrained_models/C-RADIOv2_B.pth",
+            )
+            self.assertEqual(
+                handoff["backbone_type"],
+                "c_radio_v2_vit_base_patch16_224",
+            )
+            self.assertFalse(handoff["backbone_frozen"])
 
     def test_airgap_guard_blocks_install_and_forces_no_pull(self) -> None:
         policy = {"network_mode": "airgap"}
@@ -405,6 +424,237 @@ class ReportRenderingTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             committed = json.loads((results / "deft_state.json").read_text())
             self.assertEqual(committed["events"][-1]["stage"], "data_merge")
+
+    def test_backbone_profiles_preserve_default_and_cover_dinov3(self) -> None:
+        expected_dinov3 = {
+            "vit_small_dinov3",
+            "vit_small_plus_dinov3",
+            "vit_base_dinov3",
+            "vit_large_dinov3",
+            "vit_huge_plus_dinov3",
+            "vit_7b_dinov3",
+        }
+        self.assertTrue(
+            expected_dinov3.issubset(stage_backbone.BACKBONE_PROFILES)
+        )
+
+        args = SimpleNamespace(
+            backbone_type=stage_backbone.DEFAULT_BACKBONE_TYPE,
+            repo_id=None,
+            filename=None,
+            stage_name=None,
+        )
+        self.assertEqual(
+            stage_backbone.resolve_source(args),
+            (
+                stage_backbone.DEFAULT_REPO_ID,
+                stage_backbone.DEFAULT_FILENAME,
+                stage_backbone.DEFAULT_STAGE_NAME,
+            ),
+        )
+
+        args.backbone_type = "vit_large_dinov3"
+        self.assertEqual(
+            stage_backbone.resolve_source(args),
+            (
+                "timm/vit_large_patch16_dinov3.lvd1689m",
+                "model.safetensors",
+                "vit_large_dinov3.safetensors",
+            ),
+        )
+
+    def test_custom_source_overrides_bypass_workspace_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = pathlib.Path(temporary)
+            specs = workspace / "specs"
+            specs.mkdir()
+            (specs / "baseline_spec.yaml").write_text(
+                "model:\n"
+                "  backbone:\n"
+                "    type: customer_backbone\n"
+            )
+            destination = workspace / "custom.safetensors"
+            args = SimpleNamespace(
+                backbone_type=None,
+                workspace=str(workspace),
+                dest=str(destination),
+                repo_id="customer/backbone",
+                filename="weights.safetensors",
+                stage_name=None,
+            )
+
+            self.assertEqual(
+                stage_backbone.resolve_source(args),
+                (
+                    "customer/backbone",
+                    "weights.safetensors",
+                    stage_backbone.DEFAULT_STAGE_NAME,
+                ),
+            )
+            self.assertEqual(
+                stage_backbone.resolve_dest(args),
+                str(destination.resolve()),
+            )
+
+    def test_backbone_profile_is_inferred_from_frozen_baseline_spec(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = pathlib.Path(temporary)
+            specs = workspace / "specs"
+            specs.mkdir()
+            baseline = specs / "baseline_spec.yaml"
+            baseline.write_text(
+                "model:\n"
+                "  backbone:\n"
+                "    type: vit_large_dinov3\n"
+                "    freeze_backbone: true\n"
+            )
+            args = SimpleNamespace(
+                backbone_type=None,
+                workspace=str(workspace),
+                repo_id=None,
+                filename=None,
+                stage_name=None,
+            )
+
+            self.assertEqual(
+                stage_backbone.resolve_source(args),
+                (
+                    "timm/vit_large_patch16_dinov3.lvd1689m",
+                    "model.safetensors",
+                    "vit_large_dinov3.safetensors",
+                ),
+            )
+
+            baseline.write_text(baseline.read_text().replace("true", "false"))
+            with self.assertRaisesRegex(SystemExit, "freeze_backbone"):
+                stage_backbone.resolve_source(args)
+
+            args.backbone_type = "vit_large_dinov3"
+            with self.assertRaisesRegex(SystemExit, "freeze_backbone"):
+                stage_backbone.resolve_source(args)
+
+    def test_backbone_mount_references_use_resolved_container_path(self) -> None:
+        visual_reference = (
+            SKILL_ROOT / "references" / "visual-changenet.md"
+        ).read_text()
+        inference_reference = (
+            SKILL_ROOT / "references" / "prepare-for-inference.md"
+        ).read_text()
+
+        self.assertIn(
+            '-v "${STAGED}:${BACKBONE_CONTAINER_PATH}:ro"',
+            visual_reference,
+        )
+        self.assertIn(
+            "BACKBONE_CONTAINER_PATH=$(jq -er",
+            inference_reference,
+        )
+        self.assertIn(
+            '-v "${BACKBONE}:${BACKBONE_CONTAINER_PATH}:ro"',
+            inference_reference,
+        )
+        self.assertNotIn(
+            ".backbone ${RESULTS_DIR}/best_model.json):"
+            "/data/pretrained_models/C-RADIOv2_B.pth",
+            inference_reference,
+        )
+
+    def test_configured_converted_dinov3_checkpoint_takes_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = pathlib.Path(temporary)
+            specs = workspace / "specs"
+            backbone_dir = workspace / "augmentation" / "backbone"
+            specs.mkdir()
+            backbone_dir.mkdir(parents=True)
+            converted = backbone_dir / "customer-converted.safetensors"
+            converted.write_bytes(b"converted")
+            (specs / "baseline_spec.yaml").write_text(
+                "model:\n"
+                "  backbone:\n"
+                "    type: vit_large_dinov3\n"
+                "    pretrained_backbone_path: "
+                "/data/pretrained_models/customer-converted.safetensors\n"
+                "    freeze_backbone: true\n"
+            )
+            args = SimpleNamespace(
+                backbone_type=None,
+                workspace=str(workspace),
+                dest=None,
+                repo_id=None,
+                filename=None,
+                stage_name=None,
+            )
+
+            self.assertEqual(
+                stage_backbone.resolve_dest(args), str(converted.resolve())
+            )
+
+            converted.unlink()
+            with self.assertRaisesRegex(SystemExit, "configured DINOv3"):
+                stage_backbone.resolve_dest(args)
+
+    def test_handoff_resolves_exact_configured_backbone(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            backbone_dir = pathlib.Path(temporary)
+            expected = backbone_dir / "vit_large_dinov3.safetensors"
+            expected.write_bytes(b"converted")
+            (backbone_dir / "unrelated.pth").write_bytes(b"decoy")
+            train_spec = {
+                "model": {
+                    "backbone": {
+                        "type": "vit_large_dinov3",
+                        "pretrained_backbone_path": (
+                            "/data/pretrained_models/vit_large_dinov3.safetensors"
+                        ),
+                        "freeze_backbone": True,
+                    }
+                }
+            }
+            state = {"config": {"backbone_weight_dir": str(backbone_dir)}}
+
+            resolved = prepare_inference_spec._resolve_backbone(train_spec, state)
+            self.assertEqual(resolved[0], str(expected.resolve()))
+            self.assertEqual(
+                resolved[1],
+                "/data/pretrained_models/vit_large_dinov3.safetensors",
+            )
+            self.assertEqual(resolved[2:], ("vit_large_dinov3", True))
+
+            expected.unlink()
+            with self.assertRaisesRegex(FileNotFoundError, "exact pretrained"):
+                prepare_inference_spec._resolve_backbone(train_spec, state)
+
+    def test_handoff_rejects_missing_backbone_path(self) -> None:
+        train_spec = {
+            "model": {
+                "backbone": {
+                    "type": "vit_large_dinov3",
+                    "pretrained_backbone_path": None,
+                    "freeze_backbone": True,
+                }
+            }
+        }
+        with self.assertRaisesRegex(ValueError, "has no .*pretrained"):
+            prepare_inference_spec._resolve_backbone(train_spec, {"config": {}})
+
+    def test_handoff_rejects_unrelated_sole_backbone(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            backbone_dir = pathlib.Path(temporary)
+            (backbone_dir / "vit_large_dinov3.safetensors").write_bytes(b"wrong")
+            train_spec = {
+                "model": {
+                    "backbone": {
+                        "type": "c_radio_v2_vit_base_patch16_224",
+                        "pretrained_backbone_path": (
+                            "/data/pretrained_models/C-RADIOv2_B.pth"
+                        ),
+                        "freeze_backbone": False,
+                    }
+                }
+            }
+            state = {"config": {"backbone_weight_dir": str(backbone_dir)}}
+            with self.assertRaisesRegex(FileNotFoundError, "exact pretrained"):
+                prepare_inference_spec._resolve_backbone(train_spec, state)
 
     def _state(self, results: pathlib.Path) -> dict:
         contract = {

--- a/skills/models/tao-train-visual-changenet/schemas/evaluate.schema.json
+++ b/skills/models/tao-train-visual-changenet/schemas/evaluate.schema.json
@@ -1865,7 +1865,8 @@
                 "vit_small_plus_dinov3",
                 "vit_base_dinov3",
                 "vit_large_dinov3",
-                "vit_huge_plus_dinov3"
+                "vit_huge_plus_dinov3",
+                "vit_7b_dinov3"
               ],
               "title": "Backbone architectures",
               "type": "categorical"

--- a/skills/models/tao-train-visual-changenet/schemas/inference.schema.json
+++ b/skills/models/tao-train-visual-changenet/schemas/inference.schema.json
@@ -1865,7 +1865,8 @@
                 "vit_small_plus_dinov3",
                 "vit_base_dinov3",
                 "vit_large_dinov3",
-                "vit_huge_plus_dinov3"
+                "vit_huge_plus_dinov3",
+                "vit_7b_dinov3"
               ],
               "title": "Backbone architectures",
               "type": "categorical"

--- a/skills/models/tao-train-visual-changenet/schemas/segment_evaluate.schema.json
+++ b/skills/models/tao-train-visual-changenet/schemas/segment_evaluate.schema.json
@@ -1865,7 +1865,8 @@
                 "vit_small_plus_dinov3",
                 "vit_base_dinov3",
                 "vit_large_dinov3",
-                "vit_huge_plus_dinov3"
+                "vit_huge_plus_dinov3",
+                "vit_7b_dinov3"
               ],
               "title": "Backbone architectures",
               "type": "categorical"

--- a/skills/models/tao-train-visual-changenet/schemas/segment_inference.schema.json
+++ b/skills/models/tao-train-visual-changenet/schemas/segment_inference.schema.json
@@ -1865,7 +1865,8 @@
                 "vit_small_plus_dinov3",
                 "vit_base_dinov3",
                 "vit_large_dinov3",
-                "vit_huge_plus_dinov3"
+                "vit_huge_plus_dinov3",
+                "vit_7b_dinov3"
               ],
               "title": "Backbone architectures",
               "type": "categorical"

--- a/skills/models/tao-train-visual-changenet/schemas/segment_train.schema.json
+++ b/skills/models/tao-train-visual-changenet/schemas/segment_train.schema.json
@@ -1779,7 +1779,8 @@
                 "vit_small_plus_dinov3",
                 "vit_base_dinov3",
                 "vit_large_dinov3",
-                "vit_huge_plus_dinov3"
+                "vit_huge_plus_dinov3",
+                "vit_7b_dinov3"
               ],
               "title": "Backbone architectures",
               "type": "categorical"

--- a/skills/models/tao-train-visual-changenet/schemas/train.schema.json
+++ b/skills/models/tao-train-visual-changenet/schemas/train.schema.json
@@ -1779,7 +1779,8 @@
                 "vit_small_plus_dinov3",
                 "vit_base_dinov3",
                 "vit_large_dinov3",
-                "vit_huge_plus_dinov3"
+                "vit_huge_plus_dinov3",
+                "vit_7b_dinov3"
               ],
               "title": "Backbone architectures",
               "type": "categorical"


### PR DESCRIPTION
### What changes are proposed in this pull request?

Extend the existing DEFT AOI workflow and generated Visual ChangeNet schemas for frozen DINOv3 while preserving the existing C-RADIO default.

- Adds staging profiles for ViT-S, S+, B, L, H+, and 7B.
- Infers the selected profile from the existing workspace baseline YAML when no CLI override is supplied.
- Hard-stops if a DINOv3 DEFT baseline is not frozen, including explicit `--backbone-type` selection.
- Reuses an explicitly configured converted TAO checkpoint before considering Hugging Face; a missing explicit checkpoint hard-stops.
- Uses the matching staged Hugging Face artifact only when no checkpoint is configured.
- Preserves the established C-RADIO host/container filename mapping, including workspaces containing other staged weights.
- Carries exact backbone type, frozen state, host artifact, and container path into the inference handoff.
- Mounts the selected host backbone at that exact container path for training and handoff inference.
- Adds ViT-7B only to Visual ChangeNet schemas; SegFormer remains unchanged.

### Why are the changes needed?

The DEFT AOI loop must run task-level fine-tuning with a frozen DINOv3 backbone, using either customer-converted TAO SSL weights or compatible public timm/Hugging Face weights, without changing the existing AOI workflow for C-RADIO users.

### Related issues

JIRA: TAO-2511.

Companion tao-pytorch and tao-core branches: `TAO-2511-frozen-dinov3-aoi`.

### Does this PR introduce _any_ user-facing change?

Yes. `stage_backbone.py` accepts all six Visual ChangeNet DINOv3 types and the existing workspace-spec-driven preflight selects the configured frozen DINO profile. C-RADIO remains the default and is backward compatible.

### How was this patch tested?

- Required TAO image, DEFT AOI application and schema-drift suites: **33 passed**.
- Full `./scripts/validate-skills.sh`: passed.
- Exact PR-range hooks: license header passed.
- Python compilation and `git diff --check`: passed.
- All six public timm/Hugging Face profile repositories were verified to contain `model.safetensors`.
- Independent architecture, correctness, and MR-readiness panel completed with no remaining blockers.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex

### Release note

```release-note
DEFT AOI now supports frozen DINOv3 ViT-S, S+, B, L, H+, and 7B backbones using explicit converted TAO checkpoints or staged timm/Hugging Face weights while preserving the C-RADIO default.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`)
- [x] I have read the contributing guidelines
- [x] The code follows the project style, and repository checks pass locally
- [x] I added or updated tests covering this change
- [x] All applicable tests pass locally
- [x] Generated schemas are updated
- [x] Necessary executable skill references are updated
- [ ] A version or changelog update is not required for this patch
- [x] No secrets, credentials, proprietary data, or customer data are included
- [x] I understand the contribution is licensed under the repository license

### Notes for reviewers

Only the two executable references required by the runtime contract are changed: `references/visual-changenet.md` and `references/prepare-for-inference.md`. No extra note or planning Markdown files are added. The existing C-RADIO profile remains the default. For DINOv3, the baseline spec is the source of truth and `freeze_backbone: true` is enforced before staging or training.