### PR TITLE
[TAO-000][CI] dummy: reproduce main validate-skills 3b breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,5 @@ PRs must pass all three before merge.
 - **Minimum-viable skill is `SKILL.md` only.** Add `references/skill_info.yaml` only when multi-action structured metadata earns its keep.
 - **One canonical location per skill.** Model, data, platform, and application skills live only in their layer directories; `skills/core/` is for Codex helper/router skills, not mirrored copies.
 - **Prefer portability over cleverness.** A skill that works across three coding agents is more valuable than a skill that works perfectly in one.
+
+<!-- dummy PR: verify main CI (validate-skills 3b) state -->


### PR DESCRIPTION
Trivial README touch off fresh main — no skill/content changes. Running `/build` to demonstrate that **main is currently red on validate-skills 3b** (`skills/applications/tao-run-automl/SKILL.md` is 20,125 bytes > 20,000 cap, introduced by #84/#78). This isolates the breakage to main itself, not any specific change. Safe to close.