### PR TITLE
[TAO-0][Docs] Pin NV-Tesseract skill docs to main branch

### DIFF
--- a/skills/models/tao-finetune-nv-tesseract-ad-diffusion/SKILL.md
+++ b/skills/models/tao-finetune-nv-tesseract-ad-diffusion/SKILL.md
@@ -56,7 +56,8 @@ If you ever hit a `401`/`403` (gated access or private fork) or a `504` on first
 ## Quick start
 
 ```bash
-cd /path/to/NV-Tesseract/ad_diffusion  # git clone https://github.com/NVIDIA/NV-Tesseract
+git clone --branch main --single-branch https://github.com/NVIDIA/NV-Tesseract
+cd NV-Tesseract/ad_diffusion
 uv sync                              # install dependencies (one-time)
 
 # Inference — synthetic data, auto-downloads weights from HF on first run
@@ -88,7 +89,7 @@ and returns the original DataFrame with `Anomaly` (0/1) and `MAE` columns append
 
 ```python
 import sys, pandas as pd
-sys.path.append("/path/to/NV-Tesseract/ad_diffusion")  # git clone https://github.com/NVIDIA/NV-Tesseract
+sys.path.append("/path/to/NV-Tesseract/ad_diffusion")  # clone NV-Tesseract with --branch main
 from sdk.anomaly_analysis import perform_anomaly_analysis_with_diffusion
 
 df = pd.read_csv("your_data.csv")

--- a/skills/models/tao-finetune-nv-tesseract-forecasting/SKILL.md
+++ b/skills/models/tao-finetune-nv-tesseract-forecasting/SKILL.md
@@ -53,7 +53,7 @@ If you hit a `401`/`403` (gated access or license not accepted) or a `504` on fi
 ## Quick start
 
 ```bash
-git clone https://github.com/NVIDIA/NV-Tesseract
+git clone --branch main --single-branch https://github.com/NVIDIA/NV-Tesseract
 cd NV-Tesseract/forecasting
 uv sync --group dev
 uv pip install -e .          # editable install — required for clean sdk.* imports
@@ -70,7 +70,7 @@ with `{target_column}_forecast` rows for the requested horizon.
 
 ```python
 import sys, pandas as pd
-sys.path.append("/path/to/NV-Tesseract/forecasting")  # git clone https://github.com/NVIDIA/NV-Tesseract
+sys.path.append("/path/to/NV-Tesseract/forecasting")  # clone NV-Tesseract with --branch main
 from sdk.forecasting import perform_forecasting
 
 df = pd.read_csv("your_data.csv")   # must have timestamp + numeric target column


### PR DESCRIPTION
## Summary
- Update NV-Tesseract AD diffusion and forecasting skill examples to clone NVIDIA/NV-Tesseract with --branch main --single-branch.
- Clarify inline import comments so TAO users do not accidentally consume unreleased dev changes when the NV-Tesseract default branch is dev.

## Validation
- ./scripts/validate-skills.sh
- git diff --check origin/main..HEAD
- Clean Lepton smoke cloned NV-Tesseract branch main at commit a36a6a6.
- TAO AutoMLRunner AD diffusion train smoke passed: val_loss 0.20958107623916405.
- TAO AutoMLRunner forecasting train smoke passed: val_mse 0.24955270758696965.