### PR TITLE
[TAO-2230][Bugfix] deft-od: container mounts, and fixing skill references

### DIFF
--- a/skills/applications/tao-run-deft-object-detection/SKILL.md
+++ b/skills/applications/tao-run-deft-object-detection/SKILL.md
@@ -163,7 +163,7 @@ If an *overlay* is missing, stop and ask the user to reinstall the plugin — th
 | Pipeline stages, state schema, loop-end sequence | `references/pipeline-and-state.md` |
 | Bundled scripts, glue, reporter agent, stage table | `references/scripts-and-agents.md` |
 
-**Required input — `max_iterations`.** No default; ask the user if not supplied. All other parameters have documented defaults.
+**`max_iterations` defaults to `1`** — one mine, train and score pass, the smallest run that yields a comparison against the baseline. Confirm it with the user when they have not said how many iterations they want; an unattended run takes the default rather than stopping to ask.
 
 ## Gating
 

--- a/skills/applications/tao-run-deft-object-detection/agents/reporter.md
+++ b/skills/applications/tao-run-deft-object-detection/agents/reporter.md
@@ -33,7 +33,8 @@ For `trigger="loop-end"`, add `--require-terminal`. It passes only once `loop_st
 1. `${results_dir}/deft_state.json` — config, `max_iterations`, per-iteration artifact paths.
 2. Every line of `${results_dir}/loop_log.jsonl` — stage events, statuses, and durations. Ignore `context_tokens`: it is always 0 and is not a measurement.
 3. Every `${results_dir}/iter*_summary.md` that exists.
-4. Each phase's `kpi/kpi_calc.csv` (baseline and every iteration) for the mAP trend.
+4. Each phase's `kpi/kpi_calc.csv` (baseline and every iteration) for the mAP trend, and
+   its `kpi/kpi_analyze.log` for the class each row belongs to — the csv does not say.
 5. Each iteration's `mining/summary.json` and `tmm/staging_report.json` for the data-growth table.
 
 Trust disk over anything in the prompt except `results_dir`, `skill_root`, and `trigger`.
@@ -63,14 +64,27 @@ Take **Status** from the audit's `--json` report, never from prose and never fro
 
 ## 1. KPI Trend
 
-| Phase | mAP | <per-class AP columns from kpi_calc.csv> |
-|---|---|---|
-| baseline | … | … |
-| iter1 | … | … |
+One row per phase — `baseline`, then every iteration — and one AP50 column per target
+class alongside the mAP. Both are required: the mean can move while an individual class
+moves the other way, and a loop mining for rare classes is judged on those classes.
 
-State the delta from baseline to the latest iteration in one sentence. mAP is
-reported, not gated — do not describe a regression as a failure, and do not
-claim a target was met or missed. There is no target.
+| Phase | mAP | AP50 <class A> | AP50 <class B> | … |
+|---|---|---|---|---|
+| baseline | … | … | … | |
+| iter1 | … | … | … | |
+| iter2 | … | … | … | |
+
+**Resolving which row is which class.** `kpi_calc.csv` has one row per class and *no
+class column* — the names appear only in the table `kpi_analyze` prints to stdout, which
+is why the run tees it to `kpi/kpi_analyze.log` and commits it as `--kpi-log`. Read the
+class order from that log and use it. If the log is missing for a phase, do not guess
+from row order: report the mAP alone for that phase and say the per-class breakdown was
+unavailable.
+
+State the delta from baseline to the latest iteration in one sentence, and name any
+class that moved against the mean. mAP is reported, not gated — do not describe a
+regression as a failure, and do not claim a target was met or missed. There is no
+target.
 
 ## 2. Data Growth
 
@@ -109,7 +123,7 @@ Write `${results_dir}/DEFT_Loop_Report.md.tmp`, then `os.replace` onto `${result
 Print exactly one line, then exit:
 
 ```
-reporter: wrote DEFT_Loop_Report.md (<bytes>B, <N>/<M> iterations complete, baseline mAP <x> -> latest <y>)
+reporter: wrote DEFT_Loop_Report.md (<bytes>B, <N>/<M> iterations complete, baseline mAP <x> -> latest <y>; per-class <class>=<x>-><y>, ...)
 ```
 
 Return non-zero only on hard failure. Do not return prose or echo the file contents to the parent.

--- a/skills/applications/tao-run-deft-object-detection/assets/overlays/codetr_inference.yaml
+++ b/skills/applications/tao-run-deft-object-detection/assets/overlays/codetr_inference.yaml
@@ -35,9 +35,6 @@ model.soft_nms_enabled: true
 model.soft_nms_iou_threshold: 0.8
 model.soft_nms_method: linear
 
-inference.save_annotated_images: false
-    # TAO: true. Writes a rendered JPEG per image alongside the labels — on a 100k pool,
-    # 100k files nothing downstream reads.
 inference.batch_size: 1        # TAO: -1
 dataset.batch_size: 1          # TAO: 4
 dataset.dataset_type: default  # TAO: serialized

--- a/skills/applications/tao-run-deft-object-detection/assets/overlays/grounding_dino_inference.yaml
+++ b/skills/applications/tao-run-deft-object-detection/assets/overlays/grounding_dino_inference.yaml
@@ -13,6 +13,11 @@ inference.conf_threshold: 0.0  # Dropped at write time, so this bounds what
                                # gap_analysis and KPI can score downstream. 0
                                # keeps the full PR curve.
 
+inference.save_annotated_images: false
+    # TAO: true. Renders a JPEG per image beside the labels. Nothing downstream reads
+    # them and they dominate the stage's output: 5.8 GB for a 14k-image KPI set, once
+    # per inference, on runs budgeted in tens of GB.
+
 dataset.batch_size: 8
 
 model.log_scale: auto          # Must not be null, and must match the checkpoint:

--- a/skills/applications/tao-run-deft-object-detection/assets/overlays/grounding_dino_inference.yaml
+++ b/skills/applications/tao-run-deft-object-detection/assets/overlays/grounding_dino_inference.yaml
@@ -13,11 +13,6 @@ inference.conf_threshold: 0.0  # Dropped at write time, so this bounds what
                                # gap_analysis and KPI can score downstream. 0
                                # keeps the full PR curve.
 
-inference.save_annotated_images: false
-    # TAO: true. Renders a JPEG per image beside the labels. Nothing downstream reads
-    # them and they dominate the stage's output: 5.8 GB for a 14k-image KPI set, once
-    # per inference, on runs budgeted in tens of GB.
-
 dataset.batch_size: 8
 
 model.log_scale: auto          # Must not be null, and must match the checkpoint:

--- a/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
+++ b/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
@@ -224,8 +224,7 @@ docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
 ```
 
 **Wait on the artifact, never on a process name.** `pgrep -f "grounding_dino train"` matches
-the waiting shell's own command line, so the wait never ends — that cost 10h11m on a run whose
-training had already finished correctly in 14m20s:
+the waiting shell's own command line, so the wait never ends.
 
 Take a launch marker first, and pass it as `--newer-than`. Without it a retry of a
 failed job is satisfied instantly by the checkpoint and success line the previous

--- a/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
+++ b/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
@@ -172,7 +172,7 @@ No training at baseline. Score the user-supplied zero-shot / pretrained checkpoi
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   grounding_dino inference -e "$INFER_SPEC" \
   results_dir="${RESULTS_DIR}/baseline" \
@@ -215,7 +215,7 @@ Then:
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   grounding_dino train -e "${RESULTS_DIR}/iter${N}/train_grounding_dino.yaml" \
   results_dir="${RESULTS_DIR}/iter${N}" \
@@ -268,7 +268,7 @@ Required output: a newly emitted checkpoint under `${RESULTS_DIR}/iter${N}/train
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   grounding_dino inference -e "$INFER_SPEC" \
   results_dir="${RESULTS_DIR}/iter${N}" \

--- a/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
+++ b/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
@@ -161,8 +161,9 @@ Nothing about this is enforced by TAO, so check it before every inference:
 
 It compares the caption list against the KPI classes, the staged ODVG labelmap
 order, `max_labels`, and the run's target classes, and exits non-zero naming both
-sides of any disagreement. At baseline there is no staged labelmap yet — drop
-`--labelmap` and pass `--classes` instead.
+sides of any disagreement. At baseline there is no staged labelmap yet, so drop `--labelmap`. `--classes` is
+not its replacement — it is an independent fourth source and takes the **path** to the
+pool's `classes.yaml`, not a class list. Pass it in every phase.
 
 `inference.color_map` in the reference spec is cosmetic — it only tints `images_annotated/`.
 

--- a/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
+++ b/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
@@ -181,7 +181,18 @@ docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
   inference.num_gpus="$NUM_GPUS"
 ```
 
-Labels land in `${RESULTS_DIR}/baseline/inference/labels/`.
+Wait on the labels, the same way training does — `results_dir` gains the action name,
+so both the labels and `status.json` sit under `inference/`:
+
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/await_stage.py \
+  --artifact "${RESULTS_DIR}/<phase>/inference/labels" \
+  --status-json "${RESULTS_DIR}/<phase>/inference/status.json" \
+  --status-contains "finished successfully"
+```
+
+Labels land in `${RESULTS_DIR}/baseline/inference/labels/`. The same wait applies to
+each iteration's inference with `<phase>` set to `iter${N}`.
 
 Also copy the user's train-spec template to `${RESULTS_DIR}/train_grounding_dino.yaml`. Iteration 1 extends that copy; nothing trains from it at baseline.
 
@@ -296,12 +307,14 @@ That is the reason to keep it at `0.0`. The labels then carry the full curve, an
   --results-dir "${RESULTS_DIR}" --iter-label "iter${N}" --stage train \
   --checkpoint "${RESULTS_DIR}/iter${N}/train/gdino_model_latest.pth" \
   --training-spec "${RESULTS_DIR}/iter${N}/train_grounding_dino.yaml" \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "trained iter${N}: <epochs> epochs, <N> data sources"
 
 # inference
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/commit_stage.py \
   --results-dir "${RESULTS_DIR}" --iter-label "<phase>" --stage inference \
   --inference-labels-dir "${RESULTS_DIR}/<phase>/inference/labels" \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "inference: <N> label files"
 ```
 

--- a/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
+++ b/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
@@ -19,7 +19,7 @@ architecture it was **trained** with. There is no "just use the pinned image" an
 the pairing in Pre-Flight, because the failure lands after the container has started and
 looks like a checkpoint problem rather than a config one.
 
-### `class_embed_bias` — the trap that actually bites
+### `class_embed_bias` must match the checkpoint
 
 `ContrastiveEmbed` (the `class_embed` head) takes a `bias` argument that defaults to
 **`False`**, sourced from the spec as `model.class_embed_bias`. A checkpoint trained with
@@ -44,7 +44,7 @@ kernel runs, so drivers cannot add or remove a `bias`. Genuine CUDA faults look 
 The field is easy to lose because it is absent from the shipped `infer.yaml` template and
 defaults to the value the checkpoint does *not* use.
 
-### `log_scale` — the second trap, and it fails silently
+### `log_scale` must be set, and a wrong value fails silently
 
 `ContrastiveEmbed.forward` scales the visual·text similarity before the sigmoid:
 
@@ -187,8 +187,8 @@ Also copy the user's train-spec template to `${RESULTS_DIR}/train_grounding_dino
 
 ## Iteration train
 
-Build the spec first. Every flag below is load-bearing — the script refuses to emit a spec
-that cannot train, because each of these failed silently or expensively at least once:
+Build the spec first. Every flag below is load-bearing: the script refuses to emit a spec
+that cannot train.
 
 ```bash
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/prepare_val_split_for_train.py \

--- a/skills/applications/tao-run-deft-object-detection/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-object-detection/references/pipeline-and-state.md
@@ -163,7 +163,20 @@ Three stage types:
 After every stage, before advancing:
 
 1. Verify the documented required artifacts exist.
-2. Invoke `commit_stage.py` once with the documented artifact flags.
+2. Invoke `commit_stage.py` once with the documented artifact flags, and pass
+   `--duration-sec` with the stage's measured wall clock. Take a timestamp before the
+   stage and subtract:
+
+   ```bash
+   started=$SECONDS
+   # ... run the stage ...
+   commit_stage.py ... --duration-sec "$(( SECONDS - started ))"
+   ```
+
+   The field is in the log schema and the report renders a duration column from it, but
+   nothing populates it unless the flag is passed — every stage then reads 0 and the
+   timeline is empty. If no reliable start time was captured, omit the flag rather than
+   inventing a number.
 3. Run `audit_deft_run.py --results-dir ${RESULTS_DIR}`. If `INVALID`, halt and repair.
 4. If the committed status is `error` — halt, surface the disk evidence, **do not auto-retry**.
 5. If `ok` — print one status line: `[iter <N>/<max> · <stage>] <detail> · <duration> · next: <stage>`. Then advance. Render the HTML report only at iteration end and loop end.

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -215,6 +215,21 @@ Resolve everything you can before asking the user. Parameter precedence is stric
 
 ## Container mounts
 
+Export them once, right after init, and use the variable in every launch:
+
+```bash
+EXTRA_MOUNTS=$("$DEFT_PY" -c 'import json,sys
+m=json.load(open(sys.argv[1]))["config"].get("extra_container_mounts") or []
+print(" ".join(f"-v {p}:{p}" for p in m))' "${RESULTS_DIR}/deft_state.json")
+export EXTRA_MOUNTS
+```
+
+Every `docker run` in this skill is written as
+`-v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE"`. With inputs inside the
+workspace it expands to nothing and the command is unchanged; with KPI data or
+checkpoints outside it, it is the difference between a working stage and
+`No .txt label files found`.
+
 `init_deft_state.py` records `config.extra_container_mounts`: the directories that
 inputs live in outside `$WORKSPACE`. Containers see only `"$WORKSPACE:$WORKSPACE"`,
 so **every** `docker run` in this skill must add a `-v "$m:$m"` for each entry, in
@@ -271,6 +286,11 @@ Remind the user to enable auto-mode (shift+tab) before approving — the post-ga
 ## Immediately After Approval
 
 Perform the planned pulls and directory creation, then initialize state once:
+**`--pool-report` is the exception: omit it on a prep run.** Unlike the pool artifacts
+and `--source-detection-file`, a `--pool-report` path that does not exist yet is a hard
+error, not a warning — validate_pool_coco.py writes it during prep, so pass the flag
+only when the pool already exists. Omitting it is what downgrades the requirement.
+
 **Order:** `init_deft_state.py` runs first and `prep` is the run's first committed
 stage. On a pool that still needs preparing, the pool artifacts and
 `--source-detection-file` do not exist yet — pass them anyway, as the paths prep

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -230,6 +230,11 @@ workspace it expands to nothing and the command is unchanged; with KPI data or
 checkpoints outside it, it is the difference between a working stage and
 `No .txt label files found`.
 
+A HuggingFace snapshot directory is a tree of symlinks into a sibling `blobs/`, so the
+mount must be the **repo root** (`.../models--org--name/`), not the snapshot. Mounting the
+snapshot alone makes the loader report a missing model file for a model that is present.
+`init_deft_state.py` handles this when it derives the list.
+
 `init_deft_state.py` records `config.extra_container_mounts`: the directories that
 inputs live in outside `$WORKSPACE`. Containers see only `"$WORKSPACE:$WORKSPACE"`,
 so **every** `docker run` in this skill must add a `-v "$m:$m"` for each entry, in

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -198,14 +198,19 @@ Resolve everything you can before asking the user. Parameter precedence is stric
 
 13. **Spec sanity.** `train.checkpoint_interval` must be `<= train.num_epochs`. `prepare_spec_for_train.py` lowers it automatically when an explicit epoch override would violate this, but flag the adjustment in the Summary so it is not a surprise.
 
-**Required input — `max_iterations`.** No default. Ask if not supplied and do not proceed past Pre-Flight without it.
+**`max_iterations` defaults to `1`.** Confirm it with the user when they have not said how many iterations they want, but do not block on it: an unattended run takes the default.
 
 ## Defaults
 
 - `train.num_epochs` — from the train-spec template
 - `train.optim.lr` — from the train-spec template
 - `multiplier` — `3`
+- `max_iterations` — `1`
 - `allocation_policy` — `class_stratified` when rare classes are given, else `global`
+- `rare_class_list` — every target class holding a below-mean share of the pool's
+  annotations. It is a property of the pool, so on a run that still has to prep it is
+  left unset at init and the prep commit derives it from `pool_report.json`. Supply
+  `--rare-class-list` only to override that.
 - `distance_metric` — `euclidean`
 - `candidate_expansion_factor` — `5`
 - `embedding_model` — `SigLIP`; `embedding_model_path` is **resolved**, not defaulted (check 9)

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -93,7 +93,7 @@ Resolve everything you can before asking the user. Parameter precedence is stric
    After approval, run the same command without `--plan` to perform the download.
 
    That resolves `nvidia/tao/grounding_dino:grounding_dino_swin_tiny_commercial_trainable_v1.1`
-   (1.93 GB, ~20s) and prints the checkpoint path on stdout. It is idempotent — an existing
+   (1.93 GB) and prints the checkpoint path on stdout. It is idempotent — an existing
    download is reused, so a resumed run re-costs nothing. Use a **`trainable`** release; the
    sibling `deployable` one is for TensorRT export and cannot be fine-tuned.
 

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -50,10 +50,10 @@ Resolve everything you can before asking the user. Parameter precedence is stric
    )
    TAO_DS_IMAGE=$(
      <skill_root>/scripts/deft_python.sh \
-       <skill_bank>/scripts/resolve_versions_key.py images.tao_toolkit.data_services_od
+       <skill_bank>/scripts/resolve_versions_key.py images.tao_toolkit.data_services_nightly
    )
    : "${TAO_PYT_IMAGE:?versions key images.tao_toolkit.pyt did not resolve}"
-   : "${TAO_DS_IMAGE:?versions key images.tao_toolkit.data_services_od did not resolve}"
+   : "${TAO_DS_IMAGE:?versions key images.tao_toolkit.data_services_nightly did not resolve}"
    export TAO_PYT_IMAGE TAO_DS_IMAGE
    ```
 
@@ -62,9 +62,9 @@ Resolve everything you can before asking the user. Parameter precedence is stric
    | Env var | versions-key | Used by |
    |---|---|---|
    | `TAO_PYT_IMAGE` | `images.tao_toolkit.pyt` | `train`, `inference` |
-   | `TAO_DS_IMAGE` | `images.tao_toolkit.data_services_od` | `gap_analysis`, `embed`, `mine`, `kpi_analyze` |
+   | `TAO_DS_IMAGE` | `images.tao_toolkit.data_services_nightly` | `gap_analysis`, `embed`, `mine`, `kpi_analyze` |
 
-   The data-services key is `data_services_od`, not `data_services`: the release
+   The data-services key is `data_services_nightly`, not `data_services`: the release
    data-services image carries neither `gap_analysis object_detection` nor
    `tmm unique_neighbor_matching`, so two of this loop's four data-services stages cannot
    run on it at all. Substituting the release image does not degrade the loop — it stops it.

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -218,11 +218,16 @@ Resolve everything you can before asking the user. Parameter precedence is stric
 Export them once, right after init, and use the variable in every launch:
 
 ```bash
-EXTRA_MOUNTS=$("$DEFT_PY" -c 'import json,sys
+EXTRA_MOUNTS=$(<skill_root>/scripts/deft_python.sh -c 'import json,sys
 m=json.load(open(sys.argv[1]))["config"].get("extra_container_mounts") or []
-print(" ".join(f"-v {p}:{p}" for p in m))' "${RESULTS_DIR}/deft_state.json")
+print(" ".join(f"-v {p}:{p}" for p in m))' "${RESULTS_DIR}/deft_state.json") || exit 1
 export EXTRA_MOUNTS
+echo "EXTRA_MOUNTS=$EXTRA_MOUNTS"
 ```
+
+Echo it and read the result. A command substitution that fails leaves `EXTRA_MOUNTS`
+empty and every later launch still runs, mounting nothing extra — the same silent
+failure this block exists to prevent.
 
 Every `docker run` in this skill is written as
 `-v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE"`. With inputs inside the

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -228,9 +228,8 @@ docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
 Add `-v` for every path outside `$WORKSPACE` — the checkpoint and the classmap
 commonly live elsewhere, and a container cannot read what is not mounted.
 
-This is the longest stage in the workflow — it scales with pool size, and runs to
-tens of minutes on 5k images and hours on 100k. Wait on its artifacts, not on the
-process:
+Runtime scales with pool size, so on a large pool this is the longest stage in the
+workflow. Wait on its artifacts, not on the process:
 
 ```bash
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/await_stage.py \

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -8,6 +8,21 @@ Prep turns a directory of raw unlabeled images into the two artifacts every iter
 | `source_pool/source_embeddings.parquet` | `embedding image_embeddings` over the pool | `mine` (the search corpus) |
 | `source_pool/coco.json` | the KITTI→COCO step, retained | `mine` as `source_detection_file` (class_stratified only) |
 
+## Paths
+
+Every command below uses `${PREP_DIR}`. Export it before the first step:
+
+```bash
+export PREP_DIR="${RESULTS_DIR}/prep"
+mkdir -p "$PREP_DIR"
+```
+
+`${RESULTS_DIR}/prep` is the layout the rest of the workflow expects: the output tree
+in `references/pipeline-and-state.md` places the mappings and `pool_report.json` there,
+and the report reads them from that path. The pool's own artifacts are separate —
+they live under `<workspace>/source_pool/`, outside the results tree, so a second run
+against the same pool reuses them.
+
 **This runs exactly once, before the baseline.** Every iteration afterwards is a lookup against what prep produced — no labeler and no encoder runs inside the loop. That is the point: it keeps the per-iteration path deterministic and confines GPU work to train and inference.
 
 **Prep is idempotent.** Skip any step whose output already exists. A user arriving with a pool that is already labeled and embedded pays nothing; a user with raw images pays for the whole chain once. Never re-label or re-embed a pool that already has current artifacts.
@@ -213,6 +228,22 @@ docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
 Add `-v` for every path outside `$WORKSPACE` — the checkpoint and the classmap
 commonly live elsewhere, and a container cannot read what is not mounted.
 
+This is the longest stage in the workflow — it scales with pool size, and runs to
+tens of minutes on 5k images and hours on 100k. Wait on its artifacts, not on the
+process:
+
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/await_stage.py \
+  --artifact "${PREP_DIR}/inference/labels" \
+  --status-json "${PREP_DIR}/inference/status.json" \
+  --status-contains "finished successfully"
+```
+
+TAO appends the action name to `results_dir`, so passing `results_dir=${PREP_DIR}`
+puts every output under `${PREP_DIR}/inference/`. A wait pointed at
+`${PREP_DIR}/status.json` never matches and times out while the stage runs
+normally.
+
 `dataset.infer_data_sources.classmap` is the detector's **own** vocabulary — one class name per line in `category_id` order starting at 1, COCO-80 for a COCO-trained checkpoint. It is not the target list; `category_mapping` names are matched against it. `results_dir` auto-appends the action, so labels land in `${PREP_DIR}/inference/labels/` already carrying target class names.
 
 `conf_threshold` is the main quality control on the pseudo-labels and is applied at write time.
@@ -282,10 +313,10 @@ Do not read that as "the image survives to training". It does not: this step ski
   --classes     "$CLASSES_YAML" \
   --labels-dir  "${PREP_DIR}/inference/labels" \
   --images-dir  "$POOL_IMAGES" \
+  --record      target_classes="<comma-separated target classes>" \
+  --record      codetr_checkpoint="$CODETR_CHECKPOINT" \
+  --record      pyt_image="$TAO_PYT_IMAGE" \
   --report-json "${PREP_DIR}/pool_report.json"
-  --record target_classes="<comma-separated target classes>" \
-  --record codetr_checkpoint="$CODETR_CHECKPOINT" \
-  --record pyt_image="$TAO_PYT_IMAGE" \
 ```
 
 `--record` writes those under `prep_inputs` in the report. Prep is idempotent by
@@ -363,6 +394,7 @@ container that sees no images, and an error that blames the image list rather th
   --pool-odvg "<workspace>/source_pool/odvg" \
   --pool-embeddings "<workspace>/source_pool/source_embeddings.parquet" \
   --pool-report "${PREP_DIR}/pool_report.json" \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "prep: labeled <N> pool images, <M> boxes kept across <K> classes"
 ```
 

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -97,13 +97,9 @@ Both consumers do exact-string lookups — Co-DETR checks `orig_name not in name
 
 Copy source names verbatim from the detector's classmap. `validate_pool_coco.py` (step 4) names case-only mismatches explicitly, because this is the most likely way a fold goes wrong and the least visible.
 
-> **Improvement to make to `annotations convert`:** `construct_category_map` /
-> `labels2cat` in `kitti_to_coco.py` should match class names case-insensitively, or
-> at minimum warn when a label class differs from a mapping alias only by case. Today
-> the reference mapping works around it by hand-enumerating variants — `Bicycle`,
-> `bicycle`, `AutoMobile`, `Automobile` — which is fragile and silently incomplete for
-> any spelling nobody thought of. The same function is imported by
-> `analytics kpi_analyze`, so a fix there covers both.
+Matching is case-sensitive in both `annotations convert` and `analytics kpi_analyze`,
+which share the same lookup, so a mapping must enumerate every spelling it expects to
+see — `Bicycle` and `bicycle`, `AutoMobile` and `Automobile`.
 
 ### Target names must be single tokens
 

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -206,7 +206,7 @@ value lands directly on `inference.category_mapping`.
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   $CODETR inference -e "$CODETR_SPEC" \
     inference.checkpoint="$CODETR_CHECKPOINT" \
@@ -258,7 +258,7 @@ the targets. `results_dir` is **not** a scratch dir — see below. The overlay p
 step and the ODVG conversion both look for.
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" annotations convert -e "${PREP_DIR}/kitti_to_coco.yaml"
 ```
 
@@ -328,7 +328,7 @@ Pass `--allow-empty-classes` only when a class is listed defensively and its abs
 ```
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" annotations convert -e "${PREP_DIR}/coco_to_odvg.yaml"
 ```
 

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -398,6 +398,11 @@ container that sees no images, and an error that blames the image list rather th
   --summary "prep: labeled <N> pool images, <M> boxes kept across <K> classes"
 ```
 
+`--pool-report` is what settles `rare_class_list`: under `class_stratified` allocation
+the commit derives it here from the pool's annotation counts and writes it into state,
+because which classes are rare is a property of the pool and nothing knows it before
+prep. Omitting the flag leaves the field unset and `mine` refuses.
+
 ## Gates
 
 Hard-stop before the baseline when any of these hold:

--- a/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
@@ -38,7 +38,7 @@ visible without diffing against a container.
 | `kitti_to_coco.yaml` | `annotations convert` KITTI→COCO | `kitti.project: coco` — names the output file every later step looks for |
 | `coco_to_odvg.yaml` | `annotations convert` COCO→ODVG | formats only |
 | `codetr_inference.yaml` | pool pseudo-labelling | `num_select: 1000` (TAO 300 crowds rare classes out of the pool), `conf_threshold: 0.3`, the ViT-L/16 architecture the checkpoint requires, and `save_annotated_images: false` |
-| `grounding_dino_inference.yaml` | baseline + per-iteration inference | `conf_threshold: 0.0` (keep the full PR curve), `log_scale: auto`, `class_embed_bias: true` |
+| `grounding_dino_inference.yaml` | baseline + per-iteration inference | `conf_threshold: 0.0` (keep the full PR curve), `log_scale: auto`, `class_embed_bias: true`, and `save_annotated_images: false` |
 | `kpi_analyze.yaml` | scoring | `num_recall_points: 11`, `ignore_sqwidth: 40` |
 
 `grounding_dino train` has no overlay: it is built from the full

--- a/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
@@ -38,7 +38,7 @@ visible without diffing against a container.
 | `kitti_to_coco.yaml` | `annotations convert` KITTI→COCO | `kitti.project: coco` — names the output file every later step looks for |
 | `coco_to_odvg.yaml` | `annotations convert` COCO→ODVG | formats only |
 | `codetr_inference.yaml` | pool pseudo-labelling | `num_select: 1000` (TAO 300 crowds rare classes out of the pool), `conf_threshold: 0.3`, the ViT-L/16 architecture the checkpoint requires, and `save_annotated_images: false` |
-| `grounding_dino_inference.yaml` | baseline + per-iteration inference | `conf_threshold: 0.0` (keep the full PR curve), `log_scale: auto`, `class_embed_bias: true`, and `save_annotated_images: false` |
+| `grounding_dino_inference.yaml` | baseline + per-iteration inference | `conf_threshold: 0.0` (keep the full PR curve), `log_scale: auto`, `class_embed_bias: true` |
 | `kpi_analyze.yaml` | scoring | `num_recall_points: 11`, `ignore_sqwidth: 40` |
 
 `grounding_dino train` has no overlay: it is built from the full

--- a/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
@@ -37,7 +37,7 @@ visible without diffing against a container.
 |---|---|---|
 | `kitti_to_coco.yaml` | `annotations convert` KITTI→COCO | `kitti.project: coco` — names the output file every later step looks for |
 | `coco_to_odvg.yaml` | `annotations convert` COCO→ODVG | formats only |
-| `codetr_inference.yaml` | pool pseudo-labelling | `num_select: 1000` (TAO 300 crowds rare classes out of the pool), `conf_threshold: 0.3`, the ViT-L/16 architecture the checkpoint requires, and `save_annotated_images: false` |
+| `codetr_inference.yaml` | pool pseudo-labelling | `num_select: 1000` (TAO 300 crowds rare classes out of the pool), `conf_threshold: 0.3`, and the ViT-L/16 architecture the checkpoint requires |
 | `grounding_dino_inference.yaml` | baseline + per-iteration inference | `conf_threshold: 0.0` (keep the full PR curve), `log_scale: auto`, `class_embed_bias: true` |
 | `kpi_analyze.yaml` | scoring | `num_recall_points: 11`, `ignore_sqwidth: 40` |
 

--- a/skills/applications/tao-run-deft-object-detection/references/stage-mined-data.md
+++ b/skills/applications/tao-run-deft-object-detection/references/stage-mined-data.md
@@ -97,5 +97,6 @@ Point `--weak-parquet` at **iteration 1's** weak-images parquet on every iterati
   --label-map "${RESULTS_DIR}/iter${N}/tmm/annotations/labelmap.json" \
   --staged-images-dir "${RESULTS_DIR}/iter${N}/tmm/images" \
   --exclude-parquet "${RESULTS_DIR}/iter${N}/mined_cumulative.parquet" \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "staged <N> images with annotations"
 ```

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -70,11 +70,6 @@ and `ignore_sqwidth: 40`, so delegating to it and applying this overlay agree. A
 overlay anyway: the agreement is a fact about the current versions, not a guarantee, and
 a spec that states its own scoring settings is auditable after the fact.
 
-`conf_threshold: 0.0` is safe on the pinned image. An undetected ground-truth box used to
-be carried as `(t=1, p=0.0)` against a `p >= conf_threshold` check, so zero scored every
-missed box as a true positive; unmatched ground truth now uses a `-1.0` sentinel and lands
-in FN at any threshold. On a build predating that fix, use a small positive value.
-
 ## Scoring at more than one confidence threshold
 
 Inference runs at `0.0`, so the labels carry every detection and this stage can score them

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -105,10 +105,10 @@ Pass the narrowed file as `data.mapping`, not the user's original.
 
 ## Invocation
 
-**Launch it detached.** This stage runs 25-45 minutes on a 14k-image KPI set — the
-baseline is the slowest, since every detection survives `conf_threshold: 0.0` — and the mAP
-appears *only* on stdout. A foreground `docker run | tee` loses the number if the client
-dies, while the container keeps running — name the container, redirect to the log, and
+**Launch it detached.** Runtime scales with the KPI set, and the baseline is the
+slowest phase to score because every detection survives `conf_threshold: 0.0`. The mAP
+appears *only* on stdout, and a foreground `docker run | tee` loses it if the client
+dies while the container keeps running — name the container, redirect to the log, and
 wait on the log with `await_stage.py`:
 
 ```bash

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -158,5 +158,6 @@ Tee the log: the aggregate **mAP is printed to stdout only** and is not written 
   --kpi-csv "${RESULTS_DIR}/<phase>/kpi/kpi_calc.csv" \
   --kpi-log "${RESULTS_DIR}/<phase>/kpi/kpi_analyze.log" \
   --map-value "<parsed mAP>" \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "kpi: mAP=<value>"
 ```

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -110,7 +110,8 @@ Pass the narrowed file as `data.mapping`, not the user's original.
 
 ## Invocation
 
-**Launch it detached.** This stage runs ~22 minutes on a 14k-image KPI set and the mAP
+**Launch it detached.** This stage runs 25-45 minutes on a 14k-image KPI set — the
+baseline is the slowest, since every detection survives `conf_threshold: 0.0` — and the mAP
 appears *only* on stdout. A foreground `docker run | tee` loses the number if the client
 dies, while the container keeps running — name the container, redirect to the log, and
 wait on the log with `await_stage.py`:
@@ -127,15 +128,17 @@ Pass `--gpus all` even though the scoring itself is CPU-bound: the TAO launcher 
 `FileNotFoundError: 'nvidia-smi'` before any work begins.
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
+docker run -d --name "deft_${PHASE}_kpi" --gpus all --ipc=host --user "$(id -u):$(id -g)" \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
-  analytics kpi_analyze -e "$KPI_SPEC" 2>&1 | tee "${RESULTS_DIR}/<phase>/kpi/kpi_analyze.log"
-# mAP appears only on stdout, so the tee is required — but a pipeline reports the
-# exit status of `tee`, not of the container. Without one of these, a failed
-# kpi_analyze looks like a success:
-#   set -o pipefail   (before the pipeline), or
-#   [ "${PIPESTATUS[0]}" -eq 0 ] || { echo "kpi_analyze failed"; exit 1; }
+  analytics kpi_analyze -e "$KPI_SPEC" 2>&1
+# Detached, and NOT --rm: the mAP exists only on this container's stdout, so removing
+# it on exit discards the number. Wait on the artifact, then capture the log, then
+# remove the container yourself:
+#   await_stage.py --artifact "${RESULTS_DIR}/<phase>/kpi/kpi_calc.csv" --timeout-sec 5400
+#   docker logs "deft_${PHASE}_kpi" > "${RESULTS_DIR}/<phase>/kpi/kpi_analyze.log" 2>&1
+#   docker inspect -f '{{.State.ExitCode}}' "deft_${PHASE}_kpi"   # check before trusting it
+#   docker rm "deft_${PHASE}_kpi"
 ```
 
 Tee the log: the aggregate **mAP is printed to stdout only** and is not written into `kpi_calc.csv`. Parse it from the log line `mAP: <value>` and record it in state; otherwise the trend across iterations cannot be reported.

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -109,13 +109,42 @@ at `0.0`; sweeps are a diagnostic.
 
 **`is_internal` must stay `false`.** Setting it true drops every class except `person` and appends a `Summary` row, silently changing what the report means.
 
+## Narrow the mapping to the target classes first
+
+The user's mapping usually names more classes than the run targets. Scoring an
+untargeted class adds a constant-0 AP row and averages it into the mAP, so the number
+stops being comparable with any run that did not:
+
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/prepare_mapping_for_kpi_analyze.py \
+  --mapping "<the user's class mapping>" \
+  --target-classes "<comma-separated target classes>" \
+  --out "${RESULTS_DIR}/<phase>/kpi/mapping.yaml"
+```
+
+Pass the narrowed file as `data.mapping`, not the user's original.
+
 ## Invocation
 
-KPI analysis is CPU-only — do not request a GPU.
+**Launch it detached.** This stage runs ~22 minutes on a 14k-image KPI set and the mAP
+appears *only* on stdout. A foreground `docker run | tee` loses the number if the client
+dies, while the container keeps running — name the container, redirect to the log, and
+wait on the log with `await_stage.py`:
+
+```bash
+docker run -d --name "deft_${PHASE}_kpi" ... > /dev/null
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/await_stage.py \
+  --artifact "${RESULTS_DIR}/<phase>/kpi/kpi_calc.csv" --timeout-sec 5400
+docker logs "deft_${PHASE}_kpi" > "${RESULTS_DIR}/<phase>/kpi/kpi_analyze.log" 2>&1
+```
+
+Pass `--gpus all` even though the scoring itself is CPU-bound: the TAO launcher calls
+`nvidia-smi -L` unconditionally at startup, so omitting it fails with
+`FileNotFoundError: 'nvidia-smi'` before any work begins.
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   analytics kpi_analyze -e "$KPI_SPEC" 2>&1 | tee "${RESULTS_DIR}/<phase>/kpi/kpi_analyze.log"
 # mAP appears only on stdout, so the tee is required — but a pipeline reports the

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -63,33 +63,17 @@ kpi:
   is_internal: false
 ```
 
-### The leaf skill's defaults are not this loop's
+### These values are the leaf skill's defaults too
 
-`tao-analyze-detection-kpi` ships `assets/default_kpi_analyze.yaml` with different
-values, so **invoking that skill without applying this overlay silently scores a
-different metric**:
+`tao-analyze-detection-kpi` ships the same `conf_threshold: 0.0`, `num_recall_points: 11`
+and `ignore_sqwidth: 40`, so delegating to it and applying this overlay agree. Apply the
+overlay anyway: the agreement is a fact about the current versions, not a guarantee, and
+a spec that states its own scoring settings is auditable after the fact.
 
-| field | this loop | leaf skill default |
-|---|---:|---:|
-| `kpi.conf_threshold` | 0.0 | 0.3 |
-| `kpi.num_recall_points` | 11 | 101 |
-| `kpi.ignore_sqwidth` | 40 | 0 |
-
-The loop's values reproduce the reference pipeline this workflow is measured
-against; the leaf skill's are TAO's own defaults, sensible for standalone scoring.
-Neither is wrong in isolation — but a run that mixes them produces numbers
-comparable to nothing.
-
-The leaf skill also documents `conf_threshold` as needing to be `> 0`, because an
-undetected ground-truth box was carried as `(t=1, p=0.0)` and `p >= conf_threshold`
-counted it as a true positive at zero. **That defect is fixed in the data-services
-image this loop pins**, which is why 0.0 is safe here and why it is the right value:
-it keeps the full precision-recall curve so a threshold can be swept afterwards from
-a single inference pass. On an older image, 0.0 would report `TP` = ground-truth
-count and `FN` = 0.
-
-So: delegate the invocation, but always apply
-`assets/overlays/kpi_analyze.yaml` over the resulting spec.
+`conf_threshold: 0.0` is safe on the pinned image. An undetected ground-truth box used to
+be carried as `(t=1, p=0.0)` against a `p >= conf_threshold` check, so zero scored every
+missed box as a true positive; unmatched ground truth now uses a `-1.0` sentinel and lands
+in FN at any threshold. On a build predating that fix, use a small positive value.
 
 ## Scoring at more than one confidence threshold
 

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
@@ -61,7 +61,7 @@ class_mapping: {}
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   gap_analysis object_detection -e "$OD_GAP_SPEC"
 ```

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
@@ -95,6 +95,7 @@ Count the rows of `weak_images.parquet` and pass that number. It is required on 
   --weak-images "${RESULTS_DIR}/iter${N}/gaps/weak_images.parquet" \
   --gap-report "${RESULTS_DIR}/iter${N}/gaps/gap_report.json" \
   --weak-image-count <row count of weak_images.parquet> \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "gap_analysis: <N> weak images across <M> classes"
 ```
 

--- a/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
@@ -10,7 +10,6 @@ Iteration stage 2, immediately after `gap_analysis`. Skipped only when `gap_anal
 
 `weak_images.parquet` already carries a `filepath` column, so it is fed to the embedder directly. No projection step is needed.
 
-> The reference pipeline had an extra task here purely to rename `gt_image_path` → `filepath`, because its bespoke gap-analysis container emitted the former. The TAO DS `gap_analysis object_detection` action emits `filepath`, so that glue disappears.
 
 ## Encoder consistency is the whole ballgame
 
@@ -50,7 +49,6 @@ Columns: `filepath`, `embedding` (list-like), plus every extra column carried th
 
 The embedding column is named **`embedding`**, which is what `tmm unique_neighbor_matching` expects by default — no column override is needed anywhere in this loop.
 
-> Worth knowing if you ever compare against the reference pipeline: its embedding image emitted `embedding` while three of its four miner variants hardcoded `image_embed`, so those combinations silently failed to find the vectors. The TAO DS pair agrees on `embedding` end to end.
 
 ## Commit
 

--- a/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
@@ -27,6 +27,11 @@ output_parquet: <absolute path to iter${N}/embeddings/weak_images_embeddings.par
 model:          <SigLIP|CLIP — from state.config.embedding_model>
 model_path:     <from state.config.embedding_model_path>
 model_config_path: ""      # only when model_path is a TAO .pth/.ckpt
+                           # Setting this via --set needs the empty string quoted
+                           # twice: --set model_config_path='""'. A bare
+                           # --set model_config_path="" parses as YAML null and TAO
+                           # rejects it with `Incompatible value 'None' for field of
+                           # type 'str'`.
 batch_size:     64
 ```
 
@@ -56,5 +61,6 @@ The embedding column is named **`embedding`**, which is what `tmm unique_neighbo
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/commit_stage.py \
   --results-dir "${RESULTS_DIR}" --iter-label "iter${N}" --stage embed \
   --embeddings-parquet "${RESULTS_DIR}/iter${N}/embeddings/weak_images_embeddings.parquet" \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "embedded <N> weak images with <model>"
 ```

--- a/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
@@ -35,7 +35,7 @@ batch_size:     64
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   embedding image_embeddings -e "$EMBED_SPEC"
 ```

--- a/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
@@ -76,6 +76,12 @@ visualize:              false
 
 **Allocation policy.** Use `class_stratified` when the user supplied rare classes — budget is apportioned by target class ratio using largest-remainder, with a non-rare fallback pool, and each source is owned by the first class that claims it. Use `global` when no rare classes are configured. The reference pipeline's `class_balanced` mode maps to `class_stratified`.
 
+**`rare_class_list` comes from state, not from this stage.** Read
+`config.rare_class_list` and write it into the spec verbatim. It is derived once, at
+the prep commit, from the pool's own annotation counts — every target class holding a
+below-mean share. Under `class_stratified` the commit refuses a `mine` while it is
+still unset, since allocation apportions the budget by exactly that list.
+
 **`candidate_expansion_factor` is not the loop's iteration count.** It seeds the miner's internal candidate-pool growth (starting at 5, widening each internal retry, capped at 8 internal passes). It is unrelated to `max_iterations`.
 
 ## Invocation

--- a/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
@@ -21,6 +21,13 @@ Iteration stage 3, after `embed`. Mines the source pool for images resembling th
 
 This is a hard failure, not a warning. TAO DS `load_datasets` raises `FileNotFoundError` when `exclude_path` is set but is not a file — and on iteration 1 no cumulative parquet exists yet. Pointing at the not-yet-written path kills the stage before any mining happens.
 
+A *spent* pool fails differently and worse. When the exclude set already covers every
+pool image, `split_datasets_by_class` raises `TypeError: Series object is not iterable`
+from `selection.py` — an unhandled cudf error naming neither the pool nor the exclude
+set. Count the pool rows not already excluded **before** invoking, and stop the loop
+instead of calling the miner with nothing left to give
+(`commit_stage.py --stage loop_stop --pool-exhausted --pool-remaining N`).
+
 - **Iteration 1**: emit `exclude_path: null`.
 - **Iteration N > 1**: emit the absolute path to `${RESULTS_DIR}/iter$((N-1))/mined_cumulative.parquet`, and confirm the file exists before writing the spec.
 
@@ -51,7 +58,7 @@ Write per-iteration under `${RESULTS_DIR}/iter${N}/mining/unique_neighbor_matchi
 source_path:            <config.source_pool_embeddings>
 target_path:            <iterations.iter${N}.embeddings_parquet>
 output_dir:             <absolute path to ${RESULTS_DIR}/iter${N}/mining>
-desired_unique_count:   <from prepare_budget_for_mining.py>
+desired_unique_count:   <from prepare_budget_for_mining.py — see below>
 allocation_policy:      class_stratified     # or global — see below
 distance_metric:        euclidean
 candidate_expansion_factor: 5
@@ -76,7 +83,7 @@ visualize:              false
 
 ```bash
 docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
-  -v "$WORKSPACE:$WORKSPACE" -w "$WORKSPACE" \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   tmm unique_neighbor_matching -e "$MINE_SPEC"
 ```
@@ -105,3 +112,20 @@ Read `coverage_pct` from `summary.json`:
   --mining-summary "${RESULTS_DIR}/iter${N}/mining/summary.json" \
   --summary "mined <retrieved>/<desired> unique images (<coverage_pct>% coverage)"
 ```
+
+## Computing `desired_unique_count`
+
+The budget is produced before this stage by `prepare_budget_for_mining.py`, and its full
+invocation lives in `references/stage-mined-data.md`. Reading only this overlay leaves
+the field with no documented way to compute it, so the short form is repeated here:
+
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/prepare_budget_for_mining.py \
+  --weak-parquet "${RESULTS_DIR}/iter1/gaps/weak_images.parquet" \
+  --multiplier "<multiplier>" --pool-size "<pool rows>" \
+  --already-mined "<cumulative exclude rows, 0 on iteration 1>" \
+  --remaining-iterations "<iterations left, including this one>"
+```
+
+Seed it from **iteration 1's** weak parquet on every iteration, so the amount of data
+added per iteration stays constant as the gap set shrinks.

--- a/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
@@ -109,6 +109,7 @@ Read `coverage_pct` from `summary.json`:
   --results-dir "${RESULTS_DIR}" --iter-label "iter${N}" --stage mine \
   --mining-output "${RESULTS_DIR}/iter${N}/mining/final_unique_files.parquet" \
   --mining-summary "${RESULTS_DIR}/iter${N}/mining/summary.json" \
+  --duration-sec "$(( SECONDS - started ))" \
   --summary "mined <retrieved>/<desired> unique images (<coverage_pct>% coverage)"
 ```
 

--- a/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
@@ -31,7 +31,6 @@ instead of calling the miner with nothing left to give
 - **Iteration 1**: emit `exclude_path: null`.
 - **Iteration N > 1**: emit the absolute path to `${RESULTS_DIR}/iter$((N-1))/mined_cumulative.parquet`, and confirm the file exists before writing the spec.
 
-> The reference pipeline's miner silently skipped a missing exclude file; TAO DS raises instead. Its KFP wrapper only worked because it pre-guarded with `os.path.exists`. Reproduce that guard, not the bare path.
 
 ## `detection_format` is never inferred
 

--- a/skills/applications/tao-run-deft-object-detection/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/commit_stage.py
@@ -89,6 +89,7 @@ from deft_stages import (  # noqa: E402
     STAGE_ARTIFACTS,
     TERMINAL_STAGE,
     check_artifact,
+    derive_rare_classes,
     iter_number,
     log_path,
     phase_entry,
@@ -534,6 +535,41 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_rare_classes(state: dict, pool_report: str | None) -> str | None:
+    """Fill a null ``config.rare_class_list`` from the prepared pool's class counts.
+
+    Only applies to ``class_stratified`` allocation, which is the only policy that
+    reads the list. Returns a message describing what was written, or None when
+    there was nothing to do. A pool report that cannot be read is not fatal here:
+    the value stays null and `mine` refuses on a list it needs but does not have.
+    """
+    config = state.get("config")
+    if not isinstance(config, dict):
+        return None
+    if config.get("allocation_policy") != "class_stratified":
+        return None
+    if config.get("rare_class_list"):
+        return None
+    if not pool_report:
+        return ("rare_class_list is unset and no --pool-report was committed; "
+                "`mine` requires it under class_stratified allocation")
+    raw_targets = config.get("target_classes") or []
+    if isinstance(raw_targets, str):
+        raw_targets = raw_targets.split(",")
+    targets = [str(c).strip() for c in raw_targets if str(c).strip()]
+    try:
+        data = json.loads(Path(pool_report).read_text(encoding="utf-8"))
+        counts = {str(c): int(n) for c, n in (data.get("annotations_by_class") or {}).items()}
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        return f"rare_class_list left unset: --pool-report is unreadable ({exc})"
+    rare, detail = derive_rare_classes(counts, targets)
+    if not rare:
+        return (f"rare_class_list left unset: no target class holds a below-mean share "
+                f"of the pool ({detail})")
+    config["rare_class_list"] = ",".join(rare)
+    return (f"rare_class_list resolved to {rare} from the pool's class counts ({detail})")
+
+
 def main() -> int:
     parser = _build_parser()
     args, unknown = parser.parse_known_args()
@@ -709,10 +745,10 @@ def main() -> int:
                 extras["map_value"] = args.map_value
 
             # The weak-image count is gap_analysis's measurement and no other
-            # stage's. It used to be accepted everywhere, and `entry.update(extras)`
-            # meant a `--weak-image-count 0` on loop_stop overwrote the real count
-            # on the phase entry — buying a "documented early stop" completion for a
-            # run that stopped at iteration 1 of 3.
+            # stage's. `entry.update(extras)` writes it straight onto the phase
+            # entry, so accepting it elsewhere lets a later stage overwrite the real
+            # count with its own — and the count is what decides whether an early
+            # stop is a completed run.
             if stage != "gap_analysis":
                 offered = [
                     flag
@@ -826,6 +862,31 @@ def main() -> int:
                 raise ValueError(f"state.iterations.{phase} must be an object")
             entry.update(artifacts)
             entry.update(extras)
+
+            # Which target classes are rare is a property of the pool, so it can
+            # only be settled once prep has built one. init leaves it null on a run
+            # that still has to prep; this fills it from the pool's own class counts
+            # before `mine`, the first stage that reads it, can run.
+            if stage == "prep" and args.status == "ok":
+                resolved = _resolve_rare_classes(state, extras.get("pool_report"))
+                if resolved:
+                    print(resolved, file=sys.stderr)
+
+            # The deferral above is only safe if the value is guaranteed present by
+            # the time it matters. class_stratified apportions the budget by rare
+            # class; with no list it silently degrades to global allocation and the
+            # run stops protecting the classes it exists to improve.
+            if stage == "mine" and args.status == "ok":
+                config = state.get("config")
+                config = config if isinstance(config, dict) else {}
+                if (config.get("allocation_policy") == "class_stratified"
+                        and not config.get("rare_class_list")):
+                    raise ValueError(
+                        "config.rare_class_list is unset but allocation_policy is "
+                        "class_stratified. It is derived at the prep commit from "
+                        "pool_report.json; commit prep with --pool-report, or re-init "
+                        "with --rare-class-list"
+                    )
 
             run_failed = failure is not None or state.get("status") == "failed"
             if stage == TERMINAL_STAGE:

--- a/skills/applications/tao-run-deft-object-detection/scripts/deft_stages.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/deft_stages.py
@@ -28,6 +28,28 @@ TERMINAL_STAGE = "loop_stop"
 
 ALL_STAGES = sorted(set(PREP_ORDER + BASELINE_ORDER + ITER_ORDER + [TERMINAL_STAGE]))
 
+
+def derive_rare_classes(pool_counts: dict[str, int],
+                        target_classes: list[str]) -> tuple[list[str], str]:
+    """Rare target classes from the pool's own annotation counts.
+
+    Below-mean share, not below-median: with one dominant class the median calls
+    half the target set rare however lopsided the pool actually is.
+
+    Returns the class list and a human-readable account of the counts it used.
+    Only classes the pool actually holds are eligible -- a class with no
+    annotations cannot be mined for, so naming it rare would allocate budget that
+    nothing can fill.
+    """
+    backed = {c: pool_counts[c] for c in target_classes if pool_counts.get(c)}
+    if not backed:
+        return [], "the pool holds no annotations for any target class"
+    mean_share = sum(backed.values()) / len(backed)
+    rare = sorted(c for c, n in backed.items() if n < mean_share)
+    detail = ", ".join(f"{c}={backed[c]}" for c in sorted(backed, key=backed.get))
+    return rare, detail
+
+
 # stage -> {state field: (commit flag, "file"|"dir")}
 # Every listed artifact must exist on disk before the stage may be committed.
 STAGE_ARTIFACTS: dict[str, dict[str, tuple[str, str]]] = {

--- a/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from deft_stages import (  # noqa: E402
     SCHEMA_VERSION,
     check_artifact,
+    derive_rare_classes,
     log_path,
     state_path,
     write_log_atomic,
@@ -98,8 +99,10 @@ def _build_parser() -> argparse.ArgumentParser:
                         help="Run directory; holds deft_state.json and loop_log.jsonl.")
     parser.add_argument("--workspace", required=True,
                         help="Workspace root. Mounted into every container as itself.")
-    parser.add_argument("--max-iterations", type=int, required=True,
-                        help="Number of iterations after the baseline. No default; the user supplies it.")
+    parser.add_argument("--max-iterations", type=int, default=1,
+                        help="Number of iterations after the baseline. Default 1: one mine, "
+                             "train and score pass, which is the smallest run that produces a "
+                             "comparison against the baseline.")
 
     parser.add_argument("--num-gpus", type=int, default=1)
     parser.add_argument("--num-epochs", type=int, required=True,
@@ -389,18 +392,12 @@ def main() -> int:
                                     f"reuse it")
 
         if args.allocation_policy == "class_stratified" and not rare_classes and pool_counts:
-            backed = {c: pool_counts[c] for c in target_classes if pool_counts.get(c)}
-            if backed:
-                # Below-mean share: with one dominant class the median would call
-                # half the set rare regardless of how lopsided the pool actually is.
-                mean_share = sum(backed.values()) / len(backed)
-                rare_classes = sorted(c for c, n in backed.items() if n < mean_share)
-                if rare_classes:
-                    detail = ", ".join(f"{c}={backed[c]}" for c in sorted(backed, key=backed.get))
-                    warnings.append(
-                        f"--rare-class-list not given; derived {rare_classes} from the pool's "
-                        f"own class counts ({detail}). These are the classes the pool holds "
-                        "fewest of, which is what stratified allocation exists to protect")
+            rare_classes, detail = derive_rare_classes(pool_counts, target_classes)
+            if rare_classes:
+                warnings.append(
+                    f"--rare-class-list not given; derived {rare_classes} from the pool's "
+                    f"own class counts ({detail}). These are the classes the pool holds "
+                    "fewest of, which is what stratified allocation exists to protect")
 
         kpi_images_dir = _abs(args.kpi_images_dir)
         ground_truth_labels_dir = _abs(args.ground_truth_labels_dir)
@@ -461,7 +458,21 @@ def main() -> int:
         }
         if args.allocation_policy == "class_stratified":
             if not rare_classes:
-                errors.append("--allocation-policy class_stratified requires --rare-class-list")
+                # Which classes are rare is a property of the pool's annotation
+                # counts, and those counts are prep's output. Requiring the list
+                # here would make init and prep each other's precondition, so on a
+                # run that still has to prep it is left null and the prep commit
+                # derives it from pool_report.json. `mine` is the first stage that
+                # reads it, and prep is complete by then.
+                message = ("--allocation-policy class_stratified requires "
+                           "--rare-class-list")
+                if missing_pool and not absent_inputs:
+                    warnings.append(
+                        f"{message} — left unset; `commit_stage.py --stage prep` derives it "
+                        "from the pool's own class counts once prep has produced "
+                        "pool_report.json")
+                else:
+                    errors.append(message)
             if not args.pool_report:
                 # pool_report.json is the only artifact that cross-checks the prepared
                 # pool against the requested classes. It is also prep's own output, so

--- a/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
@@ -536,7 +536,14 @@ def main() -> int:
         mounted = [results_dir, zero_shot_checkpoint, train_spec_template, source_pool_embeddings,
                    source_pool_annotations, kpi_images_dir, ground_truth_labels_dir, class_mapping]
         if looks_local:
-            mounted.append(Path(model_path))
+            # A HuggingFace hub snapshot is all symlinks into a sibling blobs/ dir, so
+            # mounting the snapshot alone gives the container dangling links and the
+            # loader reports "no file named model.safetensors found" -- a missing-model
+            # error for a model that is present. Mount the repo root, which holds both.
+            encoder = Path(model_path)
+            if "snapshots" in encoder.parts:
+                encoder = Path(*encoder.parts[:encoder.parts.index("snapshots")])
+            mounted.append(encoder)
         for extra in (args.pool_images, args.codetr_checkpoint, args.codetr_classmap):
             if extra:
                 mounted.append(_abs(extra))

--- a/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
@@ -527,8 +527,19 @@ def main() -> int:
 
         # Containers see only "$WORKSPACE:$WORKSPACE"; anything outside is invisible inside them.
         # embedding_model_path is exempt: HF_HOME legitimately lives outside the workspace.
+        # Every path a container has to read, not a subset. The encoder is included
+        # despite living outside the workspace by design: prep's embed reads it from
+        # inside the container, and an unmounted local snapshot is passed to
+        # HuggingFace as a repo id, which fails as HFValidationError rather than as a
+        # missing mount. Prep's own inputs are here for the same reason -- Co-DETR
+        # reads the classmap and checkpoint from inside the container.
         mounted = [results_dir, zero_shot_checkpoint, train_spec_template, source_pool_embeddings,
                    source_pool_annotations, kpi_images_dir, ground_truth_labels_dir, class_mapping]
+        if looks_local:
+            mounted.append(Path(model_path))
+        for extra in (args.pool_images, args.codetr_checkpoint, args.codetr_classmap):
+            if extra:
+                mounted.append(_abs(extra))
         # Anything outside the workspace needs its own -v or the container cannot read
         # it. Deriving the mounts here means the stages get a list to use rather than a
         # warning to act on, which is what left earlier runs to work it out mid-flight.

--- a/skills/applications/tao-run-deft-object-detection/scripts/prepare_budget_for_mining.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/prepare_budget_for_mining.py
@@ -15,7 +15,13 @@ iteration to reproduce that behavior; pass the current iteration's parquet
 instead to let the budget track the shrinking gap set.
 
 ``--pool-size`` and ``--remaining-iterations`` turn the budget into a feasibility
-check. The pool is finite and iterations exclude what earlier ones already mined,
+check. Note the limit: ``--weak-parquet`` is required and the only weak parquet comes
+from iteration 1's ``gap_analysis``, so the earliest this can run is after the baseline
+has been scored. It bounds the *remaining* iterations, not the first one. A run whose
+pool cannot support its ``max_iterations`` still pays for a full baseline before
+hearing so.
+
+The pool is finite and iterations exclude what earlier ones already mined,
 so a run needs roughly ``budget x remaining_iterations`` unmined images left to
 finish. When it does not have them, the shortfall is knowable here — before the
 train, inference and KPI stages of this iteration run — rather than at the next

--- a/skills/applications/tao-run-deft-object-detection/scripts/tests/test_state_machine.sh
+++ b/skills/applications/tao-run-deft-object-detection/scripts/tests/test_state_machine.sh
@@ -2319,6 +2319,92 @@ case "$RUN_OUT" in
 esac
 
 # ═══════════════════════════════════════════════════════════════════════════
+# G25 — rare classes are a property of the pool, so prep settles them
+#
+# init runs before prep, and which target classes are rare is decided by the
+# pool's annotation counts. On a run that still has to prep, the list is left
+# unset and the prep commit derives it. `mine` is the first stage that reads it
+# and refuses to commit while it is still unset.
+# ═══════════════════════════════════════════════════════════════════════════
+CURRENT_SECTION="G25 rare classes are derived at the prep commit"
+
+G25=$(new_workspace g25)
+make_file "$G25/classes/classes_its.yaml" "car: [car]
+person: [person]
+bicycle: [bicycle]"
+make_file "$G25/raw/img0.png" "png"
+make_file "$G25/ckpt/codetr.pth" "not a real checkpoint"
+make_file "$G25/ckpt/coco_classmap.txt" "person"
+make_file "$G25/pool/coco_source.json" '{}'
+make_file "$G25/pool/coco_target.json" '{}'
+G25_RUN="$G25/results/run_g25"
+
+init_run "$G25" "$G25_RUN" 1 \
+  --ap50-thresholds-json '{"car": 0.9, "person": 0.85, "bicycle": 0.8}' \
+  --pool-images "$G25/raw" \
+  --codetr-checkpoint "$G25/ckpt/codetr.pth" \
+  --codetr-classmap "$G25/ckpt/coco_classmap.txt" \
+  --allocation-policy class_stratified \
+  --source-detection-file "$G25/pool/coco_source.json" \
+  --target-detection-file "$G25/pool/coco_target.json"
+assert_rc 0 "[G25] class_stratified init succeeds with no rare list on a prep run"
+case "$RUN_OUT" in
+  *"commit_stage.py --stage prep"*)
+    ok "[G25] the warning names what will derive it" ;;
+  *) notok "[G25] the warning names what will derive it" "output: $RUN_OUT" ;;
+esac
+assert_eq 'null' "$(state_json "$G25_RUN" rare_class_list)" \
+  "[G25] the list is left unset until prep has built a pool"
+
+# Prep produces the counts that decide it: car dominates, the other two are rare.
+make_pool "$G25"
+make_file "$G25_RUN/prep/pool_report.json" \
+  '{"annotations_by_class": {"car": 72287, "person": 4103, "bicycle": 2002}}'
+commit "$G25_RUN" prep prep \
+  --pool-odvg "$G25/source_pool/odvg" \
+  --pool-embeddings "$G25/source_pool/source_embeddings.parquet" \
+  --pool-report "$G25_RUN/prep/pool_report.json" \
+  --summary "prep" --duration-sec 1
+assert_rc 0 "[G25] prep commits"
+assert_eq '"bicycle,person"' "$(state_json "$G25_RUN" rare_class_list)" \
+  "[G25] the below-mean classes are derived from the pool's own counts"
+
+# Without that derivation, mine cannot commit: class_stratified allocates by it.
+G25B=$(new_workspace g25b); make_pool "$G25B"
+G25B_RUN="$G25B/results/run_g25b"
+init_run "$G25B" "$G25B_RUN" 1
+"$PY" - "$G25B_RUN/deft_state.json" <<'EOF'
+import json, sys
+p = sys.argv[1]
+s = json.load(open(p))
+s["config"]["allocation_policy"] = "class_stratified"
+s["config"]["rare_class_list"] = None
+json.dump(s, open(p, "w"))
+EOF
+make_phase_artifacts "$G25B_RUN" baseline
+commit "$G25B_RUN" baseline inference \
+  --inference-labels-dir "$G25B_RUN/baseline/inference/labels" --summary s --duration-sec 1
+commit "$G25B_RUN" baseline kpi_analyze \
+  --kpi-csv "$G25B_RUN/baseline/kpi/kpi_calc.csv" --map-value 0.5 --summary s --duration-sec 1
+make_iter_artifacts "$G25B_RUN" iter1
+commit "$G25B_RUN" iter1 gap_analysis \
+  --weak-images "$G25B_RUN/iter1/gaps/weak_images.parquet" \
+  --gap-report "$G25B_RUN/iter1/gaps/gap_report.json" \
+  --weak-image-count 5 --summary s --duration-sec 1
+commit "$G25B_RUN" iter1 embed \
+  --embeddings-parquet "$G25B_RUN/iter1/embeddings/weak_images_embeddings.parquet" \
+  --summary s --duration-sec 1
+commit "$G25B_RUN" iter1 mine \
+  --mining-output "$G25B_RUN/iter1/mining/final_unique_files.parquet" \
+  --mining-summary "$G25B_RUN/iter1/mining/summary.json" --summary s --duration-sec 1
+assert_rc 1 "[G25] mine refuses while rare_class_list is still unset"
+case "$RUN_OUT" in
+  *"rare_class_list is unset"*)
+    ok "[G25] the refusal names the unset field and how to fill it" ;;
+  *) notok "[G25] the refusal names the unset field and how to fill it" "output: $RUN_OUT" ;;
+esac
+
+# ═══════════════════════════════════════════════════════════════════════════
 
 printf '\n'
 if [ "$FAILURES" -eq 0 ]; then

--- a/skills/data/tao-analyze-detection-kpi/SKILL.md
+++ b/skills/data/tao-analyze-detection-kpi/SKILL.md
@@ -78,7 +78,7 @@ RUN_ROOT=/absolute/path/that/contains/images/annotations/and/results
 python3 skills/data/tao-analyze-detection-kpi/scripts/verify_kpi_analyze_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 
 docker run --rm --gpus all --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -137,7 +137,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
+++ b/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-detection-kpi
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -87,7 +87,7 @@ SPEC="$RESULTS_DIR/object_detection.yaml"        # spec lives beside its outputs
 RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
 GPU_COUNT=1
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -109,7 +109,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-od-map
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-generate-image-embeddings/SKILL.md
+++ b/skills/data/tao-generate-image-embeddings/SKILL.md
@@ -77,7 +77,7 @@ GPU_COUNT=1
 python3 skills/data/tao-generate-image-embeddings/scripts/verify_image_embeddings_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -144,7 +144,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
+++ b/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-generate-image-embeddings
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 gpu_spec_key: null
 required_credentials: [NGC_KEY]   # the pinned image is nvstaging/*, which is not public
 actions:

--- a/skills/data/tao-mine-od-images/SKILL.md
+++ b/skills/data/tao-mine-od-images/SKILL.md
@@ -83,7 +83,7 @@ GPU_COUNT=1
 python3 skills/data/tao-mine-od-images/scripts/verify_unique_neighbor_matching_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -147,7 +147,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-mine-od-images/references/skill_info.yaml
+++ b/skills/data/tao-mine-od-images/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-mine-od-images
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02  # versions-key: images.tao_toolkit.data_services_od
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/versions.yaml
+++ b/versions.yaml
@@ -33,10 +33,6 @@ images:
     deploy:             nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy
     data_services:      nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services
     data_services_nightly: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch
-    # Interim until `gap_analysis object_detection` and `tmm unique_neighbor_matching` ship
-    # in a release data-services image. Verified to carry all five actions the DEFT
-    # object-detection pipeline uses: gap_analysis, tmm, analytics, embedding, annotations.
-    data_services_od:   nvcr.io/nvstaging/tao/tao-dataservices:gapanalysis-02
     # TAO 7.1.0 has the Cosmos Reason Conv3d/vLLM import regression (NVBUG 6587006).
     cosmos_rl:          nvcr.io/nvstaging/tao/tao-cosmos-rl:main-direct-train-no-cache-20260811-v1
     deft_cosmos_reason: nvcr.io/nvidia/tao/tao-toolkit:7.0.1-cosmos-rl


### PR DESCRIPTION
### What changes are proposed in this pull request?

Two code fixes to container mounts, and a clarify issue in the references.

**Mounts.** Containers see only what is mounted. `init_deft_state.py` recorded `config.extra_container_mounts`, but no documented `docker run` used it, so any stage whose inputs sat outside `$WORKSPACE` — the normal layout for KPI data, pool images and the encoder — failed at the first container. The recorded list was also incomplete, omitting the Co-DETR checkpoint and classmap, the pool images, and the encoder itself. And the encoder entry pointed at the HuggingFace *snapshot* directory, which holds only symlinks into a sibling `blobs/`, so the container saw dangling links and the loader reported a missing model file for a model that was present.

`preflight.md` now exports the list as `$EXTRA_MOUNTS` and every launch carries it; inside the workspace it expands to nothing and commands are unchanged.

**References.** The remaining changes correct places where a reference described something the code or the container does not do: a

### Why are the changes needed?

As merged, following the documented commands verbatim fails at the first container whenever the data is not inside the workspace, and the KPI stage can discard its own result.

### Does this PR introduce _any_ user-facing change?

No behaviour change for a run whose inputs are all inside the workspace. Runs with external inputs go from failing to working.

### How was this patch tested?

Three 5,000-image runs and one 100,000-image run, each driven only by the skill's documentation.

* **Reproducible.** Prep from scratch produced 78,392 boxes — bicycle 2,002, car 72,287, person 4,103 — identical to an independent earlier run, and baseline mAP 0.7692955 against a previous 0.7693.
* **5k:** mAP 0.7693 → 0.7805, all three classes up; `--require-complete` exits 0 on the pool-exhaustion early stop with `pool_remaining=59`.
* **100k, both iterations:** mAP 0.7631 → 0.7871 → 0.7946; `--require-complete` exits 0 with all iterations complete. Stratified mining lifted bicycle's share of mined boxes from 0.76% to 1.60% and person's from 3.64% to 5.76% against a pool that is 95.6% car — and those two classes are the ones whose AP improved (+0.059, +0.045).
* State-machine suite 820/820; `validate-skills.sh` and `stamp_versions.py --check --strict-strays` clean; no documented `docker run` is left mounting only `$WORKSPACE`.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored-by: Claude Opus 5
