### PR TITLE
[TAO-0][Bugfix] NVBug 6596799: Validate the complete IAA DEFT config

### DIFF
--- a/scripts/tests/test_iaa_deft_config.py
+++ b/scripts/tests/test_iaa_deft_config.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Schema and value validation tests for the bundled IAA DEFT config."""
+
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IAA_ROOT = REPO_ROOT / "skills/applications/tao-run-deft-iaa"
+sys.path.insert(0, str(IAA_ROOT / "scripts"))
+from iaa_deft.config import IaaDeftConfig  # noqa: E402
+
+
+def _template():
+    return yaml.safe_load((IAA_ROOT / "specs/deft_config.yaml").read_text())
+
+
+def _write(tmp_path: Path, payload) -> Path:
+    path = tmp_path / "deft_config.yaml"
+    path.write_text(yaml.safe_dump(payload))
+    return path
+
+
+def _set(payload, dotted: str, value):
+    target = payload
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        target = target[part]
+    target[parts[-1]] = value
+
+
+def test_shipped_config_passes_full_validation():
+    config = IaaDeftConfig(str(IAA_ROOT / "specs/deft_config.yaml"))
+    assert config.mining_topn == 25
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("mining.topn", 0),
+        ("mining.topn", None),
+        ("mining.topn", ""),
+        ("experiment.visualize", "not_a_number"),
+        ("experiment.visualize_embeddings", -1),
+        ("training.continual_model", "true"),
+        ("iaa.eval_caption_dir", -1),
+        ("iaa.mining_pool_mode", "raal"),
+        ("gap_analysis.queries_per_slice", None),
+        ("gap_analysis.query_types", -1),
+        ("gap_analysis.caption_diversity.max_rows_per_image_path", 0),
+        ("mining.history_aware.replay_fraction", 2.0),
+    ],
+)
+def test_present_invalid_values_are_refused_by_full_key(tmp_path, key, value):
+    payload = copy.deepcopy(_template())
+    _set(payload, key, value)
+    path = _write(tmp_path, payload)
+
+    with pytest.raises(ValueError) as error:
+        IaaDeftConfig(str(path))
+
+    assert str(path) in str(error.value)
+    assert key in str(error.value)
+
+
+@pytest.mark.parametrize("key", ["mining.typo_topn", "unknown_section"])
+def test_unknown_keys_are_refused(tmp_path, key):
+    payload = copy.deepcopy(_template())
+    _set(payload, key, 99)
+    path = _write(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=key):
+        IaaDeftConfig(str(path))
+
+
+def test_only_absent_optional_values_take_defaults(tmp_path):
+    payload = copy.deepcopy(_template())
+    del payload["mining"]["topn"]
+    path = _write(tmp_path, payload)
+
+    assert IaaDeftConfig(str(path)).mining_topn == 5

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/config.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/config.py
@@ -7,8 +7,415 @@
 """Parsed configuration for an IAA CLIP DEFT experiment."""
 
 import json
+import math
 import os
 import yaml
+
+
+_MISSING = object()
+
+
+def _error(config_path: str, key: str, message: str) -> None:
+    raise ValueError(f"{config_path}: {key} {message}")
+
+
+def _mapping(root, key: str, source: str, config_path: str, *, required=True):
+    value = root.get(key, _MISSING)
+    qualified = f"{source}.{key}" if source else key
+    if value is _MISSING:
+        if required:
+            _error(config_path, qualified, "is required")
+        return {}
+    if not isinstance(value, dict):
+        _error(config_path, qualified, "must be an object")
+    return value
+
+
+def _known(mapping, allowed, source: str, config_path: str) -> None:
+    unknown = sorted(set(mapping) - set(allowed), key=repr)
+    if unknown:
+        _error(
+            config_path,
+            f"{source}.{unknown[0]}" if source else unknown[0],
+            "is not a recognized setting",
+        )
+
+
+def _value(mapping, key: str, source: str, config_path: str, *, required=False):
+    value = mapping.get(key, _MISSING)
+    qualified = f"{source}.{key}" if source else key
+    if value is _MISSING and required:
+        _error(config_path, qualified, "is required")
+    return value, qualified
+
+
+def _string(
+    mapping,
+    key: str,
+    source: str,
+    config_path: str,
+    *,
+    required=False,
+    allow_empty=False,
+    choices=None,
+) -> None:
+    value, qualified = _value(
+        mapping, key, source, config_path, required=required
+    )
+    if value is _MISSING:
+        return
+    if not isinstance(value, str) or (not allow_empty and not value.strip()):
+        suffix = "string" if allow_empty else "non-empty string"
+        _error(config_path, qualified, f"must be a {suffix}; got {value!r}")
+    if choices is not None and value not in choices:
+        _error(
+            config_path,
+            qualified,
+            f"must be one of {', '.join(sorted(choices))}; got {value!r}",
+        )
+
+
+def _boolean(mapping, key: str, source: str, config_path: str, *, required=False):
+    value, qualified = _value(
+        mapping, key, source, config_path, required=required
+    )
+    if value is _MISSING:
+        return
+    if not isinstance(value, bool):
+        _error(config_path, qualified, f"must be a boolean; got {value!r}")
+
+
+def _integer(
+    mapping,
+    key: str,
+    source: str,
+    config_path: str,
+    *,
+    required=False,
+    minimum=None,
+) -> None:
+    value, qualified = _value(
+        mapping, key, source, config_path, required=required
+    )
+    if value is _MISSING:
+        return
+    if not isinstance(value, int) or isinstance(value, bool):
+        _error(config_path, qualified, f"must be an integer; got {value!r}")
+    if minimum is not None and value < minimum:
+        _error(config_path, qualified, f"must be >= {minimum}; got {value!r}")
+
+
+def _number(
+    mapping,
+    key: str,
+    source: str,
+    config_path: str,
+    *,
+    minimum=None,
+    maximum=None,
+) -> None:
+    value, qualified = _value(mapping, key, source, config_path)
+    if value is _MISSING:
+        return
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+    ):
+        _error(config_path, qualified, f"must be a finite number; got {value!r}")
+    if minimum is not None and value < minimum:
+        _error(config_path, qualified, f"must be >= {minimum}; got {value!r}")
+    if maximum is not None and value > maximum:
+        _error(config_path, qualified, f"must be <= {maximum}; got {value!r}")
+
+
+def _validate_config(root, config_path: str) -> None:
+    if not isinstance(root, dict):
+        _error(config_path, "<root>", "must be an object")
+    _known(
+        root,
+        {
+            "experiment",
+            "iteration",
+            "training",
+            "mining",
+            "gap_analysis",
+            "iaa",
+            "lepton_e2e",
+            "kratos_namespace",
+        },
+        "",
+        config_path,
+    )
+
+    experiment = _mapping(root, "experiment", "", config_path)
+    _known(
+        experiment,
+        {
+            "name",
+            "results_path",
+            "train_config",
+            "eval_config",
+            "tao_pytorch_root",
+            "visualize",
+            "visualize_embeddings",
+        },
+        "experiment",
+        config_path,
+    )
+    for key in ("name", "results_path", "train_config", "eval_config"):
+        _string(experiment, key, "experiment", config_path, required=True)
+    _string(
+        experiment, "tao_pytorch_root", "experiment", config_path, allow_empty=True
+    )
+    for key in ("visualize", "visualize_embeddings"):
+        _boolean(experiment, key, "experiment", config_path)
+
+    iteration = _mapping(root, "iteration", "", config_path)
+    _known(iteration, {"start", "end"}, "iteration", config_path)
+    _integer(iteration, "start", "iteration", config_path, required=True, minimum=1)
+    _integer(iteration, "end", "iteration", config_path, required=True, minimum=1)
+    if iteration["end"] < iteration["start"]:
+        _error(config_path, "iteration.end", "must be >= iteration.start")
+
+    training = _mapping(root, "training", "", config_path)
+    _known(
+        training,
+        {"init_checkpoint", "continual_model", "continual_dataset", "num_nodes"},
+        "training",
+        config_path,
+    )
+    _string(
+        training,
+        "init_checkpoint",
+        "training",
+        config_path,
+        required=True,
+        allow_empty=True,
+    )
+    _boolean(training, "continual_model", "training", config_path, required=True)
+    _boolean(training, "continual_dataset", "training", config_path, required=True)
+    _integer(training, "num_nodes", "training", config_path, minimum=1)
+
+    mining = _mapping(root, "mining", "", config_path)
+    _known(
+        mining,
+        {"topn", "knn_metric", "knn_batch_size", "history_aware", "recovery"},
+        "mining",
+        config_path,
+    )
+    _integer(mining, "topn", "mining", config_path, minimum=1)
+    _string(
+        mining,
+        "knn_metric",
+        "mining",
+        config_path,
+        choices={"cosine", "euclidean"},
+    )
+    _integer(mining, "knn_batch_size", "mining", config_path, minimum=1)
+    history = _mapping(mining, "history_aware", "mining", config_path, required=False)
+    _known(history, {"enabled", "replay_fraction"}, "mining.history_aware", config_path)
+    _boolean(history, "enabled", "mining.history_aware", config_path)
+    _number(
+        history,
+        "replay_fraction",
+        "mining.history_aware",
+        config_path,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    recovery = _mapping(mining, "recovery", "mining", config_path, required=False)
+    _known(recovery, {"caption_expansion"}, "mining.recovery", config_path)
+    expansion = _mapping(
+        recovery,
+        "caption_expansion",
+        "mining.recovery",
+        config_path,
+        required=False,
+    )
+    _known(
+        expansion,
+        {
+            "enabled",
+            "mode",
+            "max_pairs_per_image_path",
+            "max_expanded_pair_fraction",
+            "dedupe_normalized_caption",
+            "count_expanded_pairs_toward_target",
+        },
+        "mining.recovery.caption_expansion",
+        config_path,
+    )
+    expansion_path = "mining.recovery.caption_expansion"
+    _boolean(expansion, "enabled", expansion_path, config_path)
+    _string(
+        expansion,
+        "mode",
+        expansion_path,
+        config_path,
+        choices={"nearest", "all"},
+    )
+    _integer(
+        expansion, "max_pairs_per_image_path", expansion_path, config_path, minimum=1
+    )
+    _number(
+        expansion,
+        "max_expanded_pair_fraction",
+        expansion_path,
+        config_path,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    _boolean(expansion, "dedupe_normalized_caption", expansion_path, config_path)
+    count_value, count_key = _value(
+        expansion, "count_expanded_pairs_toward_target", expansion_path, config_path
+    )
+    if count_value is not _MISSING and not (
+        isinstance(count_value, bool)
+        or (
+            isinstance(count_value, str)
+            and count_value in {"auto", "true", "false"}
+        )
+    ):
+        _error(config_path, count_key, "must be auto, true, false, or a boolean")
+
+    visualization = _mapping(root, "lepton_e2e", "", config_path, required=False)
+    viz_keys = {
+        "viz_max_samples_per_group",
+        "viz_max_total_samples",
+        "viz_tile_size",
+    }
+    _known(visualization, viz_keys, "lepton_e2e", config_path)
+    for key in viz_keys:
+        _integer(visualization, key, "lepton_e2e", config_path, minimum=1)
+
+    iaa = _mapping(root, "iaa", "", config_path)
+    iaa_keys = {
+        "train_pairs_source_file",
+        "pool_pairs_source_file",
+        "eval_pairs_source_file",
+        "train_image_dir",
+        "train_caption_dir",
+        "source_image_dir",
+        "source_caption_dir",
+        "eval_image_dir",
+        "eval_caption_dir",
+        "seed_exclude_datasets",
+        "augmented_suffix",
+        "query_types",
+        "mining_pool_mode",
+        "max_seed_rows",
+        "max_aug_pool_rows",
+        "val_sample_size",
+    }
+    _known(iaa, iaa_keys, "iaa", config_path)
+    _string(
+        iaa, "train_pairs_source_file", "iaa", config_path, allow_empty=True
+    )
+    _string(iaa, "pool_pairs_source_file", "iaa", config_path)
+    for key in (
+        "eval_pairs_source_file",
+        "train_image_dir",
+        "train_caption_dir",
+        "source_image_dir",
+        "source_caption_dir",
+        "eval_image_dir",
+        "eval_caption_dir",
+    ):
+        _string(iaa, key, "iaa", config_path, required=True)
+    for key in ("seed_exclude_datasets", "augmented_suffix", "query_types"):
+        _string(iaa, key, "iaa", config_path)
+    _string(
+        iaa,
+        "mining_pool_mode",
+        "iaa",
+        config_path,
+        choices={"real", "augmented", "real_and_augmented"},
+    )
+    _integer(iaa, "max_seed_rows", "iaa", config_path, minimum=0)
+    _integer(iaa, "max_aug_pool_rows", "iaa", config_path, minimum=0)
+    _integer(iaa, "val_sample_size", "iaa", config_path, minimum=1)
+    if not str(iaa.get("pool_pairs_source_file") or "").strip() and not str(
+        iaa.get("train_pairs_source_file") or ""
+    ).strip():
+        _error(
+            config_path,
+            "iaa.pool_pairs_source_file",
+            "or iaa.train_pairs_source_file must be a non-empty string",
+        )
+
+    gap = _mapping(root, "gap_analysis", "", config_path, required=False)
+    gap_keys = {
+        "metric_name",
+        "queries_per_slice",
+        "min_num_queries",
+        "query_types",
+        "weak_attribute_topk",
+        "target_query_count",
+        "total_queries_mAP",
+        "analyze_by_mAP",
+        "caption_diversity",
+    }
+    _known(gap, gap_keys, "gap_analysis", config_path)
+    for key in ("metric_name", "query_types"):
+        _string(gap, key, "gap_analysis", config_path)
+    _integer(gap, "queries_per_slice", "gap_analysis", config_path, minimum=1)
+    _integer(gap, "min_num_queries", "gap_analysis", config_path, minimum=0)
+    _integer(gap, "weak_attribute_topk", "gap_analysis", config_path, minimum=1)
+    _integer(gap, "target_query_count", "gap_analysis", config_path, minimum=1)
+    _integer(gap, "total_queries_mAP", "gap_analysis", config_path, minimum=1)
+    _boolean(gap, "analyze_by_mAP", "gap_analysis", config_path)
+    diversity = _mapping(
+        gap, "caption_diversity", "gap_analysis", config_path, required=False
+    )
+    diversity_path = "gap_analysis.caption_diversity"
+    diversity_keys = {
+        "enabled",
+        "history_file",
+        "history_policy",
+        "coverage_target",
+        "min_unique_texts_per_attribute",
+        "max_unique_texts_per_attribute",
+        "max_rows_per_unique_text",
+        "max_rows_per_image_path",
+        "recent_exclude_iters",
+        "replay_fraction_when_noncontinual",
+    }
+    _known(diversity, diversity_keys, diversity_path, config_path)
+    _boolean(diversity, "enabled", diversity_path, config_path)
+    _string(diversity, "history_file", diversity_path, config_path)
+    _string(
+        diversity,
+        "history_policy",
+        diversity_path,
+        config_path,
+        choices={"auto", "prefer_unseen", "novelty_with_replay"},
+    )
+    _number(
+        diversity,
+        "coverage_target",
+        diversity_path,
+        config_path,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    for key in (
+        "min_unique_texts_per_attribute",
+        "max_unique_texts_per_attribute",
+        "recent_exclude_iters",
+    ):
+        _integer(diversity, key, diversity_path, config_path, minimum=0)
+    for key in ("max_rows_per_unique_text", "max_rows_per_image_path"):
+        _integer(diversity, key, diversity_path, config_path, minimum=1)
+    _number(
+        diversity,
+        "replay_fraction_when_noncontinual",
+        diversity_path,
+        config_path,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    _string(root, "kratos_namespace", "", config_path, allow_empty=True)
 
 
 def _bool_str(value) -> str:
@@ -56,6 +463,7 @@ class IaaDeftConfig:
 
         with open(config_path) as f:
             _cfg = yaml.safe_load(f)
+        _validate_config(_cfg, config_path)
 
         self.sweep_args_str: str = json.dumps({
             "config": config_path,


### PR DESCRIPTION
## Reported issue

NVBug 6596799: the IAA DEFT config loader accepted unknown keys and silently coerced present invalid values. For example, `mining.topn: 0` became 5, `experiment.visualize: "not_a_number"` became true, and a numeric path became an invented filesystem path.

## Original reproduction

1. Load the shipped `deft_config.yaml`.
2. Mutate fields one at a time to zero, null, an empty string, a wrong type, or an unknown key.
3. Instantiate `IaaDeftConfig`.

Before this change, invalid values were accepted across many fields and the resulting in-memory configuration no longer matched the file.

## Root cause

The loader coerced and defaulted values before validating the YAML structure. Falsy-value fallback expressions also made a present invalid value indistinguishable from an absent optional key.

## Implementation

- Validate the complete nested config before any coercion.
- Reject unknown sections and keys.
- Enforce boolean, numeric, enum, list, path-string, and range contracts by full dotted key.
- Preserve defaults only for genuinely absent optional keys.

## Regression coverage

Added/updated `scripts/tests/test_iaa_deft_config.py` with representative invalid values, unknown keys, the shipped valid config, and the absent-key default case.

## Post-fix verification

The refreshed branch rejected all original examples by file and full key: zero/null/empty `mining.topn`, non-boolean visualization values, numeric paths, invalid pool mode, invalid query settings, and unknown keys. Removing optional `mining.topn` still produced default 5.

- `python -m pytest -q scripts/tests` — **274 passed, 2 skipped**
- focused config/container tests — **21 passed**
- `scripts/validate-skills.sh` — **passed**
- `git diff --check origin/main...HEAD` — **passed**

## Residual risk

This validates the skill-owned configuration boundary rather than launching a GPU loop, which is appropriate for this loader-only failure. NVBug 6596801 is a narrower overlapping enum fix and may need conflict resolution depending on merge order.

## Why this fixes the root cause

Validation now occurs once at the skill-owned YAML boundary, before construction can coerce or default any value. Every downstream IAA code path therefore receives the same validated structure, and absent optional values remain distinct from present invalid values.

## Shortcuts intentionally avoided

The change does not enumerate only the reported bad literals, silently replace malformed values with defaults, or add test-only exceptions. It validates the full schema and reports the complete field path.