### PR TITLE
[TAO-0][Bugfix] NVBug 6596801: Reject unknown IAA mining pool modes

### DIFF
--- a/scripts/tests/test_iaa_deft_config.py
+++ b/scripts/tests/test_iaa_deft_config.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused configuration validation tests for IAA DEFT."""
+
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IAA_ROOT = REPO_ROOT / "skills/applications/tao-run-deft-iaa"
+sys.path.insert(0, str(IAA_ROOT / "scripts"))
+from iaa_deft.config import IaaDeftConfig  # noqa: E402
+
+
+def _write_config(tmp_path: Path, *, mining_pool_mode):
+    payload = yaml.safe_load((IAA_ROOT / "specs/deft_config.yaml").read_text())
+    payload = copy.deepcopy(payload)
+    payload["iaa"]["mining_pool_mode"] = mining_pool_mode
+    config = tmp_path / "deft_config.yaml"
+    config.write_text(yaml.safe_dump(payload))
+    return config
+
+
+@pytest.mark.parametrize("mode", ["real", "augmented", "real_and_augmented"])
+def test_mining_pool_mode_accepts_only_documented_values(tmp_path, mode):
+    config = IaaDeftConfig(str(_write_config(tmp_path, mining_pool_mode=mode)))
+    assert config.iaa_mining_pool_mode == mode
+
+
+def test_mining_pool_mode_rejects_typo_by_full_key(tmp_path):
+    config = _write_config(tmp_path, mining_pool_mode="raal")
+
+    with pytest.raises(ValueError, match=r"iaa\.mining_pool_mode.*raal"):
+        IaaDeftConfig(str(config))

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/config.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/config.py
@@ -134,6 +134,13 @@ class IaaDeftConfig:
         self.iaa_max_seed_rows: int = int(_iaa.get("max_seed_rows", 0) or 0)
         self.iaa_max_aug_pool_rows: int = int(_iaa.get("max_aug_pool_rows", 0) or 0)
         self.iaa_mining_pool_mode: str = _iaa.get("mining_pool_mode", "real_and_augmented")
+        valid_pool_modes = {"real", "augmented", "real_and_augmented"}
+        if self.iaa_mining_pool_mode not in valid_pool_modes:
+            choices = ", ".join(sorted(valid_pool_modes))
+            raise ValueError(
+                f"{self.config_path}: iaa.mining_pool_mode must be one of "
+                f"{choices}; got {self.iaa_mining_pool_mode!r}"
+            )
         self.iaa_val_sample_size: int = int(_iaa.get("val_sample_size", 512) or 512)
         self.iaa_train_pairs_source_file: str = _abs_data_path(
             _iaa.get("train_pairs_source_file", "")


### PR DESCRIPTION
## Reported issue

NVBug 6596801: a typo such as `iaa.mining_pool_mode: raal` was accepted, allowing downstream code to choose unintended training data while the run appeared successful.

## Original reproduction and observed failure

Inspect or load `scripts/iaa_deft/config.py` with `mining_pool_mode: raal`. On `main`, the value was copied directly with no allowed-value check and no diagnostic.

## Root cause

The fixed-set selector lacked validation at the configuration boundary.

## Implementation

Validate `iaa.mining_pool_mode` against `real`, `augmented`, and `real_and_augmented`; reject any other value with the config path, full dotted key, invalid value, and allowed choices.

## Regression coverage and verification

- The exact typo `raal` is rejected by full key.
- All three documented values load unchanged.
- `python -m pytest -q scripts/tests/test_iaa_deft_config.py` — **4 passed**
- `python -m pytest -q scripts/tests` — **262 passed, 2 skipped**
- `scripts/validate-skills.sh` and `git diff --check` — **passed**

## Residual risk

This focused fix overlaps the broader validation work in NVBug 6596799, so merge order may require resolving `config.py` and the shared test filename. Independently, the branch fixes the reported root cause.

## Why this fixes the root cause

The accepted mining modes are enforced by the authoritative config loader before the value can influence dataset selection. This removes the fall-through state that allowed arbitrary strings to choose an unintended pool.

## Shortcuts intentionally avoided

The change does not special-case the reported typo or retain a fallback mode. Unknown values fail closed, while every documented value remains accepted.