### PR TITLE
[TAO-0][Bugfix] NVBug 6596803: Make DEFT config the sole mining-default source

### DIFF
--- a/scripts/tests/test_iaa_deft_container.py
+++ b/scripts/tests/test_iaa_deft_container.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 IAA_SCRIPTS = (
     Path(__file__).resolve().parents[2]
@@ -17,6 +18,8 @@ IAA_SCRIPTS = (
 )
 sys.path.insert(0, str(IAA_SCRIPTS))
 import run_deft_container as container  # noqa: E402
+
+IAA_ROOT = IAA_SCRIPTS.parent
 
 
 def test_docker_gpu_args_use_exact_approved_devices():
@@ -37,3 +40,10 @@ def test_docker_gpu_args_use_exact_approved_devices():
 def test_docker_gpu_args_reject_invalid_or_mismatched_state(config):
     with pytest.raises(ValueError):
         container._docker_gpu_args(config)  # noqa: SLF001
+
+
+def test_mining_template_has_no_competing_runtime_defaults():
+    mining = yaml.safe_load((IAA_ROOT / "specs/mining_spec.yaml").read_text())
+
+    assert mining["topn"] == "???"
+    assert mining["knn_metric"] == "???"

--- a/skills/applications/tao-run-deft-iaa/specs/mining_spec.yaml
+++ b/skills/applications/tao-run-deft-iaa/specs/mining_spec.yaml
@@ -1,8 +1,11 @@
 source_parquet: ???
 target_parquet: ???
 output_parquet: ???
-topn: 5
-knn_metric: euclidean
+# Run-specific values are supplied from the immutable DEFT config on the
+# nearest-neighbors command line. Keep these mandatory so this template cannot
+# become a second, conflicting source of defaults.
+topn: ???
+knn_metric: ???
 source_embed_column_name: embedding
 target_embed_column_name: embedding
 filter_by_label: "false"


### PR DESCRIPTION
## Reported issue

NVBug 6596803: `mining_spec.yaml` shipped `topn: 5` and `knn_metric: euclidean`, while `deft_config.yaml` shipped 25 and cosine. Editing the stage spec looked effective but runtime command values from the loop config silently won.

## Original reproduction and observed failure

Run the report's two `grep` commands over both specs. Before the fix, the same two runtime settings appeared with conflicting concrete values.

## Root cause

The stage template duplicated defaults owned by the immutable run configuration without identifying them as injected values.

## Implementation

Replace the two competing stage-template defaults with mandatory `???` placeholders and document that `command_contract.py` supplies `topn` and `knn_metric` from the immutable DEFT config.

## Regression coverage and verification

- Original grep now shows concrete values only in `deft_config.yaml`; `mining_spec.yaml` contains mandatory placeholders.
- The command contract reads `mining_topn` and `knn_metric` from recorded run state.
- `python -m pytest -q scripts/tests/test_iaa_deft_container.py` — **6 passed**
- `python -m pytest -q scripts/tests` — **259 passed, 2 skipped**
- `scripts/validate-skills.sh` and `git diff --check` — **passed**

## Residual risk

The template is intentionally incomplete until the wrapper injects the immutable values. Directly launching that raw template without the documented wrapper remains unsupported.

## Why this fixes the root cause

The run-specific topn and distance metric now have exactly one owner: the immutable DEFT config. The mining template makes those fields mandatory, and the command contract supplies the approved values on every invocation.

## Shortcuts intentionally avoided

The change does not try to keep two sets of defaults synchronized or patch only the shipped values. Removing template defaults prevents future drift by construction.