### PR TITLE
[TAO-0][Bugfix] NVBug 6596814: Carry the trained model across IAA iterations by default

### DIFF
--- a/scripts/tests/test_iaa_deft_defaults.py
+++ b/scripts/tests/test_iaa_deft_defaults.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for IAA DEFT workflow defaults."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IAA_ROOT = REPO_ROOT / "skills/applications/tao-run-deft-iaa"
+
+
+def _prepare_module():
+    path = IAA_ROOT / "scripts/prepare_deft_config.py"
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("prepare_deft_config", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_continual_model_is_the_template_and_cli_default():
+    config = yaml.safe_load((IAA_ROOT / "specs/deft_config.yaml").read_text())
+    assert config["training"]["continual_dataset"] is True
+    assert config["training"]["continual_model"] is True
+
+    parser = _prepare_module()._parser()
+    action = next(item for item in parser._actions if item.dest == "continual_model")
+    assert action.default is True

--- a/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
+++ b/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
@@ -102,10 +102,11 @@ another label/path even when its numeric value is plausible.
        --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N"
    ```
 
-   In the default continual-dataset/non-continual-model mode, the accumulated
-   mined datasets are included but training starts from the configured base
-   model each iteration. With approved continual-model mode, the adapter uses
-   the prior iteration's normalized state. Never hand-edit the generated YAML.
+   In the default continual-dataset/continual-model mode, each iteration uses
+   the accumulated mined datasets and the prior iteration's normalized model
+   state. When non-continual model mode is explicitly approved, training starts
+   from the configured base model each iteration. Never hand-edit the generated
+   YAML.
 2. Recheck occupancy for the approved GPU IDs. If the shape must change, stop
    for a revised pre-flight approval and begin a new immutable run; do not
    patch the current config.

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -196,7 +196,7 @@ hardware, pool size, and accumulated data can change this substantially.
 | GPU shape | `num_gpus=1`, `gpu_ids=0` |
 | mining | budget `10000`, top-N `25`, cosine distance |
 | history selection | enabled, replay fraction `0.20` |
-| continual behavior | dataset `true`, model `false` |
+| continual behavior | dataset `true`, model `true` |
 | visualization | contact sheets `true`, embedding plot `true` |
 | Hugging Face token forwarding | disabled; enable only when the approved model/environment requires it |
 | PyTorch image | `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` | <!-- versions-key: images.tao_toolkit.pyt -->

--- a/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
@@ -331,7 +331,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--history-aware", default=True, type=_bool)
     parser.add_argument("--replay-fraction", default=0.20, type=float)
     parser.add_argument("--continual-dataset", default=True, type=_bool)
-    parser.add_argument("--continual-model", default=False, type=_bool)
+    parser.add_argument("--continual-model", default=True, type=_bool)
     parser.add_argument("--visualize", default=True, type=_bool)
     parser.add_argument("--visualize-embeddings", default=True, type=_bool)
     parser.add_argument("--metric-name", default="Rank-1")

--- a/skills/applications/tao-run-deft-iaa/specs/deft_config.yaml
+++ b/skills/applications/tao-run-deft-iaa/specs/deft_config.yaml
@@ -12,7 +12,7 @@ iteration:
 
 training:
   init_checkpoint: ""
-  continual_model: false
+  continual_model: true
   continual_dataset: true
   num_nodes: 1
 


### PR DESCRIPTION
## Reported issue

NVBug 6596814: the advertised improvement loop accumulated data but defaulted `continual_model` to false, so every iteration restarted from the base model.

## Original reproduction and observed failure

`grep -nE '^ *continual_(model|dataset):' specs/deft_config.yaml` showed `continual_model: false` beside `continual_dataset: true`. The documentation did not explain a deliberate restart, and QA measured materially different accuracy.

## Root cause

The shipped template and CLI retained a non-continual model default inconsistent with the loop semantics and documentation.

## Implementation

Set `continual_model` to true in the template and CLI default, and update preflight/train references to describe the default behavior. Explicit `--continual-model false` remains supported.

## Regression coverage and verification

- Original grep now shows both continual flags true.
- A fresh parser process reports `continual_model=True`.
- Explicit false parsing still returns false.
- `python -m pytest -q scripts/tests/test_iaa_deft_defaults.py` — **1 passed**
- full suite — **259 passed, 2 skipped**
- `scripts/validate-skills.sh` and `git diff --check` — **passed**

## Residual risk

Existing initialized runs retain their immutable approved configuration; this changes only new-run defaults. Users can still explicitly choose restart-from-base behavior.

## Why this fixes the root cause

The authoritative shipped template now defaults continual training on, while the parser continues to preserve an explicit false. Each new round therefore consumes the preceding trained checkpoint unless the user intentionally opts out.

## Shortcuts intentionally avoided

The change does not force the value at runtime or ignore an explicit user choice; it corrects the default at its source.