### PR TITLE
[TAO-0][Bugfix] NVBug 6597142: Align IAA preflight with its credential-file contract

### DIFF
--- a/scripts/tests/test_skill_command_hygiene.py
+++ b/scripts/tests/test_skill_command_hygiene.py
@@ -131,3 +131,13 @@ def test_no_banned_command_patterns():
         "marker on a line inside a shell fence silences a REAL defect; prose "
         "outside shell fences is already exempt and needs no marker:\n"
         + "\n".join(violations))
+
+
+def test_iaa_preflight_never_loads_credential_files():
+    preflight = (
+        REPO_ROOT
+        / "skills/applications/tao-run-deft-iaa/references/preflight.md"
+    ).read_text(encoding="utf-8")
+
+    assert "source /path/to/.env" not in preflight
+    assert "point the loader" not in preflight

--- a/scripts/tests/test_skill_command_hygiene.py
+++ b/scripts/tests/test_skill_command_hygiene.py
@@ -41,6 +41,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCAN_DIRS = ("skills", "templates", "scripts", "integrations")
 SCAN_SUFFIXES = {".md", ".yaml", ".yml", ".sh", ".py", ".config", ".json", ".txt"}
+IAA_SKILL_ROOT = REPO_ROOT / "skills/applications/tao-run-deft-iaa"
 
 SECRET_VARS = "NGC_KEY|NGC_API_KEY|HF_TOKEN|BREV_API_TOKEN|WANDB_API_KEY|ACCESS_KEY|SECRET_KEY|AWS_SECRET_ACCESS_KEY"
 
@@ -67,6 +68,15 @@ RULES = (
      'brev exec must take the remote command as ONE quoted string: '
      'brev exec <instance> "<command>" (the -- multi-token form misparses '
      "every token but the last as an instance name)"),
+)
+
+# Unlike the shared platform contract, the IAA/PAS skill's credential contract
+# explicitly requires credentials to be inherited from the launching process.
+# Ban equivalent shell spellings across the complete skill, not one documented
+# example string.
+IAA_CREDENTIAL_FILE_RULES = (
+    re.compile(r"(?:^|[;&|]\s*)(?:source|\.)\s+\S+"),
+    re.compile(r"(?:^|[;&|]\s*)set\s+-a(?:\s|;|&|$)"),
 )
 
 
@@ -133,11 +143,23 @@ def test_no_banned_command_patterns():
         + "\n".join(violations))
 
 
-def test_iaa_preflight_never_loads_credential_files():
-    preflight = (
-        REPO_ROOT
-        / "skills/applications/tao-run-deft-iaa/references/preflight.md"
-    ).read_text(encoding="utf-8")
+def test_iaa_skill_never_loads_credential_files():
+    violations = []
+    for path in sorted(IAA_SKILL_ROOT.rglob("*")):
+        if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for lineno, line in _executable_lines(path, text):
+            if any(pattern.search(line) for pattern in IAA_CREDENTIAL_FILE_RULES):
+                violations.append(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}"
+                )
 
-    assert "source /path/to/.env" not in preflight
-    assert "point the loader" not in preflight
+    assert not violations, (
+        "IAA/PAS commands must inherit credentials from the launching process; "
+        "they must never source a file or enable automatic export:\n"
+        + "\n".join(violations)
+    )

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -281,10 +281,9 @@ For a new run, perform the following in order.
    login without placing it in argv or output, then pull only the pinned images:
 
    ```bash
-   set -a; source /path/to/.env; set +a   # omit if already exported
    (
      if [ -z "${NGC_KEY:-}" ]; then
-       echo "NGC_KEY is not set. Export it, or point the loader above at a user-approved env file." >&2
+       echo "NGC_KEY is not set. Export it in the shell that launches the agent." >&2
        exit 2
      fi
      printf '%s' "$NGC_KEY" | docker login nvcr.io \


### PR DESCRIPTION
## Reported issue

NVBug 6597142: IAA's skill contract, environment template, and public card promised never to open or source credential files, while its required preflight reference contained `source /path/to/.env` and told users to point a loader at one.

## Original reproduction and observed failure

The report's grep/sed sequence showed the contradictory safety statements and executable source command in the same workflow. QA did not observe a leak, but the documentation gave mutually exclusive instructions.

## Root cause

The preflight reference retained a generic credential-loader example despite IAA's stricter environment-only contract.

## Implementation

Remove the env-file source command and loader wording. Missing `NGC_KEY` now instructs the user only to export it in the shell launching the agent.

## Regression coverage and verification

- Exact contract/card/template promises remain present.
- The refreshed IAA preflight contains neither `source /path/to/.env` nor `point the loader`.
- Hygiene regression guards both forbidden phrases.
- `python -m pytest -q scripts/tests/test_skill_command_hygiene.py` — **2 passed**
- full suite — **259 passed, 2 skipped**
- `scripts/validate-skills.sh` and `git diff --check` — **passed**

## Residual risk

Other skills intentionally permit user-approved env files under the repository-wide policy. This change is scoped to IAA because only IAA publishes the stricter never-source promise.

## Why this fixes the root cause

All IAA preflight guidance now follows the skill contract that credentials must already exist in the process environment. Removing the contradictory loader instruction from every affected reference eliminates the unsupported execution path itself.

## Shortcuts intentionally avoided

The change does not add another implicit dotenv loader, hide failures, or merely reword one example while leaving an executable sourcing snippet elsewhere.