### PR TITLE
[TAO-0][Bugfix] NVBug 6597479: Bundle the IAA dataset rebuild implementation

### DIFF
--- a/scripts/tests/test_iaa_deft_rebuild.py
+++ b/scripts/tests/test_iaa_deft_rebuild.py
@@ -20,16 +20,19 @@ def test_bundled_rebuild_uses_export_metadata_without_export_code(tmp_path):
     metadata = tmp_path / "metadata"
     output = tmp_path / "dataset"
     metadata.mkdir()
+    decoy = metadata / "rebuild.py"
+    decoy.write_text("raise RuntimeError('export-owned code was executed')\n")
     for split in ("train", "val", "test"):
-        unique_name = f"{split}.jpg"
-        raw = output / "images_raw" / split / unique_name
+        unique_name = f"nested/{split}.jpg" if split == "train" else f"{split}.jpg"
+        image_path = f"source/{split}.jpg"
+        raw = output / "images_raw" / split / image_path
         raw.parent.mkdir(parents=True, exist_ok=True)
         raw.write_bytes(split.encode())
         rows = [
             {
                 "unique_name": unique_name,
                 "source_split": split,
-                "image_path": unique_name,
+                "image_path": image_path,
                 "caption": f"{split} caption",
             }
         ]
@@ -53,8 +56,72 @@ def test_bundled_rebuild_uses_export_metadata_without_export_code(tmp_path):
     )
 
     assert "VERIFY: PASS" in result.stdout
-    assert (output / "images/train.jpg").resolve() == (
-        output / "images_raw/train/train.jpg"
+    assert (output / "images/nested/train.jpg").resolve() == (
+        output / "images_raw/train/source/train.jpg"
     )
-    assert (output / "captions/train.txt").read_text() == "train caption\n"
-    assert not (metadata / "rebuild.py").exists()
+    assert (output / "captions/nested/train.txt").read_text() == "train caption\n"
+    assert decoy.read_text() == "raise RuntimeError('export-owned code was executed')\n"
+
+    subset_verify = subprocess.run(
+        [
+            sys.executable,
+            str(REBUILD),
+            "--metadata-root",
+            str(metadata),
+            "--out",
+            str(output),
+            "--workers",
+            "1",
+            "--splits",
+            "train",
+            "--verify-only",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "VERIFY: PASS" in subset_verify.stdout
+
+
+def test_rebuild_refuses_metadata_paths_that_escape_owned_roots(tmp_path):
+    metadata = tmp_path / "metadata"
+    output = tmp_path / "dataset"
+    metadata.mkdir()
+    raw = output / "images_raw/train/source.jpg"
+    raw.parent.mkdir(parents=True)
+    raw.write_bytes(b"image")
+    (metadata / "train_pairs.json").write_text(
+        json.dumps(
+            [
+                {
+                    "unique_name": "../escape.jpg",
+                    "source_split": "train",
+                    "image_path": "source.jpg",
+                    "caption": "caption",
+                }
+            ]
+        )
+    )
+    (metadata / "train_list.txt").write_text("../escape.jpg\n")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REBUILD),
+            "--metadata-root",
+            str(metadata),
+            "--out",
+            str(output),
+            "--workers",
+            "1",
+            "--splits",
+            "train",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "must be a non-empty relative path" in result.stderr
+    assert not (output / "escape.jpg").exists()

--- a/scripts/tests/test_iaa_deft_rebuild.py
+++ b/scripts/tests/test_iaa_deft_rebuild.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the skill-owned IAA dataset rebuild."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REBUILD = (
+    REPO_ROOT
+    / "skills/applications/tao-run-deft-iaa/scripts/iaa_deft/rebuild.py"
+)
+
+
+def test_bundled_rebuild_uses_export_metadata_without_export_code(tmp_path):
+    metadata = tmp_path / "metadata"
+    output = tmp_path / "dataset"
+    metadata.mkdir()
+    for split in ("train", "val", "test"):
+        unique_name = f"{split}.jpg"
+        raw = output / "images_raw" / split / unique_name
+        raw.parent.mkdir(parents=True, exist_ok=True)
+        raw.write_bytes(split.encode())
+        rows = [
+            {
+                "unique_name": unique_name,
+                "source_split": split,
+                "image_path": unique_name,
+                "caption": f"{split} caption",
+            }
+        ]
+        (metadata / f"{split}_pairs.json").write_text(json.dumps(rows))
+        (metadata / f"{split}_list.txt").write_text(unique_name + "\n")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REBUILD),
+            "--metadata-root",
+            str(metadata),
+            "--out",
+            str(output),
+            "--workers",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "VERIFY: PASS" in result.stdout
+    assert (output / "images/train.jpg").resolve() == (
+        output / "images_raw/train/train.jpg"
+    )
+    assert (output / "captions/train.txt").read_text() == "train caption\n"
+    assert not (metadata / "rebuild.py").exists()

--- a/skills/applications/tao-run-deft-iaa/references/data-layout.md
+++ b/skills/applications/tao-run-deft-iaa/references/data-layout.md
@@ -23,8 +23,8 @@ The IAA TAO-FT export contains:
 There is no download branch. Preserve the archives in place; extraction goes
 to the approved `DATASET_ROOT`. Do not copy multi-gigabyte archives into the
 dataset tree. If an export also contains a legacy `rebuild.py`, leave it
-unused; the workflow always executes the hash-bound copy bundled with this
-skill.
+unused; the workflow always executes the version-controlled, reviewed copy
+bundled with this skill.
 
 ## Approved extraction and rebuild
 

--- a/skills/applications/tao-run-deft-iaa/references/data-layout.md
+++ b/skills/applications/tao-run-deft-iaa/references/data-layout.md
@@ -17,12 +17,14 @@ The IAA TAO-FT export contains:
 | File | Required | Expected content |
 |---|---|---|
 | `images_raw.tar` | yes | source images under `images_raw/<source_split>/...` |
-| `meta.tar.gz` | yes | pair/list metadata, README/vocabulary files, and `rebuild.py` |
+| `meta.tar.gz` | yes | pair/list metadata and README/vocabulary files |
 | `SHA256SUMS` | no | checksums for the two archives |
 
 There is no download branch. Preserve the archives in place; extraction goes
 to the approved `DATASET_ROOT`. Do not copy multi-gigabyte archives into the
-dataset tree.
+dataset tree. If an export also contains a legacy `rebuild.py`, leave it
+unused; the workflow always executes the hash-bound copy bundled with this
+skill.
 
 ## Approved extraction and rebuild
 
@@ -51,12 +53,13 @@ tar -xzf "$METADATA_ARCHIVE" -C "$DATASET_ROOT"
 tar -xf "$IMAGES_ARCHIVE" -C "$DATASET_ROOT"
 
 "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
-  "$DATASET_ROOT/rebuild.py" --workers 16 \
+  "$SKILL_ROOT/scripts/iaa_deft/rebuild.py" \
+    --metadata-root "$DATASET_ROOT" --out "$DATASET_ROOT" --workers 16 \
   2>&1 | tee "$RESULTS_DIR/dataset_setup/rebuild_verify.log"
 ```
 
 Omit the checksum command when no manifest was approved. A checksum mismatch,
-tar failure, missing `rebuild.py`, or nonzero rebuild is a hard stop. The
+tar failure or nonzero rebuild is a hard stop. The
 rebuild log must contain `VERIFY: PASS`; `VERIFY: FAIL` or a missing pass line
 is not valid evidence. Do not continue using a partly rebuilt dataset.
 
@@ -68,8 +71,7 @@ DATASET_ROOT/
 ├── images/
 ├── captions/
 ├── train_pairs.json
-├── val_pairs.json
-└── rebuild.py
+└── val_pairs.json
 ```
 
 ## Materialize run splits and pool

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -139,7 +139,8 @@ Run this section only after required intake is resolved.
    ```
 
    Record the presence of adjacent `SHA256SUMS`. Its absence is a warning, not
-   a blocker; `rebuild.py` verification remains mandatory.
+   a blocker; verification by the skill's bundled dataset rebuild remains
+   mandatory.
 4. Inspect, but do not modify, Docker/GPU state:
 
    ```bash

--- a/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
@@ -55,7 +55,7 @@ or logs.
 
 | State stage | Producer | Adapter or launch | Read first |
 |---|---|---|---|
-| `dataset_setup` | archive `rebuild.py` plus bundled IAA data utilities | `run_iaa_stage.py dataset-materialize` | `data-layout.md` |
+| `dataset_setup` | bundled `iaa_deft/rebuild.py` plus bundled IAA data utilities | `run_iaa_stage.py dataset-materialize` | `data-layout.md` |
 | `pool_embed` | TAO data services | `run_deft_container.py` | `mining.md` |
 | `evaluate` | TAO CLIP plus bound parser | `run_iaa_stage.py eval-config`, container wrapper, parser | `clip-train-eval.md`, `metric-contract.md` |
 | `gap_analysis` | bundled IAA gap analysis | `run_iaa_stage.py gap-analysis` | `gap-analysis.md` |

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/rebuild.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/rebuild.py
@@ -22,28 +22,55 @@ def _shard(rows, out_root: Path):
     """Create one relative image symlink and caption for each pair row."""
     made_links = made_caps = skipped = 0
     for unique_name, source_split, image_path, caption in rows:
-        link = out_root / "images" / unique_name
-        target = Path("..") / "images_raw" / source_split / image_path
+        unique_path = _relative_path(unique_name, "unique_name")
+        source_path = (
+            out_root
+            / "images_raw"
+            / _relative_path(source_split, "source_split")
+            / _relative_path(image_path, "image_path")
+        )
+        link = out_root / "images" / unique_path
+        link.parent.mkdir(parents=True, exist_ok=True)
+        target = Path(os.path.relpath(source_path, start=link.parent))
         try:
             link.symlink_to(target)
             made_links += 1
         except FileExistsError:
             skipped += 1
 
-        cap = out_root / "captions" / (Path(unique_name).stem + ".txt")
+        cap = out_root / "captions" / unique_path.with_suffix(".txt")
+        cap.parent.mkdir(parents=True, exist_ok=True)
         cap.write_text(caption + "\n", encoding="utf-8")
         made_caps += 1
     return made_links, made_caps, skipped
+
+
+def _relative_path(value: str, field: str) -> Path:
+    """Return a non-empty relative path that cannot escape its owned root."""
+    path = Path(value)
+    if (
+        not value
+        or path.is_absolute()
+        or path == Path(".")
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError(f"{field} must be a non-empty relative path: {value!r}")
+    return path
 
 
 def load_rows(split: str, metadata_root: Path):
     """Project a pair JSON document down to the fields the rebuild needs."""
     with (metadata_root / f"{split}_pairs.json").open(encoding="utf-8") as handle:
         data = json.load(handle)
-    rows = [
-        (row["unique_name"], row["source_split"], row["image_path"], row["caption"])
-        for row in data
-    ]
+    rows = []
+    for row in data:
+        unique_name = str(_relative_path(row["unique_name"], "unique_name"))
+        source_split = str(_relative_path(row["source_split"], "source_split"))
+        image_path = str(_relative_path(row["image_path"], "image_path"))
+        caption = row["caption"]
+        if not isinstance(caption, str):
+            raise ValueError("caption must be a string")
+        rows.append((unique_name, source_split, image_path, caption))
     del data
     return rows
 
@@ -75,33 +102,87 @@ def rebuild(splits, workers: int, metadata_root: Path, out_root: Path) -> int:
 
 
 def verify(splits, metadata_root: Path, out_root: Path, sample: int = 2000) -> bool:
-    """Check exact counts, then sample-resolve rebuilt links and captions."""
-    expected = 0
-    names = []
+    """Check requested metadata coverage, then sample link provenance."""
+    rows_by_name = {}
+    listed_names = []
     for split in splits:
-        names_for_split = (metadata_root / f"{split}_list.txt").read_text().split()
-        expected += len(names_for_split)
-        names.extend(names_for_split)
+        names_for_split = [
+            str(_relative_path(name.strip(), f"{split}_list.txt entry"))
+            for name in (metadata_root / f"{split}_list.txt").read_text().splitlines()
+            if name.strip()
+        ]
+        listed_names.extend(names_for_split)
+        for row in load_rows(split, metadata_root):
+            name = row[0]
+            if name in rows_by_name:
+                raise ValueError(f"duplicate unique_name across requested splits: {name}")
+            rows_by_name[name] = row
 
-    image_count = len(list((out_root / "images").iterdir()))
-    caption_count = len(list((out_root / "captions").iterdir()))
-    print(f"expected {expected:,} images/ {image_count:,} captions/ {caption_count:,}")
+    expected_images = set(listed_names)
+    if len(expected_images) != len(listed_names):
+        raise ValueError("split list metadata contains duplicate unique_name values")
+    if expected_images != set(rows_by_name):
+        missing_from_pairs = sorted(expected_images - set(rows_by_name))
+        missing_from_lists = sorted(set(rows_by_name) - expected_images)
+        raise ValueError(
+            "pair/list metadata disagree; "
+            f"missing from pairs={missing_from_pairs[:5]}, "
+            f"missing from lists={missing_from_lists[:5]}"
+        )
+    expected_captions = {
+        str(Path(name).with_suffix(".txt")) for name in expected_images
+    }
+    if len(expected_captions) != len(expected_images):
+        raise ValueError("unique_name values collide after conversion to caption paths")
+
+    image_root = out_root / "images"
+    caption_root = out_root / "captions"
+    actual_images = {
+        str(path.relative_to(image_root))
+        for path in image_root.rglob("*")
+        if path.is_symlink() and path.exists()
+    }
+    actual_captions = {
+        str(path.relative_to(caption_root))
+        for path in caption_root.rglob("*")
+        if path.is_file()
+    }
+    complete_run = set(splits) == set(SPLITS)
+    counts_ok = (
+        actual_images == expected_images and actual_captions == expected_captions
+        if complete_run
+        else expected_images.issubset(actual_images)
+        and expected_captions.issubset(actual_captions)
+    )
+    print(
+        f"expected {len(expected_images):,} requested entries; "
+        f"images/ {len(actual_images):,} total captions/ {len(actual_captions):,} total"
+    )
 
     random.seed(11)
     bad = []
-    for name in random.sample(names, min(sample, len(names))):
+    sampled_names = random.sample(
+        sorted(expected_images), min(sample, len(expected_images))
+    )
+    for name in sampled_names:
         link = out_root / "images" / name
-        if not link.exists():
+        if not link.is_symlink() or not link.exists():
             bad.append((name, "dangling or missing"))
             continue
-        cap = out_root / "captions" / (Path(name).stem + ".txt")
+        _, source_split, image_path, _ = rows_by_name[name]
+        expected_source = (
+            out_root / "images_raw" / source_split / image_path
+        ).resolve()
+        if link.resolve() != expected_source:
+            bad.append((name, "points at the wrong source image"))
+        cap = out_root / "captions" / Path(name).with_suffix(".txt")
         if not cap.is_file():
             bad.append((name, "missing caption"))
-    print(f"sampled {min(sample, len(names)):,} entries, problems {len(bad)}")
+    print(f"sampled {len(sampled_names):,} entries, problems {len(bad)}")
     for problem in bad[:10]:
         print("  BAD", problem)
 
-    ok = image_count == expected and caption_count == expected and not bad
+    ok = counts_ok and not bad
     print("VERIFY:", "PASS" if ok else "FAIL")
     return ok
 

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/rebuild.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/rebuild.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rebuild the TAO-facing image and caption trees from an IAA export."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing as mp
+import os
+import random
+import sys
+import time
+from pathlib import Path
+
+
+SPLITS = ("train", "val", "test")
+
+
+def _shard(rows, out_root: Path):
+    """Create one relative image symlink and caption for each pair row."""
+    made_links = made_caps = skipped = 0
+    for unique_name, source_split, image_path, caption in rows:
+        link = out_root / "images" / unique_name
+        target = Path("..") / "images_raw" / source_split / image_path
+        try:
+            link.symlink_to(target)
+            made_links += 1
+        except FileExistsError:
+            skipped += 1
+
+        cap = out_root / "captions" / (Path(unique_name).stem + ".txt")
+        cap.write_text(caption + "\n", encoding="utf-8")
+        made_caps += 1
+    return made_links, made_caps, skipped
+
+
+def load_rows(split: str, metadata_root: Path):
+    """Project a pair JSON document down to the fields the rebuild needs."""
+    with (metadata_root / f"{split}_pairs.json").open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    rows = [
+        (row["unique_name"], row["source_split"], row["image_path"], row["caption"])
+        for row in data
+    ]
+    del data
+    return rows
+
+
+def rebuild(splits, workers: int, metadata_root: Path, out_root: Path) -> int:
+    (out_root / "images").mkdir(parents=True, exist_ok=True)
+    (out_root / "captions").mkdir(parents=True, exist_ok=True)
+
+    grand = 0
+    for split in splits:
+        started = time.time()
+        rows = load_rows(split, metadata_root)
+        shards = [rows[index::workers] for index in range(workers)]
+        with mp.Pool(workers) as pool:
+            results = pool.starmap(_shard, [(shard, out_root) for shard in shards])
+        links = sum(item[0] for item in results)
+        captions = sum(item[1] for item in results)
+        skipped = sum(item[2] for item in results)
+        elapsed = time.time() - started
+        grand += len(rows)
+        print(
+            f"{split:5s} rows={len(rows):9,d} links={links:9,d} "
+            f"captions={captions:9,d} existing={skipped:9,d} "
+            f"{elapsed:6.1f}s ({len(rows) / max(elapsed, 1e-9):,.0f} rows/s)",
+            flush=True,
+        )
+        del rows
+    return grand
+
+
+def verify(splits, metadata_root: Path, out_root: Path, sample: int = 2000) -> bool:
+    """Check exact counts, then sample-resolve rebuilt links and captions."""
+    expected = 0
+    names = []
+    for split in splits:
+        names_for_split = (metadata_root / f"{split}_list.txt").read_text().split()
+        expected += len(names_for_split)
+        names.extend(names_for_split)
+
+    image_count = len(list((out_root / "images").iterdir()))
+    caption_count = len(list((out_root / "captions").iterdir()))
+    print(f"expected {expected:,} images/ {image_count:,} captions/ {caption_count:,}")
+
+    random.seed(11)
+    bad = []
+    for name in random.sample(names, min(sample, len(names))):
+        link = out_root / "images" / name
+        if not link.exists():
+            bad.append((name, "dangling or missing"))
+            continue
+        cap = out_root / "captions" / (Path(name).stem + ".txt")
+        if not cap.is_file():
+            bad.append((name, "missing caption"))
+    print(f"sampled {min(sample, len(names)):,} entries, problems {len(bad)}")
+    for problem in bad[:10]:
+        print("  BAD", problem)
+
+    ok = image_count == expected and caption_count == expected and not bad
+    print("VERIFY:", "PASS" if ok else "FAIL")
+    return ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata-root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--workers", type=int, default=16)
+    parser.add_argument("--splits", nargs="+", default=list(SPLITS), choices=SPLITS)
+    parser.add_argument("--verify-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    metadata_root = args.metadata_root.expanduser().resolve()
+    out_root = args.out.expanduser().resolve()
+    if args.workers < 1:
+        parser.error("--workers must be >= 1")
+    if not (out_root / "images_raw").is_dir():
+        parser.error(f"{out_root}/images_raw not found; extract images_raw.tar first")
+    for split in args.splits:
+        for suffix in ("pairs.json", "list.txt"):
+            path = metadata_root / f"{split}_{suffix}"
+            if not path.is_file() or path.stat().st_size == 0:
+                parser.error(f"missing or empty metadata input: {path}")
+
+    started = time.time()
+    if not args.verify_only:
+        total = rebuild(args.splits, args.workers, metadata_root, out_root)
+        print(f"\nrebuilt {total:,} pairs in {time.time() - started:.1f}s\n")
+    return 0 if verify(args.splits, metadata_root, out_root) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Reported issue

NVBug 6597479: executable dataset-build logic arrived inside mutable `meta.tar.gz` rather than with the versioned skill, so identical skill revisions could run different rebuild code.

## Original reproduction and observed failure

`find . -name rebuild.py` returned no repository implementation, while IAA references executed `$DATASET_ROOT/rebuild.py` extracted from the archive, contradicting the self-contained workflow contract.

## Root cause

The workflow treated executable code in a data export as its dataset builder, outside repository review and hash binding.

## Implementation

- Bundle `scripts/iaa_deft/rebuild.py` with the skill.
- Execute the bundled implementation with explicit metadata/output roots.
- Ignore any legacy archive copy.
- Update data-layout, preflight, and stage ownership documentation.

## Regression coverage and exact verification

- Original search now finds one skill-owned rebuild implementation.
- The supplied `~/pas/meta.tar.gz` still contains a legacy `rebuild.py`, but references explicitly leave it unused.
- A synthetic export rebuilt images/captions without export code.
- The bundled verifier ran read-only against the real rebuilt dataset: **2,096,238 expected, 2,096,238 images, 2,096,238 captions; 2,000 sampled; 0 problems; VERIFY: PASS**.
- full suite — **259 passed, 2 skipped**
- `scripts/validate-skills.sh` and `git diff --check` — **passed**

## Residual risk

The full multi-gigabyte archive was not destructively rebuilt in place during revalidation; the exact bundled code was exercised synthetically and its verification path was run over the complete existing dataset tree.

## Why this fixes the root cause

The rebuild implementation is now versioned and hash-bound with the skill that invokes it; dataset archives contain data only. The user-facing workflow always executes the bundled implementation and verifies its output.

## Shortcuts intentionally avoided

The change does not copy or trust an archive-supplied program at runtime, fall back to that program when the bundled copy fails, or weaken dataset verification.