### PR TITLE
[TAO-0][Bugfix] NVBug 6597811: Use the canonical public HTTPS install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NVIDIA [TAO Skill Bank](https://github.com/NVIDIA-TAO/tao-skills-bank)
+# NVIDIA [TAO Skill Bank](https://github.com/NVIDIA-TAO/tao-skill-bank)
 
 Portable agent skills for training, evaluating, and running inference on NVIDIA TAO models. Works with Claude Code, Codex, Gemini CLI, or any coding agent that speaks the [Agent Skills open standard](https://agentskills.io). Most local Docker model/data actions need only Docker plus NVIDIA Container Toolkit; application workflows may declare small host-Python requirements for deterministic state and analysis adapters. Advanced features—job tracking, multi-node, S3 I/O—are built in, not bolted on: platform skills implement a four-verb execution contract over their native CLI with no `nvidia-tao-sdk`. See [Execution: no SDK required](#execution-no-sdk-required).
 
@@ -11,7 +11,7 @@ The skill bank works with both Claude Code and Codex. Pick the runtime you use.
 In a Claude Code session, add the marketplace and install the plugin:
 
 ```
-/plugin marketplace add git@github.com:NVIDIA-TAO/tao-skills-bank.git
+/plugin marketplace add https://github.com/NVIDIA-TAO/tao-skill-bank.git
 /plugin install tao-skills@tao-skill-bank
 ```
 
@@ -24,7 +24,7 @@ Codex setup has **two independent pieces** — the plugin (which surfaces the sk
 #### One command (recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NVIDIA-TAO/tao-skills-bank/main/scripts/install-codex-agents.sh | bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA-TAO/tao-skill-bank/main/scripts/install-codex-agents.sh | bash
 ```
 
 …or, if you've already cloned or extracted the repo from a zip, run
@@ -48,7 +48,7 @@ If you'd rather drive each step yourself:
 **1. Install the plugin.** Either use the VS Code Codex extension's plugin UI (select **TAO Skill Bank**), or from the CLI:
 
 ```bash
-codex plugin marketplace add git@github.com:NVIDIA-TAO/tao-skills-bank.git
+codex plugin marketplace add https://github.com/NVIDIA-TAO/tao-skill-bank.git
 codex plugin add tao-skill-bank@tao-local-plugins
 ```
 

--- a/scripts/tests/test_install_codex_agents.py
+++ b/scripts/tests/test_install_codex_agents.py
@@ -59,3 +59,11 @@ def test_installer_defaults_to_public_https_without_github_credentials(tmp_path)
 
 def test_packaged_installer_matches_top_level_installer():
     assert SKILL_INSTALLER.read_bytes() == INSTALLER.read_bytes()
+
+
+def test_readme_uses_canonical_public_marketplace_url():
+    readme = (REPO_ROOT / "README.md").read_text()
+
+    assert "git@github.com" not in readme
+    assert "NVIDIA-TAO/tao-skills-bank" not in readme
+    assert readme.count(PUBLIC_MARKETPLACE) >= 2


### PR DESCRIPTION
## Reported issue

NVBug 6597811: README installation used GitHub SSH for a public repository and the obsolete `tao-skills-bank` slug. Fresh machines without an authorized GitHub SSH key failed before the plugin was installed.

## Original reproduction and observed failure

The README's Claude and Codex marketplace commands used `git@github.com:...`. QA reproduced `Could not read from remote repository` on machines without GitHub SSH setup; HTTPS succeeded.

## Root cause

Public install documentation assumed developer SSH credentials and relied on a redirect from an obsolete repository name.

## Implementation

Use `https://github.com/NVIDIA-TAO/tao-skill-bank.git` in both marketplace commands and update the heading/raw installer links to the canonical slug.

## Regression coverage and verification

- No `git@github.com` or `NVIDIA-TAO/tao-skills-bank` remains in README.
- `git ls-remote https://github.com/NVIDIA-TAO/tao-skill-bank.git HEAD` succeeded without SSH.
- `python -m pytest -q scripts/tests/test_install_codex_agents.py` — **3 passed**
- full suite — **259 passed, 2 skipped**
- `scripts/validate-skills.sh` and `git diff --check` — **passed**

## Residual risk

Revalidation avoided mutating the user's permanent marketplace configuration; it verified the exact public transport and repository target. Other non-README stale slug consumers are handled separately by the audit PR.

## Why this fixes the root cause

The documented install entrypoint now names the canonical public repository over HTTPS, matching the actual default marketplace source and working on hosts without SSH credentials.

## Shortcuts intentionally avoided

The change does not rely on repository redirects, require SSH keys for a public checkout, or add a fallback that would leave the primary command broken.