### PR TITLE
[TAO-0][Bugfix] NVBug 6598785: Reconcile a completed container after wrapper interruption

### DIFF
--- a/scripts/tests/test_iaa_deft_container.py
+++ b/scripts/tests/test_iaa_deft_container.py
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Focused tests for IAA DEFT host/container GPU scoping."""
+"""Focused tests for IAA DEFT GPU scoping and Docker execution evidence."""
 
+import argparse
+import hashlib
 import json
+import shutil
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -21,6 +25,9 @@ sys.path.insert(0, str(IAA_SCRIPTS))
 import run_deft_container as container  # noqa: E402
 import init_deft_state as state  # noqa: E402
 import prepare_deft_config as prepare  # noqa: E402
+from command_contract import command_sha256, expected_container_command  # noqa: E402
+
+IAA_ROOT = IAA_SCRIPTS.parent
 
 
 def test_docker_gpu_args_use_exact_approved_devices():
@@ -120,3 +127,137 @@ def test_approval_gpu_namespaces_reject_malformed_values(value):
 def test_docker_gpu_args_reject_invalid_or_mismatched_state(config):
     with pytest.raises(ValueError):
         container._docker_gpu_args(config)  # noqa: SLF001
+
+
+def test_interrupted_wrapper_reconciles_completed_auto_removed_container(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    results = workspace / "results/run"
+    config_dir = results / "config"
+    dataset = workspace / "data/iaa"
+    config_dir.mkdir(parents=True)
+    dataset.mkdir(parents=True)
+
+    hashes = {}
+    for name in container.RUN_SPEC_NAMES:
+        destination = config_dir / name
+        if name == "approval.json":
+            destination.write_text("{}\n")
+        else:
+            shutil.copyfile(IAA_ROOT / "specs" / name, destination)
+        hashes[name] = hashlib.sha256(destination.read_bytes()).hexdigest()
+
+    state_config = {
+        "workspace": str(workspace),
+        "dataset_root": str(dataset),
+        "config_dir": str(config_dir),
+        "deft_config": str(config_dir / "deft_config.yaml"),
+        "tao_spec": str(config_dir / "tao_spec.yaml"),
+        "spec_sha256": hashes,
+        "platform": "docker",
+        "pyt_image": container.PINNED_IMAGES["pyt"],
+        "ds_image": container.PINNED_IMAGES["ds"],
+        "num_gpus": 1,
+        "gpu_ids": [0],
+        "requires_hf_token": False,
+        "mining_topn": 25,
+        "knn_metric": "cosine",
+    }
+    results.mkdir(parents=True, exist_ok=True)
+    (results / "deft_state.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "3",
+                "workflow": "tao-run-deft-iaa",
+                "results_dir": str(results),
+                "max_iterations": 1,
+                "config": state_config,
+            }
+        )
+    )
+
+    stage = results / "embeddings/source"
+    stage.mkdir(parents=True)
+    output = stage / "embeddings.parquet"
+    output.write_bytes(b"completed parquet")
+    log = stage / "pool_embed.log"
+    log.write_text("work complete\nExecution status: PASS\n")
+    command = expected_container_command("pool_embed", "baseline", state_config)
+    identity = hashlib.sha256(
+        f"{results}\0{stage.relative_to(results)}\0pool_embed".encode()
+    ).hexdigest()[:20]
+    container_name = f"tao-deft-{identity}"
+    started_ns = time.time_ns() - 1_000_000_000
+    status_path = stage / "pool_embed.status.json"
+    status_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "workflow": "tao-run-deft-iaa",
+                "kind": "container",
+                "name": "pool_embed",
+                "attempt": 1,
+                "image_kind": "ds",
+                "image": container.PINNED_IMAGES["ds"],
+                "command": command,
+                "command_sha256": command_sha256(command),
+                "passed_hf_token": False,
+                "container_name": container_name,
+                "cidfile": str(stage / "pool_embed.cid"),
+                "started_at": "2026-08-13T00:00:00+00:00",
+                "started_ns": started_ns,
+                "finished_at": None,
+                "status": "running",
+                "exit_code": None,
+                "log_path": str(log),
+                "fresh_outputs": [str(output)],
+            }
+        )
+    )
+    args = argparse.Namespace(
+        results_dir=results,
+        image="ds",
+        stage_dir=stage,
+        name="pool_embed",
+        pass_hf_token=False,
+        fresh_output=[output],
+        command=command,
+    )
+
+    monkeypatch.setattr(container, "_container_is_running", lambda _: False)
+    monkeypatch.setattr(container, "_container_exit_code", lambda _: None)
+
+    def unexpected_launch(*_args, **_kwargs):
+        raise AssertionError("reconciliation must not launch a second container")
+
+    monkeypatch.setattr(container.subprocess, "run", unexpected_launch)
+    _, _, returncode = container.run(args)
+
+    reconciled = json.loads(status_path.read_text())
+    assert returncode == 0
+    assert output.read_bytes() == b"completed parquet"
+    assert reconciled["attempt"] == 1
+    assert reconciled["status"] == "ok"
+    assert reconciled["exit_code"] == 0
+    assert reconciled["reconciled_after_wrapper_exit"] is True
+    assert reconciled["reconciliation_source"] == "container_log"
+
+
+def test_interrupted_wrapper_does_not_trust_pass_log_without_fresh_output(
+    tmp_path, monkeypatch
+):
+    log = tmp_path / "stage.log"
+    log.write_text("Execution status: PASS\n")
+    monkeypatch.setattr(container, "_container_exit_code", lambda _: None)
+
+    reconciled = container._reconcile_interrupted_success(  # noqa: SLF001
+        {"started_ns": time.time_ns() - 1_000_000_000},
+        status_path=tmp_path / "stage.status.json",
+        log_path=log,
+        fresh_outputs=[str(tmp_path / "missing.parquet")],
+        container_name="removed-container",
+    )
+
+    assert reconciled is False
+    assert not (tmp_path / "stage.status.json").exists()

--- a/scripts/tests/test_iaa_deft_container.py
+++ b/scripts/tests/test_iaa_deft_container.py
@@ -182,7 +182,9 @@ def test_interrupted_wrapper_reconciles_completed_auto_removed_container(
     output = stage / "embeddings.parquet"
     output.write_bytes(b"completed parquet")
     log = stage / "pool_embed.log"
-    log.write_text("work complete\nExecution status: PASS\n")
+    log.write_text(
+        "work complete\nExecution status: PASS\n" + "trailing diagnostics\n" * 6000
+    )
     command = expected_container_command("pool_embed", "baseline", state_config)
     identity = hashlib.sha256(
         f"{results}\0{stage.relative_to(results)}\0pool_embed".encode()
@@ -242,6 +244,18 @@ def test_interrupted_wrapper_reconciles_completed_auto_removed_container(
     assert reconciled["exit_code"] == 0
     assert reconciled["reconciled_after_wrapper_exit"] is True
     assert reconciled["reconciliation_source"] == "container_log"
+
+
+def test_complete_log_scan_returns_the_final_status_beyond_tail_boundaries(tmp_path):
+    log = tmp_path / "stage.log"
+    log.write_text(
+        "Execution status: PASS\n"
+        + "later diagnostic output\n" * 6000
+        + "Execution status: FAIL\n"
+    )
+
+    assert log.stat().st_size > 64 * 1024
+    assert container._last_execution_status(log) == "FAIL"  # noqa: SLF001
 
 
 def test_interrupted_wrapper_does_not_trust_pass_log_without_fresh_output(

--- a/skills/applications/tao-run-deft-iaa/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-iaa/references/pipeline-and-state.md
@@ -121,8 +121,11 @@ On startup or after context compaction:
 4. Read one reference and continue the selected stage.
 
 Uncommitted outputs can be reused only when that stage's validators accept a
-successful matching command status and fresh scoped artifacts. Otherwise the
-documented wrapper reruns the exact stage after deleting only named fresh
+successful matching command status and fresh scoped artifacts. When a
+container wrapper was interrupted and its status remains `running`, rerun the
+exact wrapper command after the deterministic container exits. The wrapper
+first reconciles durable Docker/log success evidence and fresh outputs; only
+when that fails does it consume the bounded retry and delete the named fresh
 outputs. For history selection, use its one `--resume` path. Never backfill a
 log entry or manually mark a stage complete.
 

--- a/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
@@ -113,11 +113,20 @@ container read-only and refuses to overlap it. Wait for the named container to
 exit; never kill it automatically. Rerun the exact wrapper command after exit.
 Before consuming a retry, it verifies the prior command identity and reconciles
 a status left at `running` when Docker reports exit zero or an auto-removed
-container's bounded log tail ends in `Execution status: PASS`, and every named
+container's complete durable log has a final `Execution status: PASS` marker,
+and every named
 fresh output is non-empty and newer than that attempt. The normal stage commit
 then applies the format/cardinality validators. Incomplete or contradictory
 evidence is never reconciled. `HF_TOKEN` is not forwarded unless the approved
 command needs it and `--pass-hf-token` is supplied explicitly.
+
+For a reconciled status, `exit_code` is the wrapper contract outcome. A value
+of zero means the wrapper established success from the full evidence set, not
+necessarily that it directly observed Docker exit. `docker_exit_code` is zero
+for both a retained container inspected at exit zero and an auto-removed
+container whose zero outcome was inferred from its final PASS marker. Read
+`reconciliation_source` (`docker` or `container_log`) to distinguish those
+provenance paths; `reconciled_after_wrapper_exit` is true in either case.
 Docker and host-adapter statuses also carry a stable `attempt` value. Attempt
 1 is the initial call, attempt 2 is the single evidence-based correction, and
 either wrapper refuses attempt 3. Keep the documented stable command names;

--- a/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
@@ -110,8 +110,14 @@ a file without successful matching command status is not resumable evidence.
 The wrapper uses a deterministic Docker name, CID file, and nonblocking launch
 lock. If its process dies while Docker continues, a later call inspects that
 container read-only and refuses to overlap it. Wait for the named container to
-exit; never kill it automatically. `HF_TOKEN` is not forwarded unless the
-approved command needs it and `--pass-hf-token` is supplied explicitly.
+exit; never kill it automatically. Rerun the exact wrapper command after exit.
+Before consuming a retry, it verifies the prior command identity and reconciles
+a status left at `running` when Docker reports exit zero or an auto-removed
+container's bounded log tail ends in `Execution status: PASS`, and every named
+fresh output is non-empty and newer than that attempt. The normal stage commit
+then applies the format/cardinality validators. Incomplete or contradictory
+evidence is never reconciled. `HF_TOKEN` is not forwarded unless the approved
+command needs it and `--pass-hf-token` is supplied explicitly.
 Docker and host-adapter statuses also carry a stable `attempt` value. Attempt
 1 is the initial call, attempt 2 is the single evidence-based correction, and
 either wrapper refuses attempt 3. Keep the documented stable command names;

--- a/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
@@ -254,6 +254,147 @@ def _container_is_running(container_name: str) -> bool:
     )
 
 
+def _container_exit_code(container_name: str) -> int | None:
+    """Return a retained container's exit code, or None after Docker --rm."""
+    inspected = subprocess.run(
+        [
+            "docker",
+            "container",
+            "inspect",
+            "--format",
+            "{{.State.ExitCode}}",
+            container_name,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if inspected.returncode == 0:
+        try:
+            return int(inspected.stdout.strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"Docker returned an invalid exit code for {container_name}: "
+                f"{inspected.stdout.strip()!r}"
+            ) from exc
+    combined = (inspected.stdout + inspected.stderr).lower()
+    if "no such object" in combined or "no such container" in combined:
+        return None
+    raise ValueError(
+        f"cannot inspect prior container {container_name}; Docker said: "
+        f"{(inspected.stderr or inspected.stdout).strip() or 'unknown error'}"
+    )
+
+
+def _last_execution_status(log_path: pathlib.Path) -> str | None:
+    """Read only the bounded log tail and return its final TAO status marker."""
+    with log_path.open("rb") as handle:
+        size = log_path.stat().st_size
+        handle.seek(max(0, size - 64 * 1024))
+        tail = handle.read().decode("utf-8", errors="replace")
+    statuses = re.findall(
+        r"(?m)^Execution status:\s*(PASS|FAIL)\s*$", tail, flags=re.IGNORECASE
+    )
+    return statuses[-1].upper() if statuses else None
+
+
+def _validate_interrupted_identity(
+    existing: dict[str, Any],
+    *,
+    name: str,
+    image_kind: str,
+    image: str,
+    command: list[str],
+    passed_hf_token: bool,
+    container_name: str,
+    cidfile_path: pathlib.Path,
+    log_path: pathlib.Path,
+    fresh_outputs: list[str],
+) -> None:
+    expected = {
+        "schema_version": "1",
+        "workflow": "tao-run-deft-iaa",
+        "kind": "container",
+        "name": name,
+        "image_kind": image_kind,
+        "image": image,
+        "command": command,
+        "command_sha256": command_sha256(command),
+        "passed_hf_token": passed_hf_token,
+        "container_name": container_name,
+        "cidfile": str(cidfile_path),
+        "log_path": str(log_path),
+        "fresh_outputs": fresh_outputs,
+    }
+    mismatches = [key for key, value in expected.items() if existing.get(key) != value]
+    if mismatches:
+        raise ValueError(
+            "existing running status does not match the approved command identity: "
+            + ", ".join(mismatches)
+        )
+
+
+def _reconcile_interrupted_success(
+    existing: dict[str, Any],
+    *,
+    status_path: pathlib.Path,
+    log_path: pathlib.Path,
+    fresh_outputs: list[str],
+    container_name: str,
+) -> bool:
+    """Close a status left running only when durable success evidence agrees."""
+    started_ns = existing.get("started_ns")
+    if (
+        not isinstance(started_ns, int)
+        or isinstance(started_ns, bool)
+        or started_ns < 1
+        or not log_path.is_file()
+        or log_path.stat().st_size == 0
+        or log_path.is_symlink()
+        or log_path.resolve() != log_path
+    ):
+        return False
+    for raw in fresh_outputs:
+        output = pathlib.Path(raw)
+        if (
+            output.is_symlink()
+            or not output.is_file()
+            or output.stat().st_size == 0
+            or output.stat().st_mtime_ns < started_ns
+        ):
+            return False
+
+    docker_exit_code = _container_exit_code(container_name)
+    log_status = _last_execution_status(log_path)
+    if docker_exit_code is not None:
+        if docker_exit_code != 0 or log_status == "FAIL":
+            return False
+        source = "docker"
+    else:
+        if log_status != "PASS":
+            return False
+        docker_exit_code = 0
+        source = "container_log"
+
+    finished_at = dt.datetime.fromtimestamp(
+        log_path.stat().st_mtime, tz=dt.timezone.utc
+    ).isoformat(timespec="seconds")
+    _atomic_json(
+        status_path,
+        {
+            **existing,
+            "finished_at": finished_at,
+            "status": "ok",
+            "exit_code": 0,
+            "docker_exit_code": docker_exit_code,
+            "artifact_error": None,
+            "reconciled_after_wrapper_exit": True,
+            "reconciliation_source": source,
+        },
+    )
+    return True
+
+
 def _launch_label(name: str, stage_dir: pathlib.Path, results_dir: pathlib.Path) -> str:
     if name == "pool_embed":
         return "baseline"
@@ -435,11 +576,31 @@ def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
                     "existing running status lacks the deterministic container identity; "
                     f"inspect and recover manually before replacing {status_path}"
                 )
+            _validate_interrupted_identity(
+                existing,
+                name=args.name,
+                image_kind=args.image,
+                image=image,
+                command=list(args.command),
+                passed_hf_token=bool(args.pass_hf_token),
+                container_name=container_name,
+                cidfile_path=cidfile_path,
+                log_path=log_path,
+                fresh_outputs=fresh_outputs,
+            )
             if _container_is_running(container_name):
                 raise ValueError(
                     f"prior container {container_name} is still running; wait for it to "
                     "exit, then rerun the same command (the wrapper never auto-kills it)"
                 )
+            if _reconcile_interrupted_success(
+                existing,
+                status_path=status_path,
+                log_path=log_path,
+                fresh_outputs=fresh_outputs,
+                container_name=container_name,
+            ):
+                return status_path, log_path, 0
         if prior_attempt >= 2:
             raise ValueError(
                 f"attempt budget exhausted for {args.name} (attempt={prior_attempt}); "

--- a/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
@@ -287,15 +287,21 @@ def _container_exit_code(container_name: str) -> int | None:
 
 
 def _last_execution_status(log_path: pathlib.Path) -> str | None:
-    """Read only the bounded log tail and return its final TAO status marker."""
-    with log_path.open("rb") as handle:
-        size = log_path.stat().st_size
-        handle.seek(max(0, size - 64 * 1024))
-        tail = handle.read().decode("utf-8", errors="replace")
-    statuses = re.findall(
-        r"(?m)^Execution status:\s*(PASS|FAIL)\s*$", tail, flags=re.IGNORECASE
-    )
-    return statuses[-1].upper() if statuses else None
+    """Stream the complete log and return its final TAO status marker.
+
+    Reconciliation is an exceptional recovery path, so a linear scan is a
+    better tradeoff than a fixed tail: it uses bounded memory and cannot lose
+    durable success evidence merely because later diagnostics made the log
+    larger than an arbitrary window.
+    """
+    final_status = None
+    pattern = re.compile(r"^Execution status:\s*(PASS|FAIL)\s*$", re.IGNORECASE)
+    with log_path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            match = pattern.match(line)
+            if match:
+                final_status = match.group(1).upper()
+    return final_status
 
 
 def _validate_interrupted_identity(


### PR DESCRIPTION
## Reported issue

NVBug 6598785: interrupting the host wrapper after a container completed left the stage marked `running`; the completed output could not be committed safely and rerunning could consume the final attempt or relaunch completed work.

## Original reproduction

1. Launch an IAA container stage with its deterministic container name and fresh-output contract.
2. Let the auto-removed container finish successfully and write its output and `Execution status: PASS` log marker.
3. Terminate the host wrapper before it atomically records the terminal command status.
4. Rerun the same user-facing stage command.

Before this change, the status remained `running` even though Docker no longer had the container. The wrapper could not distinguish completed work from an abandoned attempt and did not recover the stage.

## Root cause

Terminal success existed only in wrapper memory. The persisted running record had enough launch identity to locate the prior work, but the resume path did not reconcile that record against Docker state, the TAO log, and output freshness.

## Implementation summary

- Validate the complete persisted command identity before recovery.
- Inspect a retained container exit code when available.
- For an auto-removed container, require the final TAO log status to be `PASS`.
- In both cases, require every declared output to be nonempty, non-symlinked, and newer than the recorded attempt start.
- Atomically close the existing attempt as successful and return without relaunching.
- Keep ambiguous or failed evidence fail-closed.

## Regression coverage

Added interrupted-wrapper tests covering successful reconciliation without a second launch and rejection of a PASS log when a required fresh output is missing. Adjacent container identity, GPU-scope, command-status, and commit behavior remained covered.

## Exact post-fix verification

The original on-disk `running` status + PASS log + fresh output topology reconciled attempt 1 to `ok`, preserved the output, and did not call Docker launch. Removing the fresh output made reconciliation fail as intended.

- `python -m pytest -q scripts/tests` — **260 passed, 2 skipped**
- focused interruption and adjacent IAA container/commit tests — **passed**
- `scripts/validate-skills.sh` — **passed**
- `git diff --check origin/main...HEAD` — **passed**

## Why this fixes the root cause

Recovery is implemented at the durable command-status boundary where the lost wrapper transition occurred. It reconstructs the missing transition only when independent launch identity, backend/log completion, and artifact evidence agree, so every caller gets the same crash-safe behavior.

## Shortcuts intentionally avoided

The implementation does not delete the running status, blindly trust a PASS string, assume a missing container succeeded, or relaunch work just to make the stage usable. It also does not accept outputs from an older attempt.

## Residual risks or limitations

An auto-removed container with no durable PASS marker cannot be proven successful and is intentionally not reconciled. Such ambiguous state still requires the normal retry/manual recovery path rather than guessing.
