### PR TITLE
[TAO-0][Bugfix] NVBug 6601677: Route plain-language iterative attribute workflows to IAA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ User-facing DEFT shorthand resolves to canonical application skills:
 `tao-run-deft-iaa`. State the canonical name when routing; the shorthand does
 not name a separate implementation.
 
+Route requests to keep improving a CLIP / SigLIP2 image-retrieval model on
+attribute-labelled data until progress stops to `tao-run-deft-iaa`, even when
+the user does not know the DEFT or IAA names. Do not route that request to the
+PCB / VisualChangeNet `tao-run-deft-aoi` workflow, generic AutoML, or the
+single-action CLIP fine-tuning skill.
+
 ## Discovery flow
 
 Model-first routing is mandatory. Resolve a supplied model ID with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,13 @@ User-facing DEFT shorthand resolves to canonical application skills:
 `tao-run-deft-iaa`. State the canonical name when routing; the shorthand does
 not name a separate implementation.
 
-Route requests to keep improving a CLIP / SigLIP2 image-retrieval model on
-attribute-labelled data until progress stops to `tao-run-deft-iaa`, even when
-the user does not know the DEFT or IAA names. Do not route that request to the
-PCB / VisualChangeNet `tao-run-deft-aoi` workflow, generic AutoML, or the
-single-action CLIP fine-tuning skill.
+Route to `tao-run-deft-iaa` when a request combines image-text retrieval on
+attribute-labelled data with an iterative evaluate, mine, retrain, and
+re-evaluate loop. A KPI target, plateau condition, or iteration budget may
+bound the loop; CLIP/SigLIP, DEFT, and IAA names are optional routing signals.
+Do not route that combination to the PCB / VisualChangeNet
+`tao-run-deft-aoi` workflow, generic AutoML, or the single-action CLIP
+fine-tuning skill.
 
 ## Discovery flow
 

--- a/scripts/tests/test_iaa_skill_routing.py
+++ b/scripts/tests/test_iaa_skill_routing.py
@@ -16,18 +16,34 @@ def _description(relative: str) -> str:
     return yaml.safe_load(text.split("---", 2)[1])["description"]
 
 
-def test_plain_language_iaa_signals_are_explicit_and_competitors_are_bounded():
+def test_iaa_routing_contract_is_structural_and_competitors_are_bounded():
     iaa = _description("skills/applications/tao-run-deft-iaa")
     aoi = _description("skills/applications/tao-run-deft-aoi")
     automl = _description("skills/applications/tao-run-automl")
     clip = _description("skills/models/tao-finetune-clip")
 
-    for signal in ("SigLIP2", "image retrieval", "attribute-labelled", "stops getting better"):
+    exact_bug_probe = (
+        "Improve my SigLIP2 image retrieval model on my attribute-labelled "
+        "dataset until it stops getting better."
+    )
+    assert exact_bug_probe not in iaa
+    for signal in (
+        "image-text retrieval",
+        "attribute-labelled",
+        "weak-attribute or caption-pair mining",
+        "repeated retraining",
+        "validation plateau",
+    ):
         assert signal in iaa
     assert "Do not use for CLIP / SigLIP" in aoi
     assert "belong to tao-run-deft-iaa" in automl
     assert "belongs to tao-run-deft-iaa" in clip
 
     orchestration = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
-    for signal in ("SigLIP2 image-retrieval", "attribute-labelled", "tao-run-deft-iaa"):
+    for signal in (
+        "image-text retrieval",
+        "attribute-labelled",
+        "evaluate, mine, retrain",
+        "tao-run-deft-iaa",
+    ):
         assert signal in orchestration

--- a/scripts/tests/test_iaa_skill_routing.py
+++ b/scripts/tests/test_iaa_skill_routing.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression checks for mutually exclusive IAA routing metadata."""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _description(relative: str) -> str:
+    text = (REPO_ROOT / relative / "SKILL.md").read_text(encoding="utf-8")
+    return yaml.safe_load(text.split("---", 2)[1])["description"]
+
+
+def test_plain_language_iaa_signals_are_explicit_and_competitors_are_bounded():
+    iaa = _description("skills/applications/tao-run-deft-iaa")
+    aoi = _description("skills/applications/tao-run-deft-aoi")
+    automl = _description("skills/applications/tao-run-automl")
+    clip = _description("skills/models/tao-finetune-clip")
+
+    for signal in ("SigLIP2", "image retrieval", "attribute-labelled", "stops getting better"):
+        assert signal in iaa
+    assert "Do not use for CLIP / SigLIP" in aoi
+    assert "belong to tao-run-deft-iaa" in automl
+    assert "belongs to tao-run-deft-iaa" in clip
+
+    orchestration = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    for signal in ("SigLIP2 image-retrieval", "attribute-labelled", "tao-run-deft-iaa"):
+        assert signal in orchestration

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -6,7 +6,8 @@ description: Run container-backed AutoML / hyperparameter optimization (HPO) for
   optimization, HPO, automl, automl_settings, AutoMLRunner, tao_automl, bayesian search, hyperband, ASHA, LLM-guided search,
   autoresearch, or wants to tune train/evaluate/inference/distill/prune/quantize for a TAO network. Model actions use the resolved
   image; venv training requires an explicit request. Platform-agnostic — runs on any SDK (Brev,
-  SLURM, Kubernetes, Docker).
+  SLURM, Kubernetes, Docker). Do not use generic "keep improving" language alone to override a matching domain-specific
+  DEFT workflow; attribute-labelled CLIP / SigLIP image-retrieval loops belong to tao-run-deft-iaa unless HPO is explicit.
 license: Apache-2.0
 compatibility: Requires docker + nvidia-container-toolkit. Workflows declare additional requirements.
 metadata:

--- a/skills/applications/tao-run-deft-aoi/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi/SKILL.md
@@ -3,11 +3,11 @@ name: tao-run-deft-aoi
 description: >
   Run the full DEFT AOI improvement loop for NVIDIA TAO VisualChangeNet / ChangeNet PCB inspection models:
   baseline evaluate, RCA, Cosmos AnomalyGen / AMP synthetic defects, k-NN mining, retraining, and deployment
-  gating against a customer-defined primary metric and optional constraints. Supports air-gapped/offline runs
-  with pre-staged assets. Use for prompts like "run the DEFT loop", "fine-tune until the configured quality
-  metric meets its target", "optimize a customer metric", or "improve my AOI ChangeNet model with RCA and synthetic
-  defects"; do not use
-  for standalone TAO training, one-off inference, generic anomaly generation, or RCA-only analysis.
+  gating against a customer-defined primary metric and optional constraints. Use only when the request identifies
+  an AOI / automated-optical-inspection, PCB-defect, VisualChangeNet, or ChangeNet workflow. Supports air-gapped/offline
+  runs with pre-staged assets. Never infer AOI from generic iterative-improvement language. Do not use for CLIP / SigLIP
+  image retrieval, attribute-labelled image data, standalone TAO training, one-off inference, generic anomaly generation,
+  or RCA-only analysis.
 license: Apache-2.0 AND CC-BY-4.0
 compatibility: Requires docker + nvidia-container-toolkit. Workflows declare additional requirements.
 metadata:

--- a/skills/applications/tao-run-deft-iaa/SKILL.md
+++ b/skills/applications/tao-run-deft-iaa/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: tao-run-deft-iaa
 description: >
-  Iteratively improve an NVIDIA TAO CLIP / SigLIP2 image-retrieval model on
-  attribute-labelled data until its retrieval KPI reaches a target or the
-  iteration budget is exhausted. Use when a customer asks to keep improving
-  weak image attributes, even if they do not know the DEFT or Image Attribute
-  Augmentation (IAA) names. The self-contained loop performs dataset
+  Use for requests such as "Improve my SigLIP2 image retrieval model on my
+  attribute-labelled dataset until it stops getting better." Keep improving
+  an NVIDIA TAO CLIP / SigLIP2 image-retrieval model on attribute-labelled
+  data until improvement stops, its retrieval KPI reaches a target, or the
+  iteration budget is exhausted. Route iterative attribute-labelled
+  image-retrieval improvement here even when the customer does not know the
+  DEFT or Image Attribute Augmentation (IAA) names. The self-contained loop performs dataset
   preparation, zero-shot evaluation, attribute gap analysis, caption-space
   k-NN mining, history-aware selection, retraining, and re-evaluation. Treat
   `tao-deft-iaa` as shorthand for this canonical `tao-run-deft-iaa` workflow.

--- a/skills/applications/tao-run-deft-iaa/SKILL.md
+++ b/skills/applications/tao-run-deft-iaa/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: tao-run-deft-iaa
 description: >
-  Run the self-contained DEFT improvement loop for NVIDIA TAO CLIP /
-  SigLIP2 Image Attribute Augmentation (IAA): dataset preparation, zero-shot
-  evaluation, attribute gap analysis, caption-space k-NN mining,
-  history-aware selection, retraining, and re-evaluation against an IAA
-  retrieval KPI. Use for requests to run or resume the IAA DEFT loop or improve
-  an IAA model until a metric target or iteration budget is reached. Treat
+  Iteratively improve an NVIDIA TAO CLIP / SigLIP2 image-retrieval model on
+  attribute-labelled data until its retrieval KPI reaches a target or the
+  iteration budget is exhausted. Use when a customer asks to keep improving
+  weak image attributes, even if they do not know the DEFT or Image Attribute
+  Augmentation (IAA) names. The self-contained loop performs dataset
+  preparation, zero-shot evaluation, attribute gap analysis, caption-space
+  k-NN mining, history-aware selection, retraining, and re-evaluation. Treat
   `tao-deft-iaa` as shorthand for this canonical `tao-run-deft-iaa` workflow.
   Do not use for standalone CLIP training, one-off evaluation or embedding,
   generic k-NN mining, or AOI/ChangeNet DEFT workflows.

--- a/skills/applications/tao-run-deft-iaa/SKILL.md
+++ b/skills/applications/tao-run-deft-iaa/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: tao-run-deft-iaa
 description: >
-  Use for requests such as "Improve my SigLIP2 image retrieval model on my
-  attribute-labelled dataset until it stops getting better." Keep improving
-  an NVIDIA TAO CLIP / SigLIP2 image-retrieval model on attribute-labelled
-  data until improvement stops, its retrieval KPI reaches a target, or the
-  iteration budget is exhausted. Route iterative attribute-labelled
-  image-retrieval improvement here even when the customer does not know the
-  DEFT or Image Attribute Augmentation (IAA) names. The self-contained loop performs dataset
-  preparation, zero-shot evaluation, attribute gap analysis, caption-space
-  k-NN mining, history-aware selection, retraining, and re-evaluation. Treat
+  Run iterative improvement for NVIDIA TAO CLIP / SigLIP image-text retrieval
+  on attribute-labelled data. Use when a request combines retrieval evaluation,
+  weak-attribute or caption-pair mining, repeated retraining, and a stopping
+  condition based on a retrieval KPI, validation plateau, or iteration budget;
+  the customer need not know the DEFT or Image Attribute Augmentation (IAA)
+  names. The self-contained workflow performs dataset preparation, zero-shot
+  evaluation, attribute gap analysis, caption-space k-NN mining, history-aware
+  selection, retraining, and re-evaluation. Treat
   `tao-deft-iaa` as shorthand for this canonical `tao-run-deft-iaa` workflow.
   Do not use for standalone CLIP training, one-off evaluation or embedding,
   generic k-NN mining, or AOI/ChangeNet DEFT workflows.

--- a/skills/applications/tao-run-deft-iaa/evals/evals.json
+++ b/skills/applications/tao-run-deft-iaa/evals/evals.json
@@ -41,6 +41,33 @@
     ]
   },
   {
+    "id": "tao-run-deft-iaa-plain-language-routing-stage-paraphrase",
+    "question": "I have product photos paired with textual attributes. Repeatedly identify the weakest retrieval attributes, mine additional image-caption pairs, retrain, and re-evaluate until validation plateaus. Do not run anything; in one line name which skill applies, or say NONE.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Select tao-run-deft-iaa because the requested evaluate, attribute-gap, pair-mining, retrain, and re-evaluate cycle is the PAS/IAA DEFT workflow even though no internal workflow or model name appears.",
+    "expected_behavior": [
+      "Names tao-run-deft-iaa as the applicable skill",
+      "Uses the repeated retrieval evaluation, weak-attribute analysis, pair mining, and retraining cycle as the routing structure",
+      "Does not require the user to know CLIP, SigLIP, DEFT, IAA, or PAS terminology",
+      "Does not select one-shot tao-finetune-clip, tao-run-automl, or tao-run-deft-aoi",
+      "Does not run commands, scripts, containers, installs, web searches, audits, or other tools"
+    ]
+  },
+  {
+    "id": "tao-run-deft-iaa-plain-language-routing-kpi-paraphrase",
+    "question": "For this attribute-captioned person-search dataset, cycle through retrieval evaluation, hard-pair mining, and model updates until medium-query Rank-1 reaches 0.65 or four rounds finish. Do not run anything; in one line name which skill applies, or say NONE.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Select tao-run-deft-iaa because attribute-captioned retrieval with repeated mining/training/evaluation and a retrieval-KPI or iteration stop is the PAS/IAA DEFT application contract.",
+    "expected_behavior": [
+      "Names tao-run-deft-iaa as the applicable skill",
+      "Recognizes the retrieval KPI and bounded repeated mining/training/evaluation loop",
+      "Does not treat the numeric target as generic HPO and does not infer AOI or PCB inspection",
+      "Does not run commands, scripts, containers, installs, web searches, audits, or other tools"
+    ]
+  },
+  {
     "id": "tao-run-deft-iaa-basic",
     "question": "A user says: \"Use the tao-run-deft-iaa skill to plan an IAA DEFT run.\" Identify the applicable skill and outline its documented workflow. This is a planning evaluation: do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
     "expected_skill": "tao-run-deft-iaa",

--- a/skills/applications/tao-run-deft-iaa/evals/evals.json
+++ b/skills/applications/tao-run-deft-iaa/evals/evals.json
@@ -28,6 +28,19 @@
     ]
   },
   {
+    "id": "tao-run-deft-iaa-plain-language-routing-no-model-name",
+    "question": "Keep improving my image-retrieval model on attribute-labelled images until it stops getting better. Do not run anything; in one line name which skill applies, or say NONE.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Select tao-run-deft-iaa because attribute-labelled image retrieval plus iterative improvement is the IAA DEFT workflow even when the customer does not know the IAA or SigLIP2 names. Do not select AOI, which is restricted to PCB/VisualChangeNet inspection.",
+    "expected_behavior": [
+      "Names tao-run-deft-iaa as the applicable skill",
+      "Uses attribute-labelled image retrieval and repeated improvement as the routing signals",
+      "Does not select tao-run-deft-aoi without AOI, PCB, VisualChangeNet, or ChangeNet context",
+      "Does not run commands, scripts, containers, installs, web searches, audits, or other tools"
+    ]
+  },
+  {
     "id": "tao-run-deft-iaa-basic",
     "question": "A user says: \"Use the tao-run-deft-iaa skill to plan an IAA DEFT run.\" Identify the applicable skill and outline its documented workflow. This is a planning evaluation: do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
     "expected_skill": "tao-run-deft-iaa",

--- a/skills/applications/tao-run-deft-iaa/evals/evals.json
+++ b/skills/applications/tao-run-deft-iaa/evals/evals.json
@@ -15,6 +15,19 @@
     ]
   },
   {
+    "id": "tao-run-deft-iaa-plain-language-routing",
+    "question": "Improve my SigLIP2 image retrieval model on my attribute-labelled dataset until it stops getting better. Do not run anything; in one line name which skill applies, or say NONE.",
+    "expected_skill": "tao-run-deft-iaa",
+    "expected_script": null,
+    "ground_truth": "Select tao-run-deft-iaa because the request describes its iterative attribute-focused retrieval improvement loop in customer language. It is not a one-off tao-finetune-clip run, generic AutoML search, or the AOI/ChangeNet workflow. Do not execute anything.",
+    "expected_behavior": [
+      "Names tao-run-deft-iaa as the applicable skill",
+      "Recognizes attribute-labelled SigLIP2 retrieval plus repeated improvement as the IAA DEFT loop",
+      "Does not select one-shot tao-finetune-clip, tao-run-automl, or tao-run-deft-aoi",
+      "Does not run commands, scripts, containers, installs, web searches, audits, or other tools"
+    ]
+  },
+  {
     "id": "tao-run-deft-iaa-basic",
     "question": "A user says: \"Use the tao-run-deft-iaa skill to plan an IAA DEFT run.\" Identify the applicable skill and outline its documented workflow. This is a planning evaluation: do not run commands, scripts, containers, installs, web searches, audits, or any other tools.",
     "expected_skill": "tao-run-deft-iaa",

--- a/skills/models/tao-finetune-clip/SKILL.md
+++ b/skills/models/tao-finetune-clip/SKILL.md
@@ -2,7 +2,8 @@
 name: tao-finetune-clip
 description: CLIP vision-language model for image-text retrieval, zero-shot classification, embedding extraction, ONNX
   export, and TensorRT deployment. Use when fine-tuning or training CLIP, running zero-shot classification, computing image
-  embeddings, or deploying CLIP to ONNX/TensorRT.
+  embeddings, or deploying CLIP to ONNX/TensorRT. This is a single-action model skill; do not use it for an iterative
+  weak-attribute improvement loop that keeps retraining and evaluating until progress stops, which belongs to tao-run-deft-iaa.
 license: Apache-2.0
 compatibility: Requires docker + nvidia-container-toolkit.
 metadata:


### PR DESCRIPTION
## Reported issue

NVBug 6601677: a customer describing iterative image-retrieval improvement in ordinary language was routed to another TAO skill instead of `tao-run-deft-iaa`.

## Original reproduction

Start fresh plugin-only agent sessions and ask for the workflow semantically—for example, iteratively finding weak image attributes, mining similar examples, retraining, and repeating—without naming DEFT or IAA.

Before the complete fix, all four representative plain-language trials missed IAA (two returned no skill and two chose AOI). Updating only the IAA description improved but did not make routing deterministic because competing skills and the plugin-wide routing map still claimed overlapping language.

## Root cause

Routing metadata was inconsistent at the plugin boundary: the top-level application routing map omitted the semantic IAA intent, while AOI, AutoML, and one-shot CLIP metadata used broad phrases that overlapped the same request.

## Implementation summary

- Add the exact semantic intent to the canonical IAA skill description and plugin-wide application routing map.
- Scope AOI to AOI/PCB/VisualChangeNet change-inspection language.
- Scope AutoML to hyperparameter search and one-shot CLIP to one-shot training.
- Add static routing-contract regression coverage and a representative eval.

## Regression coverage

`scripts/tests/test_iaa_skill_routing.py` asserts that the plugin map and all competing descriptions remain mutually discriminating. The IAA eval set now includes a plain-language iterative request.

## Exact post-fix verification

After disabling a stale user-cached plugin copy and loading only the refreshed branch, the exact original semantic prompt routed to `tao-run-deft-iaa` in **8/8 fresh sessions**.

- `python -m pytest -q scripts/tests` — **259 passed, 2 skipped**
- focused routing regression — **passed**
- `scripts/validate-skills.sh` — **passed**
- `git diff --check origin/main...HEAD` — **passed**

## Why this fixes the root cause

The fix establishes one coherent routing contract at the plugin-wide decision layer and aligns every overlapping skill's metadata with it. It therefore resolves the ambiguity before a model chooses a skill, rather than trying to recover after the wrong skill has already been selected.

## Shortcuts intentionally avoided

The change does not depend on the literal bug prompt, add a post-routing override, or merely stuff more keywords into IAA while leaving competitors broad. It preserves valid AOI, AutoML, and one-shot CLIP routing by narrowing each to its actual domain.

## Residual risks or limitations

Natural-language routing is model-mediated, but the exact reported intent is now explicit at every routing layer and was stable across eight clean sessions. Cached older plugin installations must still be refreshed by users to receive new metadata.
