### PR TITLE
[TAO-0][Bugfix] NVBug 6602338: Publish the TAO 7.2 skill-bank release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,12 @@
   },
   "plugins": [
     {
+      "name": "tao-skill-bank",
+      "description": "Canonical cross-client entry for the TAO Skill Bank plugin. Codex resolves this name from .codex-plugin/plugin.json; Claude users may continue using the tao-skills compatibility entry.",
+      "source": "./",
+      "strict": true
+    },
+    {
       "name": "tao-skills",
       "description": "Full TAO skill bank \u2014 every model, data, platform, and application skill in one bundle. Install this for the standard agentic-fine-tuning experience.",
       "source": "./",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "NVIDIA TAO skill bank with generated capability discovery for model training, data processing, application workflows, AutoML, and platform execution.",
-    "version": "0.1.12"
+    "version": "0.1.13"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "tao-skill-bank",
   "description": "NVIDIA TAO skill bank with generated capability discovery for model training, data processing, application workflows, AutoML, and platform execution.",
-  "version": "0.1.12"
+  "version": "0.1.13"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tao-skill-bank",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "NVIDIA TAO skill bank with generated capability discovery for model training, data processing, application workflows, AutoML, and platform execution.",
   "skills": "./skills/core/",
   "interface": {

--- a/scripts/ci/render_and_validate_templates.py
+++ b/scripts/ci/render_and_validate_templates.py
@@ -46,7 +46,7 @@ COMMON = {
     "NUM_NODES": "2",
     "GPUS_PER_NODE": "8",
     "NUM_GPUS": "8",          # single-node templates spell it this way
-    "IMAGE": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt",  # versions-key: images.tao_toolkit.pyt
+    "IMAGE": "nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch",  # versions-key: images.tao_toolkit.pyt
     "COMMAND": "dino train -e /data/specs/spec.yaml",
 }
 K8S_VALS = {

--- a/scripts/tests/test_release_install_contract.py
+++ b/scripts/tests/test_release_install_contract.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the release delivered by the default marketplace."""
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_default_branch_publishes_7_2_images_and_new_plugin_version():
+    versions = yaml.safe_load((REPO_ROOT / "versions.yaml").read_text())
+    images = versions["images"]["tao_toolkit"]
+    assert "7.2.0" in images["pyt"]
+    assert "7.2.0" in images["data_services"]
+
+    manifests = [
+        json.loads((REPO_ROOT / ".claude-plugin/plugin.json").read_text()),
+        json.loads((REPO_ROOT / ".codex-plugin/plugin.json").read_text()),
+    ]
+    marketplace = json.loads(
+        (REPO_ROOT / ".claude-plugin/marketplace.json").read_text()
+    )
+    advertised = marketplace["metadata"]["version"]
+    assert advertised == "0.1.13"
+    assert {manifest["version"] for manifest in manifests} == {advertised}
+
+
+def test_iaa_stamped_pins_match_published_versions():
+    versions = yaml.safe_load((REPO_ROOT / "versions.yaml").read_text())
+    images = versions["images"]["tao_toolkit"]
+    scripts = REPO_ROOT / "skills/applications/tao-run-deft-iaa/scripts"
+    for path in (
+        scripts / "prepare_deft_config.py",
+        scripts / "init_deft_state.py",
+        scripts / "audit_deft_run.py",
+        scripts / "run_deft_container.py",
+    ):
+        text = path.read_text()
+        assert images["pyt"] in text
+        assert images["data_services"] in text

--- a/scripts/tests/test_release_install_contract.py
+++ b/scripts/tests/test_release_install_contract.py
@@ -30,6 +30,27 @@ def test_default_branch_publishes_7_2_images_and_new_plugin_version():
     assert {manifest["version"] for manifest in manifests} == {advertised}
 
 
+def test_default_marketplace_exposes_the_canonical_codex_plugin_name():
+    """A root marketplace add must expose the name Codex installs.
+
+    The shared marketplace historically listed only the Claude-facing
+    ``tao-skills`` alias. Codex reads its canonical name from plugin.json and
+    then could not find that name in the marketplace it had just registered.
+    Keep the alias for existing Claude installs, but require the canonical
+    cross-client entry too.
+    """
+    codex_manifest = json.loads(
+        (REPO_ROOT / ".codex-plugin/plugin.json").read_text()
+    )
+    shared_marketplace = json.loads(
+        (REPO_ROOT / ".claude-plugin/marketplace.json").read_text()
+    )
+    names = {entry["name"] for entry in shared_marketplace["plugins"]}
+
+    assert codex_manifest["name"] in names
+    assert "tao-skills" in names
+
+
 def test_iaa_stamped_pins_match_published_versions():
     versions = yaml.safe_load((REPO_ROOT / "versions.yaml").read_text())
     images = versions["images"]["tao_toolkit"]

--- a/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
+++ b/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
@@ -91,7 +91,7 @@ cp ${RESULTS_DIR}/best_model_inference_spec.yaml /tmp/my_inference.yaml
 # … set the four CONSUMER fields …
 
 # 3. Pinned TAO pyt image URI (stamped from the release manifest).
-TAO_PYT_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 
 # 4. Run inference. Mount paths from best_model.json into the container.
 HANDOFF="${RESULTS_DIR}/best_model.json"

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -144,8 +144,10 @@ Run this section only after required intake is resolved.
 
    ```bash
    docker version --format '{{.Server.Version}}'
-   docker image inspect nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch >/dev/null 2>&1  # versions-key: images.tao_toolkit.pyt
-   docker image inspect nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch >/dev/null 2>&1  # versions-key: images.tao_toolkit.data_services
+   TAO_PYT_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
+   TAO_DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
+   docker image inspect "$TAO_PYT_IMAGE" >/dev/null 2>&1
+   docker image inspect "$TAO_DS_IMAGE" >/dev/null 2>&1
    TARGET_GPU_ARGS=()
    IFS=, read -r -a GPU_ID_LIST <<< "$GPU_IDS"
    for GPU_ID in "${GPU_ID_LIST[@]}"; do
@@ -153,7 +155,7 @@ Run this section only after required intake is resolved.
    done
    "${TAO_SKILL_BANK_PATH:?}/scripts/check_tao_launch_preflight.py" \
      --skill-bank "$TAO_SKILL_BANK_PATH" --platform docker \
-     --container-image nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch \
+     --container-image "$TAO_PYT_IMAGE" \
      --gpu-min-count "$NUM_GPUS" "${TARGET_GPU_ARGS[@]}"
    ```
 

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -144,8 +144,8 @@ Run this section only after required intake is resolved.
 
    ```bash
    docker version --format '{{.Server.Version}}'
-   docker image inspect nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt >/dev/null 2>&1  # versions-key: images.tao_toolkit.pyt
-   docker image inspect nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services >/dev/null 2>&1  # versions-key: images.tao_toolkit.data_services
+   docker image inspect nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch >/dev/null 2>&1  # versions-key: images.tao_toolkit.pyt
+   docker image inspect nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch >/dev/null 2>&1  # versions-key: images.tao_toolkit.data_services
    TARGET_GPU_ARGS=()
    IFS=, read -r -a GPU_ID_LIST <<< "$GPU_IDS"
    for GPU_ID in "${GPU_ID_LIST[@]}"; do
@@ -153,7 +153,7 @@ Run this section only after required intake is resolved.
    done
    "${TAO_SKILL_BANK_PATH:?}/scripts/check_tao_launch_preflight.py" \
      --skill-bank "$TAO_SKILL_BANK_PATH" --platform docker \
-     --container-image nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt \
+     --container-image nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch \
      --gpu-min-count "$NUM_GPUS" "${TARGET_GPU_ARGS[@]}"
    ```
 
@@ -215,8 +215,8 @@ hardware, pool size, and accumulated data can change this substantially.
 | continual behavior | dataset `true`, model `false` |
 | visualization | contact sheets `true`, embedding plot `true` |
 | Hugging Face token forwarding | disabled; enable only when the approved model/environment requires it |
-| PyTorch image | `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` | <!-- versions-key: images.tao_toolkit.pyt -->
-| data-services image | `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services` | <!-- versions-key: images.tao_toolkit.data_services -->
+| PyTorch image | `nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch` | <!-- versions-key: images.tao_toolkit.pyt -->
+| data-services image | `nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch` | <!-- versions-key: images.tao_toolkit.data_services -->
 | monitoring | attached, poll every `5 minutes` |
 
 An ungated run evaluates every allowed iteration and completes with
@@ -269,9 +269,9 @@ Inputs
   credentials: NGC_KEY=<set | not needed | missing>;
                HF_TOKEN=<set | optional/unset | missing>
   token forwarding: requires_hf_token=<bool> (source=<user | default>)
-  PyTorch image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+  PyTorch image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
                  (source=versions.yaml; status=<local | pull after approval>)
-  data-services image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+  data-services image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
                        (source=versions.yaml; status=<local | pull after approval>)
   GPUs: <selected host IDs> (source=<user | default>);
         physical=<count>; visible=<CUDA-visible count>; requested=<num_gpus>;
@@ -307,8 +307,8 @@ For a new run, perform the following in order.
      printf '%s' "$NGC_KEY" | docker login nvcr.io \
        --username '$oauthtoken' --password-stdin >/dev/null
    )
-   docker pull nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
-   docker pull nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+   docker pull nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
+   docker pull nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
    ```
 
    Never print, persist, or place the credential value in argv.
@@ -319,7 +319,7 @@ For a new run, perform the following in order.
    : "${GPU_IDS:?approved comma-separated GPU ids are required}"
    DOCKER_GPU_REQUEST="\"device=${GPU_IDS}\""
    docker run --rm --gpus "$DOCKER_GPU_REQUEST" \
-     nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt python3 -c 'import torch; torch.zeros(1).cuda()'  # versions-key: images.tao_toolkit.pyt
+     nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch python3 -c 'import torch; torch.zeros(1).cuda()'  # versions-key: images.tao_toolkit.pyt
    ```
 
    `GPU_IDS` is the exact approved host `gpu_ids` list (for example `0` or
@@ -393,8 +393,8 @@ For a new run, perform the following in order.
      INIT_OPTIONAL_ARGS+=(--requires-hf-token)
    fi
 
-   IAA_PYT_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
-   IAA_DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+   IAA_PYT_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
+   IAA_DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 
    "$SKILL_ROOT/scripts/deft_python.sh" --workspace "$WORKSPACE" --runtime \
      "$SKILL_ROOT/scripts/init_deft_state.py" \

--- a/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
@@ -77,8 +77,8 @@ RUN_SPEC_NAMES = (
     "mining_spec.yaml",
     "approval.json",
 )
-PINNED_PYT_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"  # versions-key: images.tao_toolkit.pyt
-PINNED_DS_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services"  # versions-key: images.tao_toolkit.data_services
+PINNED_PYT_IMAGE = "nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch"  # versions-key: images.tao_toolkit.pyt
+PINNED_DS_IMAGE = "nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch"  # versions-key: images.tao_toolkit.data_services
 
 # Artifact fields recorded by commit_stage._apply_success, grouped by the
 # containment scope commit_stage enforced at commit time.

--- a/skills/applications/tao-run-deft-iaa/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/init_deft_state.py
@@ -54,8 +54,8 @@ from metric_contract import validate_contract
 
 
 WORKFLOW = "tao-run-deft-iaa"
-PINNED_PYT_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"  # versions-key: images.tao_toolkit.pyt
-PINNED_DS_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services"  # versions-key: images.tao_toolkit.data_services
+PINNED_PYT_IMAGE = "nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch"  # versions-key: images.tao_toolkit.pyt
+PINNED_DS_IMAGE = "nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch"  # versions-key: images.tao_toolkit.data_services
 RUN_SPEC_NAMES = (
     "deft_config.yaml",
     "tao_spec.yaml",

--- a/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
@@ -33,8 +33,8 @@ SPEC_NAMES = (
     "image_embed_spec.yaml",
     "mining_spec.yaml",
 )
-PINNED_PYT_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"  # versions-key: images.tao_toolkit.pyt
-PINNED_DS_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services"  # versions-key: images.tao_toolkit.data_services
+PINNED_PYT_IMAGE = "nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch"  # versions-key: images.tao_toolkit.pyt
+PINNED_DS_IMAGE = "nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch"  # versions-key: images.tao_toolkit.data_services
 
 
 def _bool(value: str) -> bool:

--- a/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
@@ -44,8 +44,8 @@ RUN_SPEC_NAMES = (
     "approval.json",
 )
 PINNED_IMAGES = {
-    "pyt": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt",  # versions-key: images.tao_toolkit.pyt
-    "ds": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services",  # versions-key: images.tao_toolkit.data_services
+    "pyt": "nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch",  # versions-key: images.tao_toolkit.pyt
+    "ds": "nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch",  # versions-key: images.tao_toolkit.data_services
 }
 
 

--- a/skills/data/tao-analyze-detection-kpi/SKILL.md
+++ b/skills/data/tao-analyze-detection-kpi/SKILL.md
@@ -78,7 +78,7 @@ RUN_ROOT=/absolute/path/that/contains/images/annotations/and/results
 python3 skills/data/tao-analyze-detection-kpi/scripts/verify_kpi_analyze_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus all --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -137,7 +137,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
+++ b/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-detection-kpi
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -87,7 +87,7 @@ SPEC="$RESULTS_DIR/object_detection.yaml"        # spec lives beside its outputs
 RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
 GPU_COUNT=1
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -109,7 +109,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-od-map
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
+++ b/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
@@ -50,7 +50,7 @@ The threshold sweep, weakness ranking, and per-lighting expansion all run inside
 
 ```bash
 # Pinned TAO data-services container URI (stamped from the release manifest)
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 echo "DS_IMAGE=$DS_IMAGE"
 
 docker info > /dev/null && echo "OK: docker"
@@ -132,7 +132,7 @@ MIN_RECALL=1.0                       # zero-miss default; lower if KPI relaxes
 TOP_K=50                             # per-label augmentation budget
 OUT="$EXP_DIR/rca_results/$(date +%Y-%m-%d_%H%M%S)"
 SPEC="$OUT/vcn_aoi_spec.yaml"
-IMG=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+IMG=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 
 mkdir -p "$OUT"
 

--- a/skills/data/tao-analyze-gaps-visual-changenet/references/container-setup.md
+++ b/skills/data/tao-analyze-gaps-visual-changenet/references/container-setup.md
@@ -4,7 +4,7 @@ The threshold sweep, weakness ranking, and per-lighting expansion all run inside
 
 ```bash
 # Pinned TAO data-services container URI (stamped from the release manifest)
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 echo "DS_IMAGE=$DS_IMAGE"
 
 docker info > /dev/null && echo "OK: docker"

--- a/skills/data/tao-analyze-gaps-vlm-bcq/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-vlm-bcq/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-vlm-bcq
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 # Fixed compute requirement: request one GPU from the platform. Even though this
 # function doesn't need a GPU, the Data Services image always calls nvidia-smi.
 # This remains null because the strict VLM BCQ spec has no GPU-count field;

--- a/skills/data/tao-generate-image-embeddings/SKILL.md
+++ b/skills/data/tao-generate-image-embeddings/SKILL.md
@@ -77,7 +77,7 @@ GPU_COUNT=1
 python3 skills/data/tao-generate-image-embeddings/scripts/verify_image_embeddings_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -144,7 +144,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
+++ b/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-generate-image-embeddings
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: [NGC_KEY]   # the pinned image is nvstaging/*, which is not public
 actions:

--- a/skills/data/tao-generate-image-grounding/SKILL.md
+++ b/skills/data/tao-generate-image-grounding/SKILL.md
@@ -123,5 +123,5 @@ All outputs go to `results_dir/`:
 
 ## Prerequisites
 
-- **Container**: `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` <!-- versions-key: images.tao_toolkit.pyt -->
+- **Container**: `nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch` <!-- versions-key: images.tao_toolkit.pyt -->
 - **API access**: At least one VLM endpoint (Gemini API key or OpenAI-compatible endpoint capable of image input)

--- a/skills/data/tao-generate-image-grounding/references/skill_info.yaml
+++ b/skills/data/tao-generate-image-grounding/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-generate-image-grounding
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-generate-referring-expressions/SKILL.md
+++ b/skills/data/tao-generate-referring-expressions/SKILL.md
@@ -139,6 +139,6 @@ All outputs go to `results_dir/`:
 
 ## Prerequisites
 
-- **Container**: `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt` <!-- versions-key: images.tao_toolkit.pyt -->
+- **Container**: `nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch` <!-- versions-key: images.tao_toolkit.pyt -->
 - **API access**: At least one VLM endpoint (Gemini API key or OpenAI-compatible endpoint capable of image input)
 - **PIL / Pillow**: Required to read image dimensions during seeding (already present in the TAO container)

--- a/skills/data/tao-generate-referring-expressions/references/skill_info.yaml
+++ b/skills/data/tao-generate-referring-expressions/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-generate-referring-expressions
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-generate-video-reasoning-annotations/SKILL.md
+++ b/skills/data/tao-generate-video-reasoning-annotations/SKILL.md
@@ -179,6 +179,6 @@ Each step 4 file looks like:
 
 ## Prerequisites
 
-- **Container**: `nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt`. <!-- versions-key: images.tao_toolkit.pyt -->
+- **Container**: `nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch`. <!-- versions-key: images.tao_toolkit.pyt -->
 - **ffmpeg / ffprobe**: required for chunk captioning (Step 1b) and highlight extraction (Step 1c).
 - **VLM endpoint**: at least one — Gemini API key or OpenAI-compatible endpoint.

--- a/skills/data/tao-generate-video-reasoning-annotations/references/skill_info.yaml
+++ b/skills/data/tao-generate-video-reasoning-annotations/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-generate-video-reasoning-annotations
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-mine-aoi-images/SKILL.md
+++ b/skills/data/tao-mine-aoi-images/SKILL.md
@@ -46,7 +46,7 @@ Use the pinned TAO data-services URI below, then confirm Docker, the NVIDIA cont
 
 ```bash
 # Pinned TAO data-services container URI (stamped from the release manifest)
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 echo "DS_IMAGE=$DS_IMAGE"
 
 docker info > /dev/null && echo "OK: docker"

--- a/skills/data/tao-mine-aoi-images/references/reference-invocation.md
+++ b/skills/data/tao-mine-aoi-images/references/reference-invocation.md
@@ -14,7 +14,7 @@ MODEL_PATH=google/siglip-base-patch16-224  # or a local checkpoint path
 TOPN=5
 METRIC=cosine
 FILTER_BY_LABEL=false
-IMG=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+IMG=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 
 mkdir -p "$OUT"
 

--- a/skills/data/tao-mine-aoi-images/references/setup.md
+++ b/skills/data/tao-mine-aoi-images/references/setup.md
@@ -4,7 +4,7 @@ The mining and embedding tasks live inside the pinned TAO data-services image be
 
 ```bash
 # Pinned TAO data-services container URI (stamped from the release manifest)
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 echo "DS_IMAGE=$DS_IMAGE"
 
 docker info > /dev/null && echo "OK: docker"

--- a/skills/data/tao-mine-nearest-neighbors/references/skill_info.yaml
+++ b/skills/data/tao-mine-nearest-neighbors/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-mine-nearest-neighbors
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-mine-od-images/SKILL.md
+++ b/skills/data/tao-mine-od-images/SKILL.md
@@ -83,7 +83,7 @@ GPU_COUNT=1
 python3 skills/data/tao-mine-od-images/scripts/verify_unique_neighbor_matching_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -147,7 +147,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-mine-od-images/references/skill_info.yaml
+++ b/skills/data/tao-mine-od-images/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-mine-od-images
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/models/tao-finetune-clip/references/skill_info.yaml
+++ b/skills/models/tao-finetune-clip/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: clip
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:
@@ -103,7 +103,7 @@ actions:
     upload_excludes:
     - inputs/
   gen_trt_engine:
-    container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+    container_image: nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
     command: clip gen_trt_engine -e {config_path}
     config_format: yaml
     mode: config

--- a/skills/models/tao-finetune-clip/references/tao-deploy-clip.md
+++ b/skills/models/tao-finetune-clip/references/tao-deploy-clip.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-finetune-cosmos-reason/references/skill_info.yaml
+++ b/skills/models/tao-finetune-cosmos-reason/references/skill_info.yaml
@@ -16,7 +16,7 @@ backend_contracts:
     container_image: nvcr.io/nvstaging/tao/cosmos-framework:cosmos3-tao-reproducibility-20260818-6aa9a80  # versions-key: images.tao_toolkit.cosmos_framework
   cosmos-rl:
     path: references/cosmos-rl-backend.yaml
-    container_image: nvcr.io/nvstaging/tao/cosmos-rl:enhanced-hooks-custom-loggers-20260816-direct-cache-fast-v7  # versions-key: images.tao_toolkit.cosmos_rl
+    container_image: nvcr.io/nvstaging/tao/cosmos_rl:7.2.0-rc-241-multiarch  # versions-key: images.tao_toolkit.cosmos_rl
 backend_resolver: scripts/cosmos_workflow.py
 backend_selection:
   policy: explicit backend wins; otherwise select by model, action, and workflow and report the rationale

--- a/skills/models/tao-train-action-recognition/SKILL.md
+++ b/skills/models/tao-train-action-recognition/SKILL.md
@@ -30,7 +30,7 @@ Docker/platform skill instead when it gives a stricter environment-specific
 command (non-root UID mapping, cache redirects, remote daemons).
 
 ```bash
-TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 TAO_PYT_IMAGE="${TAO_PYT_IMAGE:-$TAO_PYT_IMAGE_DEFAULT}"
 RUN_ROOT="${RUN_ROOT:-$PWD}"
 DOCKER_COMMON=(

--- a/skills/models/tao-train-action-recognition/references/skill_info.yaml
+++ b/skills/models/tao-train-action-recognition/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-action-recognition
 network_arch: action_recognition
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-centerpose/references/skill_info.yaml
+++ b/skills/models/tao-train-centerpose/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-centerpose
 network_arch: centerpose
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:
@@ -76,7 +76,7 @@ actions:
     upload_excludes:
     - inputs/
   gen_trt_engine:
-    container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+    container_image: nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
     command: centerpose gen_trt_engine -e {config_path}
     config_format: yaml
     mode: config

--- a/skills/models/tao-train-centerpose/references/tao-deploy-centerpose.md
+++ b/skills/models/tao-train-centerpose/references/tao-deploy-centerpose.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-deformable-detr/references/skill_info.yaml
+++ b/skills/models/tao-train-deformable-detr/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-deformable-detr
 network_arch: deformable_detr
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: coco
 gpu_spec_key: train.num_gpus
 actions:
@@ -91,7 +91,7 @@ actions:
     upload_excludes:
     - inputs/
   gen_trt_engine:
-    container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+    container_image: nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
     command: deformable_detr gen_trt_engine -e {config_path}
     config_format: yaml
     mode: config

--- a/skills/models/tao-train-deformable-detr/references/tao-deploy-deformable-detr.md
+++ b/skills/models/tao-train-deformable-detr/references/tao-deploy-deformable-detr.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-depth-anything-v2/references/skill_info.yaml
+++ b/skills/models/tao-train-depth-anything-v2/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-depth-anything-v2
 network_arch: depth_net_mono
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: RelativeMonoDataset
 gpu_spec_key: train.num_gpus
 actions:
@@ -97,7 +97,7 @@ actions:
     upload_excludes:
     - inputs/
   gen_trt_engine:
-    container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+    container_image: nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
     command: depth_net gen_trt_engine -e {config_path}
     config_format: yaml
     mode: config

--- a/skills/models/tao-train-depth-anything-v2/references/tao-deploy-depth-anything-v2.md
+++ b/skills/models/tao-train-depth-anything-v2/references/tao-deploy-depth-anything-v2.md
@@ -11,7 +11,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-dino/references/skill_info.yaml
+++ b/skills/models/tao-train-dino/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-dino
 network_arch: dino
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: coco
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-dino/references/tao-deploy-dino.md
+++ b/skills/models/tao-train-dino/references/tao-deploy-dino.md
@@ -14,7 +14,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-dinov3/SKILL.md
+++ b/skills/models/tao-train-dinov3/SKILL.md
@@ -31,7 +31,7 @@ Docker/platform skill instead when it gives a stricter environment-specific
 command (non-root UID mapping, cache redirects, remote daemons).
 
 ```bash
-TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 TAO_PYT_IMAGE="${TAO_PYT_IMAGE:-$TAO_PYT_IMAGE_DEFAULT}"
 RUN_ROOT="${RUN_ROOT:-$PWD}"
 DOCKER_COMMON=(

--- a/skills/models/tao-train-dinov3/references/skill_info.yaml
+++ b/skills/models/tao-train-dinov3/references/skill_info.yaml
@@ -4,7 +4,7 @@ huggingface_model_ids:
 - timm/vit_base_patch16_dinov3.lvd1689m
 - timm/vit_small_patch16_dinov3.lvd1689m
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: ssl
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-fast-foundation-stereo/references/skill_info.yaml
+++ b/skills/models/tao-train-fast-foundation-stereo/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-fast-foundation-stereo
 network_arch: depth_net_stereo
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: FSD
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-fast-foundation-stereo/references/tao-deploy-fast-foundation-stereo.md
+++ b/skills/models/tao-train-fast-foundation-stereo/references/tao-deploy-fast-foundation-stereo.md
@@ -11,7 +11,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-foundation-stereo/references/skill_info.yaml
+++ b/skills/models/tao-train-foundation-stereo/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-foundation-stereo
 network_arch: depth_net_stereo
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: FSD
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-foundation-stereo/references/tao-deploy-foundation-stereo.md
+++ b/skills/models/tao-train-foundation-stereo/references/tao-deploy-foundation-stereo.md
@@ -11,7 +11,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-grounding-dino/references/skill_info.yaml
+++ b/skills/models/tao-train-grounding-dino/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-grounding-dino
 network_arch: grounding_dino
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: odvg
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-grounding-dino/references/tao-deploy-grounding-dino.md
+++ b/skills/models/tao-train-grounding-dino/references/tao-deploy-grounding-dino.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-image-classification/references/skill_info.yaml
+++ b/skills/models/tao-train-image-classification/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-image-classification
 network_arch: classification_pyt
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: classification_pyt
 gpu_spec_key: train.num_gpus
 actions:
@@ -119,7 +119,7 @@ actions:
     upload_excludes:
     - inputs/
   gen_trt_engine:
-    container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+    container_image: nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
     command: classification_pyt gen_trt_engine -e {config_path}
     config_format: yaml
     mode: config

--- a/skills/models/tao-train-image-classification/references/tao-deploy-image-classification.md
+++ b/skills/models/tao-train-image-classification/references/tao-deploy-image-classification.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-mask-auto-encoder/references/skill_info.yaml
+++ b/skills/models/tao-train-mask-auto-encoder/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-mask-auto-encoder
 network_arch: mae
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: ssl
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-mask-auto-encoder/references/tao-deploy-mask-auto-encoder.md
+++ b/skills/models/tao-train-mask-auto-encoder/references/tao-deploy-mask-auto-encoder.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-mask-auto-label/SKILL.md
+++ b/skills/models/tao-train-mask-auto-label/SKILL.md
@@ -29,7 +29,7 @@ Docker/platform skill instead when it gives a stricter environment-specific
 command (non-root UID mapping, cache redirects, remote daemons).
 
 ```bash
-TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 TAO_PYT_IMAGE="${TAO_PYT_IMAGE:-$TAO_PYT_IMAGE_DEFAULT}"
 RUN_ROOT="${RUN_ROOT:-$PWD}"
 DOCKER_COMMON=(

--- a/skills/models/tao-train-mask-auto-label/references/skill_info.yaml
+++ b/skills/models/tao-train-mask-auto-label/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-mask-auto-label
 network_arch: mal
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-mask-grounding-dino/references/skill_info.yaml
+++ b/skills/models/tao-train-mask-grounding-dino/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-mask-grounding-dino
 network_arch: mask_grounding_dino
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: odvg
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-mask-grounding-dino/references/tao-deploy-mask-grounding-dino.md
+++ b/skills/models/tao-train-mask-grounding-dino/references/tao-deploy-mask-grounding-dino.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-mask2former/references/skill_info.yaml
+++ b/skills/models/tao-train-mask2former/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-mask2former
 network_arch: mask2former
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: coco_panoptic
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-mask2former/references/tao-deploy-mask2former.md
+++ b/skills/models/tao-train-mask2former/references/tao-deploy-mask2former.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-metric-learning-recognition/references/skill_info.yaml
+++ b/skills/models/tao-train-metric-learning-recognition/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-metric-learning-recognition
 network_arch: ml_recog
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-metric-learning-recognition/references/tao-deploy-metric-learning-recognition.md
+++ b/skills/models/tao-train-metric-learning-recognition/references/tao-deploy-metric-learning-recognition.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-nvdinov2/references/skill_info.yaml
+++ b/skills/models/tao-train-nvdinov2/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-nvdinov2
 network_arch: nvdinov2
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: ssl
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-nvdinov2/references/tao-deploy-nvdinov2.md
+++ b/skills/models/tao-train-nvdinov2/references/tao-deploy-nvdinov2.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-nvpanoptix3d/SKILL.md
+++ b/skills/models/tao-train-nvpanoptix3d/SKILL.md
@@ -31,7 +31,7 @@ Docker/platform skill instead when it gives a stricter environment-specific
 command (non-root UID mapping, cache redirects, remote daemons).
 
 ```bash
-TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 TAO_PYT_IMAGE="${TAO_PYT_IMAGE:-$TAO_PYT_IMAGE_DEFAULT}"
 RUN_ROOT="${RUN_ROOT:-$PWD}"
 DOCKER_COMMON=(

--- a/skills/models/tao-train-nvpanoptix3d/references/skill_info.yaml
+++ b/skills/models/tao-train-nvpanoptix3d/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-nvpanoptix3d
 network_arch: nvpanoptix3d
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: front3d
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-ocdnet/references/skill_info.yaml
+++ b/skills/models/tao-train-ocdnet/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-ocdnet
 network_arch: ocdnet
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-ocdnet/references/tao-deploy-ocdnet.md
+++ b/skills/models/tao-train-ocdnet/references/tao-deploy-ocdnet.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-ocrnet/references/skill_info.yaml
+++ b/skills/models/tao-train-ocrnet/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-ocrnet
 network_arch: ocrnet
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-ocrnet/references/tao-deploy-ocrnet.md
+++ b/skills/models/tao-train-ocrnet/references/tao-deploy-ocrnet.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-oneformer/references/skill_info.yaml
+++ b/skills/models/tao-train-oneformer/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-oneformer
 network_arch: oneformer
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: coco_panoptic
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-oneformer/references/tao-deploy-oneformer.md
+++ b/skills/models/tao-train-oneformer/references/tao-deploy-oneformer.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-optical-inspection/references/skill_info.yaml
+++ b/skills/models/tao-train-optical-inspection/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-optical-inspection
 network_arch: optical_inspection
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-optical-inspection/references/tao-deploy-optical-inspection.md
+++ b/skills/models/tao-train-optical-inspection/references/tao-deploy-optical-inspection.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-pointpillars/references/skill_info.yaml
+++ b/skills/models/tao-train-pointpillars/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-pointpillars
 network_arch: pointpillars
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-pointpillars/references/tao-deploy-pointpillars.md
+++ b/skills/models/tao-train-pointpillars/references/tao-deploy-pointpillars.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-pose-classification/SKILL.md
+++ b/skills/models/tao-train-pose-classification/SKILL.md
@@ -32,7 +32,7 @@ Docker/platform skill instead when it gives a stricter environment-specific
 command (non-root UID mapping, cache redirects, remote daemons).
 
 ```bash
-TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 TAO_PYT_IMAGE="${TAO_PYT_IMAGE:-$TAO_PYT_IMAGE_DEFAULT}"
 RUN_ROOT="${RUN_ROOT:-$PWD}"
 DOCKER_COMMON=(

--- a/skills/models/tao-train-pose-classification/references/skill_info.yaml
+++ b/skills/models/tao-train-pose-classification/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-pose-classification
 network_arch: pose_classification
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-reid/SKILL.md
+++ b/skills/models/tao-train-reid/SKILL.md
@@ -30,7 +30,7 @@ Docker/platform skill instead when it gives a stricter environment-specific
 command (non-root UID mapping, cache redirects, remote daemons).
 
 ```bash
-TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE_DEFAULT=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 TAO_PYT_IMAGE="${TAO_PYT_IMAGE:-$TAO_PYT_IMAGE_DEFAULT}"
 RUN_ROOT="${RUN_ROOT:-$PWD}"
 DOCKER_COMMON=(

--- a/skills/models/tao-train-reid/references/skill_info.yaml
+++ b/skills/models/tao-train-reid/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-reid
 network_arch: re_identification
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: default
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-rtdetr/references/skill_info.yaml
+++ b/skills/models/tao-train-rtdetr/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-rtdetr
 network_arch: rtdetr
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: coco
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-rtdetr/references/tao-deploy-rtdetr.md
+++ b/skills/models/tao-train-rtdetr/references/tao-deploy-rtdetr.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-segformer/references/skill_info.yaml
+++ b/skills/models/tao-train-segformer/references/skill_info.yaml
@@ -1,7 +1,7 @@
 name: tao-train-segformer
 network_arch: segformer
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: unet
 gpu_spec_key: train.num_gpus
 actions:

--- a/skills/models/tao-train-segformer/references/tao-deploy-segformer.md
+++ b/skills/models/tao-train-segformer/references/tao-deploy-segformer.md
@@ -10,7 +10,7 @@ Set the deploy container once at the top of the session — every command below
 uses it:
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 ### Generate TensorRT Engine

--- a/skills/models/tao-train-sparse4d/references/skill_info.yaml
+++ b/skills/models/tao-train-sparse4d/references/skill_info.yaml
@@ -1,12 +1,12 @@
 name: tao-train-sparse4d
 network_arch: sparse4d
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 data_format: ovpkl
 gpu_spec_key: train.num_gpus
 actions:
   dataset_convert:
-    container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+    container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.data_services
     command: annotations convert -e {config_path}
     config_format: yaml
     mode: config

--- a/skills/models/tao-train-visual-changenet/references/local-docker.md
+++ b/skills/models/tao-train-visual-changenet/references/local-docker.md
@@ -4,7 +4,7 @@ When running without the TAO SDK (local docker), use the pinned TAO pyt image an
 
 ```bash
 # Pinned TAO pyt container URI (stamped from the release manifest).
-TAO_PYT_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+TAO_PYT_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 
 set -a; source /path/to/.env; set +a   # omit if already exported
 docker run --rm --gpus all --shm-size=8g \

--- a/skills/models/tao-train-visual-changenet/references/skill_info.yaml
+++ b/skills/models/tao-train-visual-changenet/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: visual-changenet
 automl_enabled: true
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 gpu_spec_key: train.num_gpus
 actions:
   train:

--- a/skills/models/tao-train-visual-changenet/references/tao-deploy-visual-changenet.md
+++ b/skills/models/tao-train-visual-changenet/references/tao-deploy-visual-changenet.md
@@ -11,7 +11,7 @@ Direct TAO Deploy command name: `visual_changenet`.
 Use the pinned deploy container URI (stamped from the release manifest):
 
 ```bash
-TAO_DEPLOY_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy  # versions-key: images.tao_toolkit.deploy
+TAO_DEPLOY_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch  # versions-key: images.tao_toolkit.deploy
 ```
 
 Every invocation below uses `"$TAO_DEPLOY_IMAGE"` in place of the literal image URI.

--- a/skills/platform/tao-run-on-brev/SKILL.md
+++ b/skills/platform/tao-run-on-brev/SKILL.md
@@ -123,7 +123,7 @@ NGC auth once per instance — **never put `NGC_KEY` on argv** (it lands in the
 remote process table); pipe it to `--password-stdin`:
 
 ```bash
-IMG=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+IMG=nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 
 # NGC auth (one-time per instance) — value never on argv.
 # Single-quoted locally so $NGC_KEY expands in the instance's shell; export it

--- a/templates/skill-skeleton/data/references/skill_info.yaml
+++ b/templates/skill-skeleton/data/references/skill_info.yaml
@@ -8,7 +8,7 @@ type: data
 # Examples:
 #   container_image: tao_toolkit.pyt
 #   container_image: <literal nvcr.io URI stamped from versions.yaml — see the live line below>
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 required_credentials: []
 
 actions:

--- a/templates/skill-skeleton/model/references/skill_info.yaml
+++ b/templates/skill-skeleton/model/references/skill_info.yaml
@@ -13,7 +13,7 @@ type: model
 # Examples:
 #   container_image: tao_toolkit.pyt
 #   container_image: <literal nvcr.io URI stamped from versions.yaml — see the live line below>
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.tao_toolkit.pyt
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch  # versions-key: images.tao_toolkit.pyt
 required_credentials:
   - HF_TOKEN
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -29,12 +29,12 @@
 
 images:
   tao_toolkit:
-    pyt:                nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt
-    deploy:             nvcr.io/nvidia/tao/tao-toolkit:7.1.0-deploy
-    data_services:      nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services
+    pyt:                nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-36-multiarch
+    deploy:             nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-37-multiarch
+    data_services:      nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-36-multiarch
     # TAO 7.1.0 has the Cosmos Reason Conv3d/vLLM import regression (NVBUG 6587006).
     cosmos_framework:   nvcr.io/nvstaging/tao/cosmos-framework:cosmos3-tao-reproducibility-20260818-6aa9a80
-    cosmos_rl:          nvcr.io/nvstaging/tao/cosmos-rl:enhanced-hooks-custom-loggers-20260816-direct-cache-fast-v7
+    cosmos_rl:          nvcr.io/nvstaging/tao/cosmos_rl:7.2.0-rc-241-multiarch
     deft_cosmos_reason: nvcr.io/nvidia/tao/tao-toolkit:7.0.1-cosmos-rl
     cosmos_predict:     nvcr.io/nvidia/tao/tao-toolkit:7.0.1-cosmos-predict
     cosmos_embed:       nvcr.io/nvidia/tao/tao-toolkit:7.1.0-cosmos-embed
@@ -63,17 +63,17 @@ wheels:
   # platform skills run containers via docker/kubectl/srun and the SDK-free
   # 4-verb consumer path (tao-data-io + tao_job_record + tao-launch-workflow).
   # These `tao_sdk_*` keys exist so nvidia-tao-automl can pull a matching SDK.
-  tao_sdk:            nvidia-tao-sdk==7.1.0
-  tao_sdk_brev:       nvidia-tao-sdk[brev]==7.1.0
-  tao_sdk_slurm:      nvidia-tao-sdk[slurm]==7.1.0
-  tao_sdk_kubernetes: nvidia-tao-sdk[kubernetes]==7.1.0
-  tao_sdk_docker:     nvidia-tao-sdk[docker]==7.1.0
-  tao_sdk_all:        nvidia-tao-sdk[all]==7.1.0
+  tao_sdk:            nvidia-tao-sdk==7.2.0rc19
+  tao_sdk_brev:       nvidia-tao-sdk[brev]==7.2.0rc19
+  tao_sdk_slurm:      nvidia-tao-sdk[slurm]==7.2.0rc19
+  tao_sdk_kubernetes: nvidia-tao-sdk[kubernetes]==7.2.0rc19
+  tao_sdk_docker:     nvidia-tao-sdk[docker]==7.2.0rc19
+  tao_sdk_all:        nvidia-tao-sdk[all]==7.2.0rc19
   # nvidia-tao-automl pulls nvidia-tao-sdk as a transitive dep. One entry per
   # platform extra; append `,llm` or `,wandb` to an extra at install time for
   # the agentic-search or experiment-tracking deps.
-  tao_automl_slurm:      nvidia-tao-automl[slurm]==7.1.0
-  tao_automl_kubernetes: nvidia-tao-automl[kubernetes]==7.1.0
-  tao_automl_docker:     nvidia-tao-automl[docker]==7.1.0
-  tao_automl_brev:       nvidia-tao-automl[brev]==7.1.0
-  tao_automl_all:        nvidia-tao-automl[all]==7.1.0
+  tao_automl_slurm:      nvidia-tao-automl[slurm]==7.2.0rc18
+  tao_automl_kubernetes: nvidia-tao-automl[kubernetes]==7.2.0rc18
+  tao_automl_docker:     nvidia-tao-automl[docker]==7.2.0rc18
+  tao_automl_brev:       nvidia-tao-automl[brev]==7.2.0rc18
+  tao_automl_all:        nvidia-tao-automl[all]==7.2.0rc18


### PR DESCRIPTION
## Reported issue

NVBug 6602338: following the README/default marketplace installation returned a 0.1.12 skill bank pinned to TAO 7.1 images; the prepared TAO 7.2 release was not reachable through the public release entrypoint.

Revalidation also found that the shared root marketplace exposed only the legacy Claude entry name `tao-skills`. The Codex evaluator derives the canonical plugin name `tao-skill-bank` from `.codex-plugin/plugin.json`, registered the root marketplace successfully, and then could not install that name.

## Original reproductions and observed failures

1. Install the repository through its default local marketplace flow.
2. Inspect the installed plugin version and `versions.yaml` image resolution.
3. Prepare an IAA config from that installation.

Before the release fix, the installed manifests advertised 0.1.12 and the central image catalog plus stamped consumers resolved the 7.1 PyTorch/data-services images.

For the Codex install failure, register the repository root as the shared marketplace and run `codex plugin add tao-skill-bank@tao-skill-bank`. Before the follow-up fix, this failed with `plugin tao-skill-bank was not found in marketplace tao-skill-bank`, even though the canonical Codex manifest had exactly that name. The CI skill evaluator reproduced the same failure on commit `41ba8ad`.

## Root causes

- The release source of truth was never advanced: manifest version metadata remained 0.1.12 and `versions.yaml` still selected the 7.1 release. Generated/stamped skill references correctly followed that stale catalog, making 7.2 unreachable even though the repository contained the intended release work.
- The cross-client marketplace and the Codex plugin manifest had divergent plugin identifiers. The marketplace listed only `tao-skills`, while Codex installs `.codex-plugin/plugin.json` by its stable `tao-skill-bank` name.

## Implementation summary

- Advance Claude and Codex plugin manifests/marketplace metadata to 0.1.13.
- Advance the central TAO image and wheel catalog to the approved 7.2 release candidates.
- Regenerate all annotated consumers from the catalog, including IAA's immutable image pins.
- Add release-install and IAA pin-parity regressions.
- Expose `tao-skill-bank` as the canonical cross-client entry in the shared marketplace while retaining `tao-skills` as a compatibility entry for existing Claude installations.
- Add a regression that requires the canonical Codex manifest name to be discoverable from the shared marketplace and preserves the legacy Claude alias.

## Why these are root-cause fixes

Version selection is corrected at the repository's two authoritative release layers—the plugin manifests and central version catalog—and all consumers are regenerated from those sources. Installers and every skill therefore receive the same release without per-skill overrides.

The install repair aligns discovery with the canonical plugin identity at the marketplace boundary. It does not change evaluator behavior or special-case CI. Keeping the legacy alias avoids breaking current Claude users while ensuring Codex can resolve the name its manifest declares.

## Shortcuts intentionally avoided

The change does not hardcode 7.2 only in the IAA README or preparation script, leave installed metadata at 0.1.12, or add runtime fallback resolution. Those approaches would keep the default installed product internally inconsistent.

For the install failure, it does not rename/remove the existing `tao-skills` entry, alter the evaluator to ask for the wrong name, or suppress a failed plugin installation. Those approaches would either break compatibility or mask an invalid distributable marketplace.

## Regression coverage and exact post-fix verification

- Exact isolated Codex reproduction: with only the shared marketplace visible, `codex plugin marketplace add <branch-root>` registered `tao-skill-bank`, then `codex plugin add tao-skill-bank@tao-skill-bank` succeeded and installed plugin version **0.1.13**. The temporary marketplace/plugin registration was removed afterward and the existing local TAO plugin remained installed.
- `claude plugin validate .` — **passed** with only the pre-existing missing-author warnings; both the canonical and legacy entries resolve.
- `python -m pytest -q scripts/tests` — **363 passed, 2 skipped**.
- `python -m pytest -q scripts/tests/test_release_install_contract.py` — **3 passed**.
- `scripts/validate-skills.sh` — **passed**.
- `python scripts/stamp_versions.py --check` — **passed**, 0 stray warnings.
- `git diff --check` — **passed**.

## Residual risks or limitations

The selected images are staging release candidates and require normal registry access. They were not locally cached, so this verification did not pull or execute them; it verified installation, catalog resolution, generated pin parity, and the full repository suite. The public default-branch install will expose this release after the PR is merged; this PR does not merge it.
