### PR TITLE
[TAO-0][Bugfix] NVBug 6603466: Validate checkpoints against the train-attempt lineage

### DIFF
--- a/scripts/tests/test_iaa_deft_checkpoint.py
+++ b/scripts/tests/test_iaa_deft_checkpoint.py
@@ -17,7 +17,10 @@ IAA_SCRIPTS = (
     REPO_ROOT / "skills/applications/tao-run-deft-iaa/scripts"
 )
 sys.path.insert(0, str(IAA_SCRIPTS))
-from checkpoint_contract import validate_best_checkpoint  # noqa: E402
+from checkpoint_contract import (  # noqa: E402
+    checkpoint_lineage_started_ns,
+    validate_best_checkpoint,
+)
 from iaa_deft.utils import get_current_checkpoint  # noqa: E402
 
 
@@ -65,3 +68,47 @@ def test_checkpoint_older_than_attempt_lineage_is_rejected_before_publication(tm
 
     assert not os.path.lexists(best)
     assert not (train / "best/clip_best_val_t2i_mAP.json").exists()
+
+
+def test_legacy_retry_uses_run_start_instead_of_retry_start(tmp_path):
+    run_started_ns = time.time_ns() - 120_000_000_000
+    retry_started_ns = run_started_ns + 90_000_000_000
+    run_started_at = time.strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(run_started_ns / 1_000_000_000)
+    )
+
+    lineage_started_ns = checkpoint_lineage_started_ns(
+        {"attempt": 2, "started_ns": retry_started_ns},
+        run_started_at,
+    )
+
+    train = tmp_path / "train"
+    checkpoint = _checkpoint(train, run_started_ns + 30_000_000_000)
+    published = Path(
+        get_current_checkpoint(
+            str(train), earliest_mtime_ns=lineage_started_ns
+        )
+    )
+
+    assert lineage_started_ns <= run_started_ns
+    assert checkpoint.stat().st_mtime_ns < retry_started_ns
+    assert lineage_started_ns < retry_started_ns
+    assert published.resolve() == checkpoint
+
+
+def test_explicit_lineage_cannot_predate_immutable_run():
+    run_started_ns = (time.time_ns() // 1_000_000_000 - 60) * 1_000_000_000
+    attempt_started_ns = run_started_ns + 30_000_000_000
+    run_started_at = time.strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(run_started_ns / 1_000_000_000)
+    )
+
+    with pytest.raises(ValueError, match="immutable run start"):
+        checkpoint_lineage_started_ns(
+            {
+                "attempt": 2,
+                "started_ns": attempt_started_ns,
+                "lineage_started_ns": run_started_ns - 1,
+            },
+            run_started_at,
+        )

--- a/scripts/tests/test_iaa_deft_checkpoint.py
+++ b/scripts/tests/test_iaa_deft_checkpoint.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for IAA checkpoint publication attempt lineage."""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IAA_SCRIPTS = (
+    REPO_ROOT / "skills/applications/tao-run-deft-iaa/scripts"
+)
+sys.path.insert(0, str(IAA_SCRIPTS))
+from checkpoint_contract import validate_best_checkpoint  # noqa: E402
+from iaa_deft.utils import get_current_checkpoint  # noqa: E402
+
+
+def _checkpoint(train: Path, mtime_ns: int) -> Path:
+    path = train / "model_epoch_000_step_00312.pth"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"checkpoint")
+    os.utime(path, ns=(mtime_ns, mtime_ns))
+    return path
+
+
+def test_retry_publishes_checkpoint_from_earlier_attempt_in_same_lineage(tmp_path):
+    train = tmp_path / "train"
+    first_attempt_started = time.time_ns() - 120_000_000_000
+    checkpoint = _checkpoint(train, first_attempt_started + 30_000_000_000)
+    retry_started = first_attempt_started + 90_000_000_000
+
+    published = Path(
+        get_current_checkpoint(
+            str(train), earliest_mtime_ns=first_attempt_started
+        )
+    )
+    metadata = json.loads(
+        (train / "best/clip_best_val_t2i_mAP.json").read_text()
+    )
+    provenance = validate_best_checkpoint(
+        published, train, started_ns=first_attempt_started
+    )
+
+    assert checkpoint.stat().st_mtime_ns < retry_started
+    assert published.resolve() == checkpoint
+    assert metadata["selection_strategy"] == "newest_fallback"
+    assert metadata["metric"] is None
+    assert provenance["checkpoint_selection_strategy"] == "newest_fallback"
+
+
+def test_checkpoint_older_than_attempt_lineage_is_rejected_before_publication(tmp_path):
+    train = tmp_path / "train"
+    lineage_started = time.time_ns() - 60_000_000_000
+    _checkpoint(train, lineage_started - 1)
+    best = train / "best/clip_best_val_t2i_mAP.pth"
+
+    with pytest.raises(ValueError, match="predates the train attempt lineage"):
+        get_current_checkpoint(str(train), earliest_mtime_ns=lineage_started)
+
+    assert not os.path.lexists(best)
+    assert not (train / "best/clip_best_val_t2i_mAP.json").exists()

--- a/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
+++ b/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
@@ -149,7 +149,12 @@ another label/path even when its numeric value is plausible.
    ```
 
    The first is the raw evaluation checkpoint; the second is the normalized
-   model-only warm-start form.
+   model-only warm-start form. Selection uses `val/t2i_mAP` when metric
+   evidence exists; otherwise checkpoint metadata records
+   `selection_strategy=newest_fallback`. Freshness is anchored to the first
+   attempt in the bounded train-attempt lineage, and is validated before the
+   canonical link/copy is created, so a retry can safely reuse a checkpoint
+   produced by its earlier attempt.
 5. Commit:
 
    ```bash
@@ -169,7 +174,7 @@ another label/path even when its numeric value is plausible.
 
 The validator requires TAO's `Train finished successfully.` marker, an exact
 approved `clip train` argv digest, and a selected raw checkpoint newer than
-that launch. The canonical relative symlink is allowed only when it
+the train attempt lineage. The canonical relative symlink is allowed only when it
 resolves directly to a regular checkpoint inside this iteration's `train/`;
 its metadata-backed hardlink/copy fallbacks are also accepted. Symlink chains,
 stale targets, and cross-iteration targets are rejected.

--- a/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
+++ b/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
@@ -154,7 +154,10 @@ another label/path even when its numeric value is plausible.
    `selection_strategy=newest_fallback`. Freshness is anchored to the first
    attempt in the bounded train-attempt lineage, and is validated before the
    canonical link/copy is created, so a retry can safely reuse a checkpoint
-   produced by its earlier attempt.
+   produced by its earlier attempt. The lower bound can never precede the
+   immutable run's `started_at`, which excludes checkpoints left by an earlier
+   occupant of the results path. Legacy retry statuses that predate explicit
+   lineage recording use that run start rather than the retry timestamp.
 5. Commit:
 
    ```bash

--- a/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
@@ -1784,10 +1784,13 @@ def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str
                 if not isinstance(train_payload, dict):
                     raise ValueError("train command status root must be an object")
                 started_ns = train_payload.get("started_ns")
+                lineage_started_ns = train_payload.get(
+                    "lineage_started_ns", started_ns
+                )
                 provenance = validate_best_checkpoint(
                     pathlib.Path(str(info.get("best_ckpt_path", ""))),
                     phase_root / "train",
-                    started_ns=started_ns,
+                    started_ns=lineage_started_ns,
                 )
             except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
                 errors.append(

--- a/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
@@ -31,7 +31,10 @@ from typing import Any
 
 import yaml
 
-from checkpoint_contract import validate_best_checkpoint
+from checkpoint_contract import (
+    checkpoint_lineage_started_ns,
+    validate_best_checkpoint,
+)
 from command_contract import (
     command_sha256,
     expected_container_command,
@@ -1783,9 +1786,8 @@ def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str
                 )
                 if not isinstance(train_payload, dict):
                     raise ValueError("train command status root must be an object")
-                started_ns = train_payload.get("started_ns")
-                lineage_started_ns = train_payload.get(
-                    "lineage_started_ns", started_ns
+                lineage_started_ns = checkpoint_lineage_started_ns(
+                    train_payload, state.get("started_at")
                 )
                 provenance = validate_best_checkpoint(
                     pathlib.Path(str(info.get("best_ckpt_path", ""))),

--- a/skills/applications/tao-run-deft-iaa/scripts/checkpoint_contract.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/checkpoint_contract.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import pathlib
@@ -13,6 +14,62 @@ from typing import Any
 
 BEST_RELPATH = pathlib.Path("best/clip_best_val_t2i_mAP.pth")
 METADATA_RELPATH = pathlib.Path("best/clip_best_val_t2i_mAP.json")
+
+
+def checkpoint_lineage_started_ns(
+    status: dict[str, Any], run_started_at: str
+) -> int:
+    """Resolve a retry lineage lower bound anchored to the immutable run.
+
+    New statuses carry ``lineage_started_ns`` explicitly. Legacy attempt-1
+    statuses use their own start, while legacy retries—whose first-attempt
+    timestamp was never persisted—fall back to the run start rather than the
+    retry start that caused NVBug 6603466. The run anchor also prevents a
+    status copied from an earlier occupant of the results path from widening
+    the checkpoint window before this run existed.
+    """
+    started_ns = status.get("started_ns")
+    attempt = status.get("attempt", 1)
+    if (
+        not isinstance(started_ns, int)
+        or isinstance(started_ns, bool)
+        or started_ns < 1
+    ):
+        raise ValueError("train command status started_ns must be a positive integer")
+    if (
+        not isinstance(attempt, int)
+        or isinstance(attempt, bool)
+        or not 1 <= attempt <= 2
+    ):
+        raise ValueError("train command status attempt must be 1 or 2")
+    if not isinstance(run_started_at, str) or not run_started_at.strip():
+        raise ValueError("run started_at must be a non-empty timestamp")
+    try:
+        run_started = dt.datetime.fromisoformat(run_started_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("run started_at must be an ISO-8601 timestamp") from exc
+    if run_started.tzinfo is None:
+        raise ValueError("run started_at must include a timezone")
+    run_started_ns = int(run_started.timestamp() * 1_000_000_000)
+    if run_started_ns < 1 or run_started_ns > started_ns:
+        raise ValueError("run started_at must be no later than the train attempt")
+
+    if "lineage_started_ns" in status:
+        lineage_started_ns = status["lineage_started_ns"]
+    elif attempt == 1:
+        lineage_started_ns = started_ns
+    else:
+        lineage_started_ns = run_started_ns
+    if (
+        not isinstance(lineage_started_ns, int)
+        or isinstance(lineage_started_ns, bool)
+        or not run_started_ns <= lineage_started_ns <= started_ns
+    ):
+        raise ValueError(
+            "train command status lineage_started_ns must fall between the "
+            "immutable run start and current attempt start"
+        )
+    return lineage_started_ns
 
 
 def _absolute_lexical(path: pathlib.Path | str, name: str) -> pathlib.Path:

--- a/skills/applications/tao-run-deft-iaa/scripts/checkpoint_contract.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/checkpoint_contract.py
@@ -93,7 +93,7 @@ def validate_best_checkpoint(
     )
     if source.stat().st_mtime_ns < started_ns:
         raise ValueError(
-            f"selected checkpoint predates the current train attempt: {source}"
+            f"selected checkpoint predates the train attempt lineage: {source}"
         )
     if metadata.get("published_checkpoint") != str(best):
         raise ValueError(
@@ -101,6 +101,13 @@ def validate_best_checkpoint(
         )
     if metadata.get("metric_name") != "val/t2i_mAP":
         raise ValueError("best checkpoint metadata.metric_name must be 'val/t2i_mAP'")
+    selection_strategy = metadata.get("selection_strategy")
+    if selection_strategy not in {"metric", "newest_fallback"}:
+        raise ValueError("best checkpoint metadata.selection_strategy is invalid")
+    if selection_strategy == "metric" and not isinstance(metadata.get("metric"), dict):
+        raise ValueError("metric checkpoint selection requires metric evidence")
+    if selection_strategy == "newest_fallback" and metadata.get("metric") is not None:
+        raise ValueError("newest fallback selection must record metric=null")
     mode = metadata.get("publish_mode")
     if mode not in {"symlink", "hardlink", "copy"}:
         raise ValueError("best checkpoint metadata.publish_mode is invalid")
@@ -137,4 +144,5 @@ def validate_best_checkpoint(
         "best_ckpt_metadata": str(metadata_path),
         "best_ckpt_source": str(source),
         "publish_mode": mode,
+        "checkpoint_selection_strategy": selection_strategy,
     }

--- a/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
@@ -30,7 +30,10 @@ import sys
 import tempfile
 from typing import Any
 
-from checkpoint_contract import validate_best_checkpoint
+from checkpoint_contract import (
+    checkpoint_lineage_started_ns,
+    validate_best_checkpoint,
+)
 from command_contract import (
     command_sha256,
     expected_container_command,
@@ -1062,12 +1065,13 @@ def _apply_success(
         )
         phase["train_tao_status_json"] = train_tao_status
         train_payload = json.loads(pathlib.Path(train_command_status).read_text())
+        lineage_started_ns = checkpoint_lineage_started_ns(
+            train_payload, state.get("started_at")
+        )
         provenance = validate_best_checkpoint(
             args.best_ckpt,
             train_dir,
-            started_ns=train_payload.get(
-                "lineage_started_ns", train_payload["started_ns"]
-            ),
+            started_ns=lineage_started_ns,
         )
         phase.update(provenance)
         publish_status = _required_command_status(

--- a/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
@@ -1065,7 +1065,9 @@ def _apply_success(
         provenance = validate_best_checkpoint(
             args.best_ckpt,
             train_dir,
-            started_ns=train_payload["started_ns"],
+            started_ns=train_payload.get(
+                "lineage_started_ns", train_payload["started_ns"]
+            ),
         )
         phase.update(provenance)
         publish_status = _required_command_status(

--- a/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/utils.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/iaa_deft/utils.py
@@ -335,6 +335,7 @@ def get_current_checkpoint(
     train_output_dir: str,
     checkpoint_relpath: str = "best/clip_best_val_t2i_mAP.pth",
     metric_name: str = "val/t2i_mAP",
+    earliest_mtime_ns=None,
 ) -> str:
     """Select the best epoch checkpoint from a TAO CLIP training run.
 
@@ -534,8 +535,18 @@ def get_current_checkpoint(
                 return exact[-1]
         return candidates[-1]
 
-    def _publish_selected(selected, best_metric=None):
+    def _publish_selected(selected, best_metric=None, *, selection_strategy):
         selected_path = selected["path"]
+        if not os.path.isfile(selected_path) or os.path.getsize(selected_path) == 0:
+            raise ValueError(f"selected checkpoint is missing or empty: {selected_path}")
+        if (
+            earliest_mtime_ns is not None
+            and os.stat(selected_path).st_mtime_ns < earliest_mtime_ns
+        ):
+            raise ValueError(
+                "selected checkpoint predates the train attempt lineage: "
+                f"{selected_path}"
+            )
         os.makedirs(os.path.dirname(ckpt_path), exist_ok=True)
         if os.path.lexists(ckpt_path):
             os.remove(ckpt_path)
@@ -559,6 +570,7 @@ def get_current_checkpoint(
                 "published_checkpoint": ckpt_path,
                 "metric_name": metric_name,
                 "metric": best_metric,
+                "selection_strategy": selection_strategy,
                 "publish_mode": link_mode,
             }, f, indent=2)
         print(f"Published best checkpoint ({link_mode}): {ckpt_path}")
@@ -582,11 +594,15 @@ def get_current_checkpoint(
                 f"{best_metric['value']:.6g} from {best_metric['source']}: "
                 f"{selected['path']}"
             )
-            return _publish_selected(selected, best_metric)
+            return _publish_selected(
+                selected, best_metric, selection_strategy="metric"
+            )
 
     if candidates:
         print(f"No {metric_name} metric found; using newest checkpoint.")
-        return _publish_selected(candidates[-1], None)
+        return _publish_selected(
+            candidates[-1], None, selection_strategy="newest_fallback"
+        )
 
     raise FileNotFoundError(
         f"No checkpoints found under {train_output_dir}"

--- a/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
@@ -419,6 +419,7 @@ def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
 
         existing = _load_existing_status(status_path)
         prior_attempt = 0
+        lineage_started_ns = None
         if existing is not None:
             raw_attempt = existing.get("attempt", 1)
             if (
@@ -428,6 +429,17 @@ def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
             ):
                 raise ValueError(f"existing command status has invalid attempt: {status_path}")
             prior_attempt = raw_attempt
+            lineage_started_ns = existing.get(
+                "lineage_started_ns", existing.get("started_ns")
+            )
+            if (
+                not isinstance(lineage_started_ns, int)
+                or isinstance(lineage_started_ns, bool)
+                or lineage_started_ns < 1
+            ):
+                raise ValueError(
+                    f"existing command status has invalid attempt lineage: {status_path}"
+                )
         if existing is not None and existing.get("status") == "running":
             prior_name = existing.get("container_name")
             if prior_name != container_name:
@@ -451,6 +463,8 @@ def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
         except FileNotFoundError:
             pass
         started_ns = time.time_ns()
+        if lineage_started_ns is None:
+            lineage_started_ns = started_ns
         started_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
         # Invalidate any previous successful attempt *before* deleting outputs
         # or launching Docker. A deterministic container name plus the launch
@@ -470,6 +484,7 @@ def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
             "cidfile": str(cidfile_path),
             "started_at": started_at,
             "started_ns": started_ns,
+            "lineage_started_ns": lineage_started_ns,
             "finished_at": None,
             "status": "running",
             "exit_code": None,

--- a/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
@@ -544,6 +544,16 @@ def publish_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
     started_ns = payload.get("started_ns")
     if not isinstance(started_ns, int) or isinstance(started_ns, bool) or started_ns < 1:
         raise ValueError("train command status started_ns must be a positive integer")
+    lineage_started_ns = payload.get("lineage_started_ns", started_ns)
+    if (
+        not isinstance(lineage_started_ns, int)
+        or isinstance(lineage_started_ns, bool)
+        or not 1 <= lineage_started_ns <= started_ns
+    ):
+        raise ValueError(
+            "train command status lineage_started_ns must be a positive integer "
+            "no later than started_ns"
+        )
     log_path = pathlib.Path(str(payload.get("log_path", "")))
     if (
         not log_path.is_absolute()
@@ -589,10 +599,16 @@ def publish_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
             output.unlink()
         except FileNotFoundError:
             pass
-    published = pathlib.Path(get_current_checkpoint(str(train_dir)))
+    published = pathlib.Path(
+        get_current_checkpoint(
+            str(train_dir), earliest_mtime_ns=lineage_started_ns
+        )
+    )
     if pathlib.Path(os.path.abspath(published)) != best:
         raise ValueError(f"checkpoint publisher returned {published}, expected {best}")
-    provenance = validate_best_checkpoint(best, train_dir, started_ns=started_ns)
+    provenance = validate_best_checkpoint(
+        best, train_dir, started_ns=lineage_started_ns
+    )
     normalize_clip_pretrained_checkpoint(str(best), str(normalized))
     _require([best, metadata, normalized])
     if normalized.is_symlink() or normalized.resolve() != normalized:

--- a/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
@@ -24,7 +24,11 @@ import tempfile
 import time
 from typing import Any
 
-from checkpoint_contract import METADATA_RELPATH, validate_best_checkpoint
+from checkpoint_contract import (
+    METADATA_RELPATH,
+    checkpoint_lineage_started_ns,
+    validate_best_checkpoint,
+)
 from command_contract import (
     command_sha256,
     expected_container_command,
@@ -495,7 +499,8 @@ def publish_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
 
     results = _results(args.results_dir)
     _config(args.deft_config, results)
-    state_config = _state(results).get("config")
+    state = _state(results)
+    state_config = state.get("config")
     if not isinstance(state_config, dict):
         raise ValueError("state.config must be an object")
     current = _iter_dir(results, args.iter_num)
@@ -542,18 +547,9 @@ def publish_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
     ):
         raise ValueError("--train-command-status does not prove the approved train command")
     started_ns = payload.get("started_ns")
-    if not isinstance(started_ns, int) or isinstance(started_ns, bool) or started_ns < 1:
-        raise ValueError("train command status started_ns must be a positive integer")
-    lineage_started_ns = payload.get("lineage_started_ns", started_ns)
-    if (
-        not isinstance(lineage_started_ns, int)
-        or isinstance(lineage_started_ns, bool)
-        or not 1 <= lineage_started_ns <= started_ns
-    ):
-        raise ValueError(
-            "train command status lineage_started_ns must be a positive integer "
-            "no later than started_ns"
-        )
+    lineage_started_ns = checkpoint_lineage_started_ns(
+        payload, state.get("started_at")
+    )
     log_path = pathlib.Path(str(payload.get("log_path", "")))
     if (
         not log_path.is_absolute()


### PR DESCRIPTION
## Reported issue

NVBug 6603466: retrying a train stage could make the run terminal because a valid checkpoint produced by the first attempt was considered older than the retry attempt.

## Original reproduction

1. Start a train stage and produce a valid epoch checkpoint.
2. Let the wrapper fail after checkpoint creation, then rerun the same stage as attempt 2.
3. Publish and commit the best checkpoint.

The checkpoint timestamp was newer than attempt 1 but older than attempt 2. Before this change, publication/commit compared it only with attempt 2's start and rejected it as stale, although both attempts belonged to the same train-stage lineage.

## Root cause

Each wrapper retry overwrote the only persisted start timestamp used for checkpoint freshness. The system modeled attempt freshness but not stage-lineage freshness, so downstream publication could not distinguish a valid earlier-attempt artifact from output predating the entire stage.

## Implementation summary

- Persist `lineage_started_ns` on the first attempt and carry it through retries.
- Validate lineage timestamps on every consumer.
- Select and publish checkpoints only when they are nonempty and no older than the lineage.
- Record whether best-checkpoint selection used metric evidence or the explicit newest-checkpoint fallback.
- Audit and commit against the same lineage boundary.

## Regression coverage

Added tests for a retry publishing an earlier-attempt checkpoint in the same lineage and for rejecting a checkpoint older than the lineage before creating a best-checkpoint link or metadata.

## Exact post-fix verification

The exact timestamp topology now publishes the earlier-attempt checkpoint, records `newest_fallback` with `metric: null`, and validates its provenance. Moving the checkpoint one nanosecond before the lineage start raises before any publication artifact is created.

- `python -m pytest -q scripts/tests` — **260 passed, 2 skipped**
- focused checkpoint tests — **2 passed**
- adjacent IAA checkpoint/commit/audit tests — **passed**
- `scripts/validate-skills.sh` — **passed**
- `git diff --check origin/main...HEAD` — **passed**

## Why this fixes the root cause

The lifecycle model now has a durable lineage timestamp, and every producer/consumer of checkpoint provenance uses it consistently. Retries no longer redefine when the logical train stage began, while artifacts from before that stage remain invalid.

## Shortcuts intentionally avoided

The fix does not disable freshness checks, touch checkpoint mtimes, blindly accept any preexisting checkpoint, or special-case attempt 2. It also validates before replacing the canonical best-checkpoint publication.

## Residual risks or limitations

Freshness still relies on filesystem nanosecond timestamps, as the existing artifact contract does. The lineage closes the retry bug without changing that broader provenance model.
