### PR TITLE
[TAO-0][Bugfix] Render platform action contracts safely on Kubernetes

### DIFF
--- a/scripts/ci/render_and_validate_templates.py
+++ b/scripts/ci/render_and_validate_templates.py
@@ -58,6 +58,26 @@ K8S_VALS = {
     "MOUNT_PATH": "/data",
     "SHM_SIZE": "16Gi",
     "PVC_CLAIM": "edgeai-datasets",
+    # Platform-neutral action request template. JSON is valid YAML and is the
+    # exact encoding used by render_action_job.py.
+    "JOB_NAME_JSON": '"nightly-contract-0001"',
+    "JOB_ID_JSON": '"nightly-contract-0001"',
+    "NAMESPACE_JSON": '"default"',
+    "TTL_SECONDS_JSON": "3600",
+    "IMAGE_PULL_SECRETS_JSON": '[{"name":"ngc-pull-secret"}]',
+    "IMAGE_JSON": '"nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"',
+    "COMMAND_JSON": '["python3"]',
+    "ARGS_JSON": '["-c","print(1)"]',
+    "NUM_GPUS_JSON": '"1"',
+    "ENV_FROM_JSON": '[]',
+    "ENV_JSON": '[{"name":"HOME","value":"/tmp"}]',
+    "VOLUME_MOUNTS_JSON": (
+        '[{"name":"dshm","mountPath":"/dev/shm","readOnly":false},'
+        '{"name":"workspace","mountPath":"/results",'
+        '"subPath":"jobs/nightly/results","readOnly":false}]'
+    ),
+    "SHM_SIZE_JSON": '"16Gi"',
+    "PVC_CLAIM_JSON": '"edgeai-datasets"',
 }
 SLURM_VALS = {
     **COMMON,

--- a/scripts/ci/render_and_validate_templates.py
+++ b/scripts/ci/render_and_validate_templates.py
@@ -69,7 +69,6 @@ K8S_VALS = {
     "COMMAND_JSON": '["python3"]',
     "ARGS_JSON": '["-c","print(1)"]',
     "NUM_GPUS_JSON": '"1"',
-    "ENV_FROM_JSON": '[]',
     "ENV_JSON": '[{"name":"HOME","value":"/tmp"}]',
     "VOLUME_MOUNTS_JSON": (
         '[{"name":"dshm","mountPath":"/dev/shm","readOnly":false},'

--- a/scripts/tests/test_k8s_action_renderer.py
+++ b/scripts/tests/test_k8s_action_renderer.py
@@ -130,7 +130,7 @@ def test_no_credentials_or_registry_secret_means_no_dangling_secret_refs():
     job, action = container(render())
     pod = job["spec"]["template"]["spec"]
     assert pod["imagePullSecrets"] == []
-    assert action["envFrom"] == []
+    assert "envFrom" not in action
 
 
 def test_forwarded_credentials_are_secret_references_not_inline_values():
@@ -145,12 +145,39 @@ def test_forwarded_credentials_are_secret_references_not_inline_values():
     assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [
         {"name": "ngc-pull-secret"}
     ]
-    assert action["envFrom"] == [
-        {"secretRef": {"name": "tao-creds-abc123"}}
-    ]
-    inline_names = {item["name"] for item in action["env"]}
-    assert "HF_TOKEN" not in inline_names
-    assert "HF_TOKEN" not in manifest
+    assert "envFrom" not in action
+    environment = {item["name"]: item for item in action["env"]}
+    assert environment["HF_TOKEN"] == {
+        "name": "HF_TOKEN",
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": "tao-creds-abc123",
+                "key": "HF_TOKEN",
+            }
+        },
+    }
+
+
+def test_secret_projects_only_explicitly_forwarded_names():
+    request = iaa_pool_embed_request()
+    request["forward_env"] = ["HF_TOKEN", "AWS_ACCESS_KEY_ID"]
+    _, action = container(
+        render(request=request, credential_secret="shared-credential-secret")
+    )
+
+    assert "envFrom" not in action
+    forwarded = {
+        item["name"]: item["valueFrom"]["secretKeyRef"]
+        for item in action["env"]
+        if "valueFrom" in item
+    }
+    assert forwarded == {
+        "HF_TOKEN": {"name": "shared-credential-secret", "key": "HF_TOKEN"},
+        "AWS_ACCESS_KEY_ID": {
+            "name": "shared-credential-secret",
+            "key": "AWS_ACCESS_KEY_ID",
+        },
+    }
 
 
 def test_forwarded_credentials_require_a_secret():
@@ -160,12 +187,28 @@ def test_forwarded_credentials_require_a_secret():
         render(request=request)
 
 
+def test_credential_secret_is_rejected_when_no_names_are_approved():
+    with pytest.raises(renderer.RenderError, match="must be omitted"):
+        render(credential_secret="unexpected-shared-secret")
+
+
 def test_inline_and_forwarded_name_collision_is_rejected():
     request = iaa_pool_embed_request()
     request["environment"]["HF_TOKEN"] = "must-not-be-inline"
     request["forward_env"] = ["HF_TOKEN"]
     with pytest.raises(renderer.RenderError, match="must not be present"):
         render(request=request, credential_secret="tao-creds-abc123")
+
+
+@pytest.mark.parametrize("schema_version", [None, "0", "2", 1])
+def test_unsupported_request_schema_version_is_rejected(schema_version):
+    request = iaa_pool_embed_request()
+    if schema_version is None:
+        request.pop("schema_version")
+    else:
+        request["schema_version"] = schema_version
+    with pytest.raises(renderer.RenderError, match="request.schema_version"):
+        render(request=request)
 
 
 def test_command_tokens_are_not_interpolated_into_a_shell_string():

--- a/scripts/tests/test_k8s_action_renderer.py
+++ b/scripts/tests/test_k8s_action_renderer.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import stat
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -82,6 +84,37 @@ def iaa_staging_map():
             {"source": CACHE, "sub_path": "jobs/abc123/cache"},
         ],
     }
+
+
+def config_request(config_format="yaml", command="visual_changenet train -e {config_path}"):
+    """A producer-owned mode=config request, as emitted by DEFT stages."""
+    request = iaa_pool_embed_request()
+    bundle = request["spec_bundle"]
+    bundle.pop("args")
+    bundle.update(
+        {
+            "mode": "config",
+            "command": command,
+            "config_format": config_format,
+            "spec": {
+                "dataset": {"batch_size": 4, "class_names": ["OK", "NG"]},
+                "train": {"num_epochs": 2, "use_amp": True},
+            },
+        }
+    )
+    return request
+
+
+def materialize_and_stage(tmp_path, request):
+    source = renderer.materialize_config(request, tmp_path / "rendered-configs")
+    staging = iaa_staging_map()
+    staging["sources"].append(
+        {
+            "source": str(source),
+            "sub_path": f"jobs/abc123/config/{source.name}",
+        }
+    )
+    return source, staging
 
 
 def render(request=None, staging=None, **kwargs):
@@ -219,6 +252,146 @@ def test_command_tokens_are_not_interpolated_into_a_shell_string():
     assert action["args"][-1] == "literal=$(do-not-run); 'quoted'"
 
 
+def test_explicit_args_mode_shell_is_rendered_as_native_argv():
+    request = iaa_pool_embed_request()
+    request["spec_bundle"]["command"] = "bash -lc"
+    request["spec_bundle"]["args"] = ["printf '%s\\n' \"$HOME\""]
+    _, action = container(render(request=request))
+    assert action["command"] == ["bash", "-lc"]
+    assert action["args"] == ["printf '%s\\n' \"$HOME\""]
+
+
+def test_config_mode_materializes_stages_and_mounts_the_exact_spec(tmp_path):
+    request = config_request()
+    source, staging = materialize_and_stage(tmp_path, request)
+
+    _, action = container(
+        render(
+            request=request,
+            staging=staging,
+            config_source=source,
+        )
+    )
+
+    expected = "/tao-action-config/spec-" + source.stem.removeprefix(
+        "tao-action-config-"
+    ) + ".yaml"
+    assert action["command"] == ["visual_changenet", "train", "-e", expected]
+    assert action["args"] == []
+    assert "{config_path}" not in json.dumps(action)
+    config_mount = next(
+        mount for mount in action["volumeMounts"] if mount["mountPath"] == expected
+    )
+    assert config_mount == {
+        "name": "workspace",
+        "mountPath": expected,
+        "subPath": f"jobs/abc123/config/{source.name}",
+        "readOnly": True,
+    }
+    assert yaml.safe_load(source.read_text(encoding="utf-8")) == request["spec_bundle"]["spec"]
+
+
+@pytest.mark.parametrize("config_format", ["json", "yaml"])
+def test_json_compatible_config_materialization_is_canonical_and_idempotent(
+    tmp_path, config_format
+):
+    request = config_request(config_format)
+    request["spec_bundle"]["spec"]["optional"] = None
+    first = renderer.materialize_config(request, tmp_path / "configs")
+    second = renderer.materialize_config(request, tmp_path / "configs")
+
+    assert first == second
+    assert len(first.stem.removeprefix("tao-action-config-")) == 64
+    assert stat.S_IMODE(first.stat().st_mode) == 0o600
+    assert json.loads(first.read_text(encoding="utf-8")) == request["spec_bundle"]["spec"]
+
+
+def test_toml_config_materialization_preserves_nested_values(tmp_path):
+    request = config_request("toml", "cosmos-rl --config {config_path} train.py")
+    request["spec_bundle"]["spec"]["train"]["schedulers"] = [
+        {"name": "warmup", "steps": 5},
+        {"name": "cosine", "steps": 20},
+    ]
+    source = renderer.materialize_config(request, tmp_path / "configs")
+
+    with source.open("rb") as handle:
+        assert tomllib.load(handle) == request["spec_bundle"]["spec"]
+
+
+def test_toml_rejects_null_instead_of_silently_changing_it(tmp_path):
+    request = config_request("toml")
+    request["spec_bundle"]["spec"]["train"]["optional"] = None
+    with pytest.raises(renderer.RenderError, match="NoneType"):
+        renderer.materialize_config(request, tmp_path / "configs")
+
+
+def test_config_mode_requires_the_materialize_stage_render_sequence():
+    with pytest.raises(renderer.RenderError, match="materialize-config"):
+        render(request=config_request())
+
+
+def test_config_source_must_be_declared_by_the_staging_receipt(tmp_path):
+    request = config_request()
+    source = renderer.materialize_config(request, tmp_path / "configs")
+    with pytest.raises(renderer.RenderError, match="no staged PVC subPath"):
+        render(request=request, config_source=source)
+
+
+def test_stale_or_altered_config_source_is_rejected(tmp_path):
+    request = config_request()
+    source, staging = materialize_and_stage(tmp_path, request)
+    source.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(renderer.RenderError, match="does not match"):
+        render(request=request, staging=staging, config_source=source)
+
+
+def test_config_source_symlink_is_rejected(tmp_path):
+    request = config_request()
+    source, staging = materialize_and_stage(tmp_path, request)
+    link = tmp_path / "config-link.yaml"
+    link.symlink_to(source)
+    staging["sources"][-1]["source"] = str(link)
+    with pytest.raises(renderer.RenderError, match="cannot open|non-symlink"):
+        render(request=request, staging=staging, config_source=link)
+
+
+def test_config_command_must_contain_the_contract_placeholder(tmp_path):
+    request = config_request(command="visual_changenet train")
+    source, staging = materialize_and_stage(tmp_path, request)
+    with pytest.raises(renderer.RenderError, match=r"requires \{config_path\}"):
+        render(request=request, staging=staging, config_source=source)
+
+
+def test_args_mode_rejects_a_config_source(tmp_path):
+    source = tmp_path / "unexpected.yaml"
+    source.write_text("{}\n", encoding="utf-8")
+    staging = iaa_staging_map()
+    staging["sources"].append(
+        {"source": str(source), "sub_path": "jobs/abc123/unexpected.yaml"}
+    )
+    with pytest.raises(renderer.RenderError, match="only for spec_bundle.mode=config"):
+        render(staging=staging, config_source=source)
+
+
+def test_config_shell_script_is_preserved_for_cosmos_rl(tmp_path):
+    command = (
+        "hook=$(python -c 'import cosmos_rl; print(cosmos_rl.__file__)')\n"
+        "test -n \"$hook\"\n"
+        "exec cosmos-rl --config {config_path} \"$hook\""
+    )
+    request = config_request("toml", command)
+    source, staging = materialize_and_stage(tmp_path, request)
+    _, action = container(
+        render(request=request, staging=staging, config_source=source)
+    )
+
+    assert action["command"] == ["/bin/sh", "-c"]
+    assert action["args"][1] == "tao-action"
+    assert "hook=$(python" in action["args"][0]
+    assert "{config_path}" not in action["args"][0]
+    assert "/tao-action-config/spec-" in action["args"][0]
+
+
 def test_empty_argument_and_environment_value_are_preserved():
     request = iaa_pool_embed_request()
     request["spec_bundle"]["args"].append("")
@@ -350,6 +523,65 @@ def test_cli_renders_the_same_contract(tmp_path):
     job = yaml.safe_load(completed.stdout)
     assert job["kind"] == "Job"
     assert job["metadata"]["name"] == "tao-job-abc123"
+
+
+def test_cli_materializes_then_renders_a_config_mode_request(tmp_path):
+    request = config_request()
+    request_path = tmp_path / "action.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    materialized = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "materialize-config",
+            "--request",
+            str(request_path),
+            "--output-dir",
+            str(tmp_path / "configs"),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert materialized.returncode == 0, materialized.stderr
+    source = Path(materialized.stdout.strip())
+    staging = iaa_staging_map()
+    staging["sources"].append(
+        {
+            "source": str(source),
+            "sub_path": f"jobs/abc123/config/{source.name}",
+        }
+    )
+    staging_path = tmp_path / "staging.json"
+    staging_path.write_text(json.dumps(staging), encoding="utf-8")
+
+    rendered = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "render",
+            "--request",
+            str(request_path),
+            "--staging-map",
+            str(staging_path),
+            "--config-source",
+            str(source),
+            "--job-id",
+            "tao-job-abc123",
+            "--namespace",
+            "tao-jobs",
+            "--pvc-claim",
+            "tao-workspace",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert rendered.returncode == 0, rendered.stderr
+    _, action = container(rendered.stdout)
+    assert action["command"][:3] == ["visual_changenet", "train", "-e"]
+    assert action["volumeMounts"][-1]["readOnly"] is True
 
 
 def test_name_cli_returns_backend_object_name():

--- a/scripts/tests/test_k8s_action_renderer.py
+++ b/scripts/tests/test_k8s_action_renderer.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for producer action requests consumed by Kubernetes."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    REPO
+    / "skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py"
+)
+SPEC = importlib.util.spec_from_file_location("render_action_job", SCRIPT)
+assert SPEC and SPEC.loader
+renderer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(renderer)
+
+
+RESULTS = "/localhome/user/workspace/results/run_iaa_k8s"
+CONFIG = RESULTS + "/config"
+PATCHES = "/opt/tao-skill-bank/skills/applications/tao-run-deft-iaa/patches"
+CACHE = "/localhome/user/workspace/cache"
+
+
+def iaa_pool_embed_request():
+    """The five-mount shape emitted for a real IAA pool_embed action."""
+    output = RESULTS + "/embeddings/source/embeddings.parquet"
+    return {
+        "schema_version": "1",
+        "platform": "kubernetes",
+        "workload_image": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services",
+        "spec_bundle": {
+            "network_arch": "deft-iaa",
+            "action": "deft-iaa-pool_embed-abc123",
+            "image": "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services",
+            "mode": "args",
+            "command": "embedding",
+            "args": [
+                "text_embeddings",
+                "-e",
+                "/specs/text_embed_spec.yaml",
+                "input_parquet=/results/embeddings/source/source_pool.parquet",
+                "output_parquet=/results/embeddings/source/embeddings.parquet",
+            ],
+            "compute_shape": {"gpus": 1, "nodes": 1},
+        },
+        "mounts": [
+            {"source": RESULTS, "target": "/results", "read_only": False},
+            {"source": RESULTS, "target": RESULTS, "read_only": False},
+            {"source": CONFIG, "target": "/specs", "read_only": True},
+            {"source": PATCHES, "target": "/patches", "read_only": True},
+            {"source": CACHE, "target": "/cache", "read_only": False},
+        ],
+        "environment": {
+            "HOME": "/tmp",
+            "PYTHONPATH": "/patches",
+            "HF_HOME": "/cache/huggingface",
+            "XDG_CACHE_HOME": "/cache",
+        },
+        "forward_env": [],
+        "fresh_outputs": [output],
+    }
+
+
+def iaa_staging_map():
+    return {
+        "schema_version": "1",
+        "sources": [
+            {"source": RESULTS, "sub_path": "jobs/abc123/results"},
+            {"source": CONFIG, "sub_path": "jobs/abc123/results/config"},
+            {"source": PATCHES, "sub_path": "jobs/abc123/patches"},
+            {"source": CACHE, "sub_path": "jobs/abc123/cache"},
+        ],
+    }
+
+
+def render(request=None, staging=None, **kwargs):
+    return renderer.render_action_job(
+        request or iaa_pool_embed_request(),
+        staging or iaa_staging_map(),
+        job_id="tao-job-abc123",
+        namespace="tao-jobs",
+        pvc_claim="tao-workspace",
+        **kwargs,
+    )
+
+
+def container(manifest):
+    job = yaml.safe_load(manifest)
+    return job, job["spec"]["template"]["spec"]["containers"][0]
+
+
+def test_iaa_five_mount_request_preserves_aliases_and_access_modes():
+    job, action = container(render())
+    mounts = {item["mountPath"]: item for item in action["volumeMounts"]}
+
+    assert job["metadata"]["namespace"] == "tao-jobs"
+    assert job["metadata"]["annotations"]["tao.nvidia.com/job-record-id"] == "tao-job-abc123"
+    assert set(mounts) == {
+        "/dev/shm",
+        "/results",
+        RESULTS,
+        "/specs",
+        "/patches",
+        "/cache",
+    }
+    assert mounts["/results"]["subPath"] == "jobs/abc123/results"
+    assert mounts[RESULTS]["subPath"] == "jobs/abc123/results"
+    assert mounts["/results"]["readOnly"] is False
+    assert mounts[RESULTS]["readOnly"] is False
+    assert mounts["/specs"]["readOnly"] is True
+    assert mounts["/patches"]["readOnly"] is True
+    assert mounts["/cache"]["readOnly"] is False
+    assert action["command"] == ["embedding"]
+    assert action["args"] == iaa_pool_embed_request()["spec_bundle"]["args"]
+    assert action["resources"]["limits"]["nvidia.com/gpu"] == "1"
+
+
+def test_no_credentials_or_registry_secret_means_no_dangling_secret_refs():
+    job, action = container(render())
+    pod = job["spec"]["template"]["spec"]
+    assert pod["imagePullSecrets"] == []
+    assert action["envFrom"] == []
+
+
+def test_forwarded_credentials_are_secret_references_not_inline_values():
+    request = iaa_pool_embed_request()
+    request["forward_env"] = ["HF_TOKEN"]
+    manifest = render(
+        request=request,
+        credential_secret="tao-creds-abc123",
+        image_pull_secret="ngc-pull-secret",
+    )
+    job, action = container(manifest)
+    assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [
+        {"name": "ngc-pull-secret"}
+    ]
+    assert action["envFrom"] == [
+        {"secretRef": {"name": "tao-creds-abc123"}}
+    ]
+    inline_names = {item["name"] for item in action["env"]}
+    assert "HF_TOKEN" not in inline_names
+    assert "HF_TOKEN" not in manifest
+
+
+def test_forwarded_credentials_require_a_secret():
+    request = iaa_pool_embed_request()
+    request["forward_env"] = ["HF_TOKEN"]
+    with pytest.raises(renderer.RenderError, match="credential-secret"):
+        render(request=request)
+
+
+def test_inline_and_forwarded_name_collision_is_rejected():
+    request = iaa_pool_embed_request()
+    request["environment"]["HF_TOKEN"] = "must-not-be-inline"
+    request["forward_env"] = ["HF_TOKEN"]
+    with pytest.raises(renderer.RenderError, match="must not be present"):
+        render(request=request, credential_secret="tao-creds-abc123")
+
+
+def test_command_tokens_are_not_interpolated_into_a_shell_string():
+    request = iaa_pool_embed_request()
+    request["spec_bundle"]["args"].append("literal=$(do-not-run); 'quoted'")
+    _, action = container(render(request=request))
+    assert action["command"] == ["embedding"]
+    assert action["args"][-1] == "literal=$(do-not-run); 'quoted'"
+
+
+def test_empty_argument_and_environment_value_are_preserved():
+    request = iaa_pool_embed_request()
+    request["spec_bundle"]["args"].append("")
+    request["environment"]["OPTIONAL_SETTING"] = ""
+    _, action = container(render(request=request))
+    assert action["args"][-1] == ""
+    environment = {item["name"]: item["value"] for item in action["env"]}
+    assert environment["OPTIONAL_SETTING"] == ""
+
+
+def test_duplicate_source_aliases_need_only_one_staging_entry():
+    manifest = render()
+    _, action = container(manifest)
+    workspace_mounts = [
+        item for item in action["volumeMounts"] if item["name"] == "workspace"
+    ]
+    assert len(workspace_mounts) == 5
+    assert sum(item["subPath"] == "jobs/abc123/results" for item in workspace_mounts) == 2
+
+
+def test_missing_staging_mapping_is_rejected():
+    staging = iaa_staging_map()
+    staging["sources"] = [
+        row for row in staging["sources"] if row["source"] != PATCHES
+    ]
+    with pytest.raises(renderer.RenderError, match="no staged PVC subPath"):
+        render(staging=staging)
+
+
+def test_undeclared_staging_mapping_is_rejected():
+    staging = iaa_staging_map()
+    staging["sources"].append(
+        {"source": "/undeclared/input", "sub_path": "jobs/abc123/extra"}
+    )
+    with pytest.raises(renderer.RenderError, match="undeclared mount sources"):
+        render(staging=staging)
+
+
+@pytest.mark.parametrize("sub_path", ["/absolute", "../escape", "a/../escape", ".", "a\\b"])
+def test_unsafe_pvc_subpaths_are_rejected(sub_path):
+    staging = iaa_staging_map()
+    staging["sources"][0]["sub_path"] = sub_path
+    with pytest.raises(renderer.RenderError, match="sub_path|subPath|relative|traversal"):
+        render(staging=staging)
+
+
+def test_duplicate_mount_target_is_rejected():
+    request = iaa_pool_embed_request()
+    request["mounts"][1]["target"] = "/results"
+    with pytest.raises(renderer.RenderError, match="repeats Kubernetes mount target"):
+        render(request=request)
+
+
+def test_fresh_outputs_require_a_writable_covering_mount():
+    request = iaa_pool_embed_request()
+    request["mounts"][0]["read_only"] = True
+    request["mounts"][1]["read_only"] = True
+    with pytest.raises(renderer.RenderError, match="not covered by a writable"):
+        render(request=request)
+
+
+def test_staging_map_rejects_duplicate_sources():
+    staging = iaa_staging_map()
+    staging["sources"].append(dict(staging["sources"][0]))
+    with pytest.raises(renderer.RenderError, match="repeats source"):
+        render(staging=staging)
+
+
+def test_distinct_sources_cannot_share_one_exact_pvc_subpath():
+    staging = iaa_staging_map()
+    staging["sources"][1]["sub_path"] = staging["sources"][0]["sub_path"]
+    with pytest.raises(renderer.RenderError, match="one PVC subPath"):
+        render(staging=staging)
+
+
+def test_real_iaa_job_record_id_is_normalized_without_losing_identity():
+    job_id = (
+        "data-services-deft-iaa-pool_embed-"
+        "0123456789abcdef-1234567890abcdef-abcdef"
+    )
+    manifest = renderer.render_action_job(
+        iaa_pool_embed_request(),
+        iaa_staging_map(),
+        job_id=job_id,
+        namespace="tao-jobs",
+        pvc_claim="tao-workspace",
+    )
+    job = yaml.safe_load(manifest)
+    name = job["metadata"]["name"]
+    assert len(name) <= renderer.MAX_JOB_NAME
+    assert renderer.DNS_LABEL_RE.fullmatch(name)
+    assert "_" not in name
+    assert job["metadata"]["annotations"]["tao.nvidia.com/job-record-id"] == job_id
+    assert renderer.kubernetes_job_name(job_id) == name
+
+
+def test_normalized_names_cannot_collide_after_character_replacement():
+    underscored = renderer.kubernetes_job_name("action_with_underscore")
+    hyphenated = renderer.kubernetes_job_name("action-with-underscore")
+    assert underscored != hyphenated
+
+
+def test_cli_renders_the_same_contract(tmp_path):
+    request_path = tmp_path / "action.json"
+    staging_path = tmp_path / "staging.json"
+    request_path.write_text(json.dumps(iaa_pool_embed_request()), encoding="utf-8")
+    staging_path.write_text(json.dumps(iaa_staging_map()), encoding="utf-8")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "render",
+            "--request",
+            str(request_path),
+            "--staging-map",
+            str(staging_path),
+            "--job-id",
+            "tao-job-abc123",
+            "--namespace",
+            "tao-jobs",
+            "--pvc-claim",
+            "tao-workspace",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    job = yaml.safe_load(completed.stdout)
+    assert job["kind"] == "Job"
+    assert job["metadata"]["name"] == "tao-job-abc123"
+
+
+def test_name_cli_returns_backend_object_name():
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "name", "--job-id", "IAA.pool_embed_01"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == renderer.kubernetes_job_name("IAA.pool_embed_01")

--- a/skills/platform/tao-run-on-kubernetes/SKILL.md
+++ b/skills/platform/tao-run-on-kubernetes/SKILL.md
@@ -124,18 +124,12 @@ jobs are submitted with plain `kubectl apply`.
    or a first-time multi-GB image pull — is billed and reaper-eligible idle GPU
    time, exactly like pulling inside a SLURM allocation. Prefer tier A when the
    data is already on a PVC; choose tier C knowingly, for small inputs.
-3. **Credentials → a per-job Secret (never inline in the manifest** — it lands on
-   disk and is readable via `kubectl get job -o yaml`). Create it from an env-file
-   on **stdin** so no value hits a command line:
-   ```bash
-   set -a; source /path/to/.env; set +a   # omit if already exported
-   printf 'AWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nHF_TOKEN=%s\n' \
-     "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" "$HF_TOKEN" \
-     | kubectl create secret generic "tao-creds-$JOB_ID" --from-env-file=/dev/stdin
-   ```
-   The template references it via `envFrom.secretRef` — only the Secret *name* is
-   in the manifest.
-4. **Open the record — mints the id, binds `results_dir`, before launch:**
+
+   A producer action request may declare several mounts, including duplicate-
+   source aliases for logical and embedded absolute paths. Read
+   `references/action-request.md` and use its staging map plus packaged
+   renderer; the legacy single-root template cannot represent that contract.
+3. **Open the record — mints the id, binds `results_dir`, before launch:**
    ```bash
    JOB_ID=$("$BANK/scripts/tao_job_record.py" open --platform kubernetes --image "$IMAGE" \
      --network-arch "$ARCH" --action "$ACTION" --storage-tier "$TIER" --results-dir "$RESULTS_DIR")
@@ -143,26 +137,30 @@ jobs are submitted with plain `kubectl apply`.
    `results_dir` must be a **mounted (surviving) volume path or an S3 prefix** —
    `ttlSecondsAfterFinished` deletes the Job and its logs after it ends, so
    nothing is recoverable from the Job object later.
-5. **Render** `templates/k8s/single-pod-job.yaml.tmpl` (`CRED_SECRET=tao-creds-$JOB_ID`),
-   then **gate**: `redact_secrets.py lint <manifest>` (fails on any inline
-   credential) + `kubectl apply --dry-run=server -f <manifest>` (schema validity).
-6. **Apply + record RUNNING:**
-   ```bash
-   kubectl apply -f "$MANIFEST"
-   "$BANK/scripts/tao_job_record.py" mark "$JOB_ID" --state RUNNING --backend-ref "$NAMESPACE/$JOB_ID"
-   ```
+4. **Render, gate, apply, and record RUNNING.** For a producer action request,
+   follow `references/action-request.md`; it owns backend-name normalization,
+   conditional Secret references, native argv rendering, server dry-run, and
+   binding the applied object name to the job-record. For a simple one-root
+   spec-bundle, render `templates/k8s/single-pod-job.yaml.tmpl`, run
+   `redact_secrets.py lint` plus `kubectl apply --dry-run=server`, apply it, and
+   mark the record with `backend-ref=<namespace>/<actual-object-name>`.
 
 A submit that skipped the gate or the open has no id — so it cannot launch.
 
 ### status
 
+Keep `K8S_JOB_NAME` from submit. On reattach, read the job-record's
+`backend_ref=<namespace>/<name>` and recover both values from that field; do
+not assume the Kubernetes name equals the record id.
+
 ```bash
-kubectl get job "$JOB_ID" -o jsonpath='{.status.conditions[0].type} {.status.active} {.status.succeeded} {.status.failed}'
+kubectl get job "$K8S_JOB_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.status.conditions[0].type} {.status.active} {.status.succeeded} {.status.failed}'
 ```
 
 | kubectl signal | vocab |
 |---|---|
-| no pods scheduled | `PENDING` (`kubectl get pods -l job-name=$JOB_ID` → `ImagePullBackOff` / `Insufficient nvidia.com/gpu` in `message`) |
+| no pods scheduled | `PENDING` (`kubectl get pods -n "$NAMESPACE" -l job-name="$K8S_JOB_NAME"` → `ImagePullBackOff` / `Insufficient nvidia.com/gpu` in `message`) |
 | `active` ≥ 1 | `RUNNING` |
 | condition `Complete` | `COMPLETE` |
 | condition `Failed` | `ERROR` (classify from the pod's terminated reason — `OOMKilled` → `ERR_INFRA`) |
@@ -171,14 +169,16 @@ kubectl get job "$JOB_ID" -o jsonpath='{.status.conditions[0].type} {.status.act
 ### logs
 
 ```bash
-kubectl logs -l "job-name=$JOB_ID" --tail "${N:-200}"
+kubectl logs -n "$NAMESPACE" -l "job-name=$K8S_JOB_NAME" --tail "${N:-200}"
 ```
 
 ### cancel
 
 ```bash
-kubectl delete job "$JOB_ID" --cascade=foreground   # also deletes the pods
-kubectl delete secret "tao-creds-$JOB_ID" --ignore-not-found    # tear down the per-job Secret
+kubectl delete job "$K8S_JOB_NAME" -n "$NAMESPACE" --cascade=foreground
+if [ -n "${CRED_SECRET:-}" ]; then
+  kubectl delete secret "$CRED_SECRET" -n "$NAMESPACE" --ignore-not-found
+fi
 "$BANK/scripts/tao_job_record.py" mark "$JOB_ID" --state CANCELED --source agent
 ```
 
@@ -220,9 +220,11 @@ fake-device-plugin middle option: `references/local-cluster.md`.
 
 ## Container shell
 
-The single-pod template invokes the container command via `/bin/sh -c` (POSIX
-sh, present in busybox/distroless as well as TAO images). If your image relies
-on bash-only syntax, override the interpreter in the rendered manifest.
+The simple single-pod template invokes its command via `/bin/sh -c` (POSIX sh,
+present in busybox/distroless as well as TAO images). The producer-action
+template does not invoke a shell: it preserves `spec_bundle.command` and every
+`args` token as native container `command`/`args` arrays. A producer that needs
+a shell must declare the shell and its script as explicit argv.
 
 ## GPU Operator dependency
 

--- a/skills/platform/tao-run-on-kubernetes/SKILL.md
+++ b/skills/platform/tao-run-on-kubernetes/SKILL.md
@@ -128,7 +128,10 @@ jobs are submitted with plain `kubectl apply`.
    A producer action request may declare several mounts, including duplicate-
    source aliases for logical and embedded absolute paths. Read
    `references/action-request.md` and use its staging map plus packaged
-   renderer; the legacy single-root template cannot represent that contract.
+   renderer. For `mode=config`, materialize the producer's nested spec first,
+   stage that exact generated file, and pass it back to the renderer so the
+   pod receives a verified read-only config mount. The legacy single-root
+   template cannot represent that contract.
 3. **Open the record — mints the id, binds `results_dir`, before launch:**
    ```bash
    JOB_ID=$("$BANK/scripts/tao_job_record.py" open --platform kubernetes --image "$IMAGE" \
@@ -221,10 +224,13 @@ fake-device-plugin middle option: `references/local-cluster.md`.
 ## Container shell
 
 The simple single-pod template invokes its command via `/bin/sh -c` (POSIX sh,
-present in busybox/distroless as well as TAO images). The producer-action
-template does not invoke a shell: it preserves `spec_bundle.command` and every
-`args` token as native container `command`/`args` arrays. A producer that needs
-a shell must declare the shell and its script as explicit argv.
+present in busybox/distroless as well as TAO images). For producer action
+requests, an args-mode command and its arguments are native container argv; a
+producer that needs a shell declares the shell and its script explicitly. A
+simple config-mode command also becomes native argv after `{config_path}` is
+substituted. A producer-owned config command that is itself a multi-line shell
+script is preserved verbatim under `/bin/sh -c`; the renderer never constructs
+shell text from config values.
 
 ## GPU Operator dependency
 

--- a/skills/platform/tao-run-on-kubernetes/references/action-request.md
+++ b/skills/platform/tao-run-on-kubernetes/references/action-request.md
@@ -1,0 +1,104 @@
+# Producer Action Requests
+
+Read this reference before consuming a platform-neutral action request that
+contains a `mounts` array. The simple one-root spec-bundle template cannot
+preserve duplicate-source aliases or per-target access modes.
+
+## Stage every declared source
+
+Use `tao-data-io` when the producer source is not already visible from the
+Kubernetes compute frame. Mirror each distinct `request.mounts[].source` into
+a job-owned relative path on one bound PVC. Use delete semantics when the
+producer requires remote freshness. Record exactly one row per distinct source:
+
+```json
+{
+  "schema_version": "1",
+  "sources": [
+    {"source": "/launcher/run/results", "sub_path": "jobs/action-123/results"},
+    {"source": "/launcher/run/config", "sub_path": "jobs/action-123/results/config"},
+    {"source": "/launcher/cache", "sub_path": "jobs/action-123/cache"}
+  ]
+}
+```
+
+The staged subpaths must already exist. Verify read access and required write
+access from a pod before opening the job-record. For an application freshness
+contract, also verify every declared absent path and persist its staging
+receipt before opening the record. Never add an undeclared source or use an
+incremental copy that can retain stale outputs.
+
+## Record, credentials, and backend name
+
+Open the job-record only after the staging/freshness gate. Job-record ids allow
+characters and lengths that Kubernetes object names do not. Derive, never
+hand-edit, the collision-resistant backend name; the manifest retains the
+original record id in an annotation:
+
+```bash
+K8S_JOB_NAME=$(python3 \
+  "$BANK/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py" \
+  name --job-id "$JOB_ID")
+```
+
+When `request.forward_env` is non-empty, create `CRED_SECRET` after the record
+is open and feed exactly those approved variables through an env-file on
+stdin. For example, for a request that forwards these three names:
+
+```bash
+CRED_SECRET="${K8S_JOB_NAME}-creds"
+set -a; source /path/to/.env; set +a   # omit if already exported
+printf 'AWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nHF_TOKEN=%s\n' \
+  "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" "$HF_TOKEN" \
+  | kubectl create secret generic "$CRED_SECRET" -n "$NAMESPACE" \
+      --from-env-file=/dev/stdin
+```
+
+The manifest references only the Secret name. Omit the credential Secret when
+`forward_env` is empty. Likewise, pass an image-pull Secret only when the
+namespace needs one; do not create a dependency on a placeholder Secret.
+
+## Render and gate
+
+The renderer validates the immutable argv/image/GPU shape, exact source map,
+unique targets, safe relative PVC subpaths, writable coverage for fresh
+outputs, duplicate-source aliases, read-only flags, and conditional Secret
+references. It emits native `command`/`args` arrays, not a shell string:
+
+```bash
+RENDER_ARGS=()
+if [ -n "${CRED_SECRET:-}" ]; then
+  RENDER_ARGS+=(--credential-secret "$CRED_SECRET")
+fi
+if [ -n "${IMAGE_PULL_SECRET:-}" ]; then
+  RENDER_ARGS+=(--image-pull-secret "$IMAGE_PULL_SECRET")
+fi
+
+python3 "$BANK/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py" \
+  render --request "$ACTION_REQUEST" --staging-map "$STAGING_MAP" \
+  --job-id "$JOB_ID" --namespace "$NAMESPACE" --pvc-claim "$PVC_CLAIM" \
+  "${RENDER_ARGS[@]}" >"$MANIFEST"
+
+"$BANK/scripts/redact_secrets.py" lint "$MANIFEST"
+kubectl apply --dry-run=server -f "$MANIFEST"
+```
+
+The renderer uses `templates/k8s/action-job.yaml.tmpl`. Do not use the legacy
+`single-pod-job.yaml.tmpl` for an action request with multiple mounts.
+
+Apply and bind the real backend name to the record:
+
+```bash
+K8S_OBJECT=$(kubectl apply -f "$MANIFEST" -o name)
+[ "$K8S_OBJECT" = "job.batch/$K8S_JOB_NAME" ] || {
+  echo "unexpected Kubernetes object: $K8S_OBJECT" >&2
+  exit 1
+}
+"$BANK/scripts/tao_job_record.py" mark "$JOB_ID" --state RUNNING \
+  --backend-ref "$NAMESPACE/$K8S_JOB_NAME"
+```
+
+On reattach, recover namespace and backend name from that `backend_ref`; never
+assume the Kubernetes object name equals the record id. Status, logs, and
+cancel use the backend name. Delete `CRED_SECRET` after terminal log/output
+collection, when it was created.

--- a/skills/platform/tao-run-on-kubernetes/references/action-request.md
+++ b/skills/platform/tao-run-on-kubernetes/references/action-request.md
@@ -4,6 +4,10 @@ Read this reference before consuming a platform-neutral action request that
 contains a `mounts` array. The simple one-root spec-bundle template cannot
 preserve duplicate-source aliases or per-target access modes.
 
+The renderer accepts action-request schema version `"1"` only and fails closed
+on a missing or unsupported `request.schema_version`; update the renderer and
+this contract together before consuming a future version.
+
 ## Stage every declared source
 
 Use `tao-data-io` when the producer source is not already visible from the
@@ -54,9 +58,12 @@ printf 'AWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nHF_TOKEN=%s\n' \
       --from-env-file=/dev/stdin
 ```
 
-The manifest references only the Secret name. Omit the credential Secret when
-`forward_env` is empty. Likewise, pass an image-pull Secret only when the
-namespace needs one; do not create a dependency on a placeholder Secret.
+The manifest projects each approved `forward_env` name from the same-named key
+with an individual `env.valueFrom.secretKeyRef`; unrelated keys in the Secret
+are not imported. Omit both the credential Secret and `--credential-secret`
+when `forward_env` is empty (the renderer rejects that mismatch). Likewise,
+pass an image-pull Secret only when the namespace needs one; do not create a
+dependency on a placeholder Secret.
 
 ## Render and gate
 

--- a/skills/platform/tao-run-on-kubernetes/references/action-request.md
+++ b/skills/platform/tao-run-on-kubernetes/references/action-request.md
@@ -8,12 +8,38 @@ The renderer accepts action-request schema version `"1"` only and fails closed
 on a missing or unsupported `request.schema_version`; update the renderer and
 this contract together before consuming a future version.
 
-## Stage every declared source
+## Materialize config-mode bundles, then stage every source
+
+For `spec_bundle.mode=config`, the producer supplies a nested `spec` as
+content, not a launcher-local path. The Kubernetes consumer must first
+serialize that content and later replace the command's `{config_path}` with
+the file's in-container path:
+
+```bash
+CONFIG_RENDER_ARGS=()
+if [ "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["spec_bundle"]["mode"])' \
+    "$ACTION_REQUEST")" = "config" ]; then
+  CONFIG_SOURCE=$(python3 \
+    "$BANK/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py" \
+    materialize-config --request "$ACTION_REQUEST" \
+    --output-dir "$WORKSPACE/.tao/action-configs")
+  CONFIG_RENDER_ARGS+=(--config-source "$CONFIG_SOURCE")
+fi
+```
+
+The materializer supports the contract's `yaml`, `json`, and `toml` formats.
+It writes an atomic, content-addressed file and returns its absolute path.
+Treat that returned path as one additional consumer-derived staging source:
+copy the exact file onto the PVC and add exactly one row for it to the staging
+receipt. Do not rewrite the producer bundle as `mode=args`, hand-author a
+second config, or substitute a launcher path that the pod cannot see.
 
 Use `tao-data-io` when the producer source is not already visible from the
 Kubernetes compute frame. Mirror each distinct `request.mounts[].source` into
-a job-owned relative path on one bound PVC. Use delete semantics when the
-producer requires remote freshness. Record exactly one row per distinct source:
+a job-owned relative path on one bound PVC. If `CONFIG_SOURCE` is set, mirror
+that exact file too. Use delete semantics when the producer requires remote
+freshness. Record exactly one row per distinct source, including the generated
+config when present:
 
 ```json
 {
@@ -21,12 +47,14 @@ producer requires remote freshness. Record exactly one row per distinct source:
   "sources": [
     {"source": "/launcher/run/results", "sub_path": "jobs/action-123/results"},
     {"source": "/launcher/run/config", "sub_path": "jobs/action-123/results/config"},
-    {"source": "/launcher/cache", "sub_path": "jobs/action-123/cache"}
+    {"source": "/launcher/cache", "sub_path": "jobs/action-123/cache"},
+    {"source": "/launcher/.tao/action-configs/tao-action-config-<sha256>.yaml", "sub_path": "jobs/action-123/action-config.yaml"}
   ]
 }
 ```
 
-The staged subpaths must already exist. Verify read access and required write
+Omit the last row for `mode=args`. The staged subpaths must already exist.
+Verify read access and required write
 access from a pod before opening the job-record. For an application freshness
 contract, also verify every declared absent path and persist its staging
 receipt before opening the record. Never add an undeclared source or use an
@@ -67,10 +95,20 @@ dependency on a placeholder Secret.
 
 ## Render and gate
 
-The renderer validates the immutable argv/image/GPU shape, exact source map,
-unique targets, safe relative PVC subpaths, writable coverage for fresh
+The renderer validates the immutable command/image/GPU shape, exact source
+map, unique targets, safe relative PVC subpaths, writable coverage for fresh
 outputs, duplicate-source aliases, read-only flags, and conditional Secret
-references. It emits native `command`/`args` arrays, not a shell string:
+references. For `mode=config`, it also verifies that `CONFIG_SOURCE` is the
+canonical serialization of `spec_bundle.spec`, mounts that exact staged file
+read-only at a content-addressed path, and substitutes the path for every
+`{config_path}` occurrence. A stale, altered, unstaged, or symlinked config is
+rejected before a manifest is emitted.
+
+Simple commands are emitted as native `command`/`args` arrays. A producer-owned
+config command that is itself a multi-line shell script (for example, a
+Cosmos-RL action that discovers its hook inside the image) is preserved
+verbatim under `/bin/sh -c`; values from the config are never interpolated as
+shell text:
 
 ```bash
 RENDER_ARGS=()
@@ -84,7 +122,7 @@ fi
 python3 "$BANK/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py" \
   render --request "$ACTION_REQUEST" --staging-map "$STAGING_MAP" \
   --job-id "$JOB_ID" --namespace "$NAMESPACE" --pvc-claim "$PVC_CLAIM" \
-  "${RENDER_ARGS[@]}" >"$MANIFEST"
+  "${CONFIG_RENDER_ARGS[@]}" "${RENDER_ARGS[@]}" >"$MANIFEST"
 
 "$BANK/scripts/redact_secrets.py" lint "$MANIFEST"
 kubectl apply --dry-run=server -f "$MANIFEST"

--- a/skills/platform/tao-run-on-kubernetes/references/skill_info.yaml
+++ b/skills/platform/tao-run-on-kubernetes/references/skill_info.yaml
@@ -40,3 +40,4 @@ features:
 - log-streaming
 - pod-diagnostics
 - multi-node
+- producer-action-mount-aliases

--- a/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py
+++ b/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render one producer action request as a single-pod Kubernetes Job.
+
+The data mover first mirrors each distinct request ``mounts[].source`` into a
+job-owned directory on one PVC.  Its receipt records the relative PVC path for
+each source.  This renderer preserves every producer-declared target and access
+mode, including multiple target aliases for the same source, by mounting that
+PVC subPath once per target.
+
+Credentials are deliberately not accepted as values.  ``forward_env`` names
+are made available only through an optional, pre-created Secret reference, and
+registry authentication is an independent optional image-pull Secret.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import posixpath
+import re
+import sys
+from typing import Any
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+DEFAULT_TEMPLATE = REPO_ROOT / "templates/k8s/action-job.yaml.tmpl"
+MARKER_RE = re.compile(r"@@[A-Z][A-Z0-9_]*@@")
+ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?")
+DNS_SUBDOMAIN_RE = re.compile(
+    r"[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?"
+)
+QUANTITY_RE = re.compile(r"[1-9][0-9]*(?:Ki|Mi|Gi|Ti|Pi|Ei)")
+MAX_JOB_NAME = 52
+
+
+class RenderError(ValueError):
+    """The action request or staging receipt cannot be rendered safely."""
+
+
+def _load_object(path: pathlib.Path, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RenderError(f"cannot read {label} JSON {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RenderError(f"{label} JSON root must be an object")
+    return payload
+
+
+def _nonempty_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise RenderError(f"{label} must be a non-empty string without NUL")
+    return value
+
+
+def _string_value(value: Any, label: str) -> str:
+    if not isinstance(value, str) or "\x00" in value:
+        raise RenderError(f"{label} must be a string without NUL")
+    return value
+
+
+def _dns_name(value: str, label: str, *, label_only: bool = False) -> str:
+    pattern = DNS_LABEL_RE if label_only else DNS_SUBDOMAIN_RE
+    maximum = 63 if label_only else 253
+    if len(value) > maximum or pattern.fullmatch(value) is None:
+        kind = "DNS label" if label_only else "DNS subdomain"
+        raise RenderError(f"{label} must be a valid Kubernetes {kind}")
+    return value
+
+
+def kubernetes_job_name(job_id: str) -> str:
+    """Map an immutable job-record id to a stable Kubernetes-safe name.
+
+    Job-record components may contain underscores, uppercase letters, dots, or
+    enough text to exceed Kubernetes' practical Job-name length. Preserve an
+    already-safe short id; otherwise append a digest so normalization and
+    truncation cannot merge two record ids into one backend object.
+    """
+    original = _nonempty_string(job_id, "job id")
+    if len(original) <= MAX_JOB_NAME and DNS_LABEL_RE.fullmatch(original):
+        return original
+    slug = re.sub(r"[^a-z0-9]+", "-", original.lower()).strip("-")
+    if not slug:
+        slug = "tao-job"
+    digest = hashlib.sha256(original.encode("utf-8")).hexdigest()[:10]
+    prefix = slug[: MAX_JOB_NAME - len(digest) - 1].rstrip("-") or "tao-job"
+    return f"{prefix}-{digest}"
+
+
+def _absolute_clean_path(value: Any, label: str) -> str:
+    path = _nonempty_string(value, label)
+    if (
+        not path.startswith("/")
+        or path == "/"
+        or "\\" in path
+        or any(ord(ch) < 32 for ch in path)
+    ):
+        raise RenderError(f"{label} must be an absolute non-root POSIX path")
+    normalized = posixpath.normpath(path)
+    if normalized != path or "//" in path:
+        raise RenderError(f"{label} must be normalized and contain no traversal")
+    return path
+
+
+def _safe_sub_path(value: Any, label: str) -> str:
+    path = _nonempty_string(value, label)
+    if path.startswith("/") or "\\" in path or any(ord(ch) < 32 for ch in path):
+        raise RenderError(f"{label} must be a safe relative POSIX path")
+    normalized = posixpath.normpath(path)
+    if normalized != path or path in {".", ".."} or path.startswith("../"):
+        raise RenderError(f"{label} must be normalized and contain no traversal")
+    return path
+
+
+def _command_bundle(request: dict[str, Any]) -> tuple[str, list[str], str, int]:
+    bundle = request.get("spec_bundle")
+    if not isinstance(bundle, dict):
+        raise RenderError("request.spec_bundle must be an object")
+    if bundle.get("mode") != "args":
+        raise RenderError("Kubernetes action rendering requires spec_bundle.mode=args")
+    command = _nonempty_string(bundle.get("command"), "spec_bundle.command")
+    raw_args = bundle.get("args")
+    if not isinstance(raw_args, list):
+        raise RenderError("spec_bundle.args must be an array")
+    args = [
+        _string_value(value, f"spec_bundle.args[{index}]")
+        for index, value in enumerate(raw_args)
+    ]
+    image = _nonempty_string(bundle.get("image"), "spec_bundle.image")
+    workload_image = request.get("workload_image")
+    if workload_image is not None and workload_image != image:
+        raise RenderError("request.workload_image must equal spec_bundle.image")
+    shape = bundle.get("compute_shape")
+    if not isinstance(shape, dict):
+        raise RenderError("spec_bundle.compute_shape must be an object")
+    gpus = shape.get("gpus")
+    nodes = shape.get("nodes")
+    if not isinstance(gpus, int) or isinstance(gpus, bool) or gpus < 0:
+        raise RenderError("spec_bundle.compute_shape.gpus must be a non-negative integer")
+    if nodes != 1:
+        raise RenderError("single-pod action rendering requires compute_shape.nodes=1")
+    return command, args, image, gpus
+
+
+def _staged_sources(payload: dict[str, Any]) -> dict[str, str]:
+    if payload.get("schema_version") != "1":
+        raise RenderError("staging map schema_version must be '1'")
+    rows = payload.get("sources")
+    if not isinstance(rows, list) or not rows:
+        raise RenderError("staging map sources must be a non-empty array")
+    result: dict[str, str] = {}
+    sub_paths: dict[str, str] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise RenderError(f"staging map sources[{index}] must be an object")
+        source = _absolute_clean_path(row.get("source"), f"staging sources[{index}].source")
+        sub_path = _safe_sub_path(row.get("sub_path"), f"staging sources[{index}].sub_path")
+        if source in result:
+            raise RenderError(f"staging map repeats source: {source}")
+        if sub_path in sub_paths:
+            raise RenderError(
+                "staging map assigns one PVC subPath to distinct sources: "
+                f"{sub_paths[sub_path]} and {source}"
+            )
+        result[source] = sub_path
+        sub_paths[sub_path] = source
+    return result
+
+
+def _mounts(
+    request: dict[str, Any], staged: dict[str, str]
+) -> tuple[list[dict[str, Any]], list[tuple[pathlib.PurePosixPath, bool]]]:
+    rows = request.get("mounts")
+    if not isinstance(rows, list) or not rows:
+        raise RenderError("request.mounts must be a non-empty array")
+    rendered: list[dict[str, Any]] = [
+        {"name": "dshm", "mountPath": "/dev/shm", "readOnly": False}
+    ]
+    used_sources: set[str] = set()
+    targets: set[str] = {"/dev/shm"}
+    source_modes: list[tuple[pathlib.PurePosixPath, bool]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise RenderError(f"request.mounts[{index}] must be an object")
+        source = _absolute_clean_path(row.get("source"), f"mounts[{index}].source")
+        target = _absolute_clean_path(row.get("target"), f"mounts[{index}].target")
+        read_only = row.get("read_only")
+        if not isinstance(read_only, bool):
+            raise RenderError(f"mounts[{index}].read_only must be boolean")
+        if source not in staged:
+            raise RenderError(f"mount source has no staged PVC subPath: {source}")
+        if target in targets:
+            raise RenderError(f"request repeats Kubernetes mount target: {target}")
+        targets.add(target)
+        used_sources.add(source)
+        source_modes.append((pathlib.PurePosixPath(source), read_only))
+        rendered.append(
+            {
+                "name": "workspace",
+                "mountPath": target,
+                "subPath": staged[source],
+                "readOnly": read_only,
+            }
+        )
+    extras = sorted(set(staged) - used_sources)
+    if extras:
+        raise RenderError("staging map contains undeclared mount sources: " + ", ".join(extras))
+    return rendered, source_modes
+
+
+def _require_writable_outputs(
+    request: dict[str, Any], source_modes: list[tuple[pathlib.PurePosixPath, bool]]
+) -> None:
+    outputs = request.get("fresh_outputs", [])
+    if not isinstance(outputs, list):
+        raise RenderError("request.fresh_outputs must be an array")
+    for index, raw in enumerate(outputs):
+        output = pathlib.PurePosixPath(
+            _absolute_clean_path(raw, f"fresh_outputs[{index}]")
+        )
+        writable = False
+        for source, read_only in source_modes:
+            try:
+                output.relative_to(source)
+            except ValueError:
+                continue
+            if not read_only:
+                writable = True
+                break
+        if not writable:
+            raise RenderError(
+                f"fresh output is not covered by a writable declared mount: {output}"
+            )
+
+
+def _environment(
+    request: dict[str, Any], credential_secret: str | None
+) -> tuple[list[dict[str, str]], list[dict[str, dict[str, str]]]]:
+    raw_environment = request.get("environment", {})
+    if not isinstance(raw_environment, dict):
+        raise RenderError("request.environment must be an object")
+    environment: list[dict[str, str]] = []
+    for name in sorted(raw_environment):
+        if ENV_NAME_RE.fullmatch(name) is None:
+            raise RenderError(f"invalid environment variable name: {name!r}")
+        value = _string_value(raw_environment[name], f"environment.{name}")
+        environment.append({"name": name, "value": value})
+
+    raw_forward = request.get("forward_env", [])
+    if not isinstance(raw_forward, list):
+        raise RenderError("request.forward_env must be an array")
+    forward: list[str] = []
+    for index, raw in enumerate(raw_forward):
+        name = _nonempty_string(raw, f"forward_env[{index}]")
+        if ENV_NAME_RE.fullmatch(name) is None:
+            raise RenderError(f"invalid forwarded environment variable name: {name!r}")
+        if name in forward:
+            raise RenderError(f"request.forward_env repeats {name}")
+        if name in raw_environment:
+            raise RenderError(f"credential {name} must not be present in request.environment")
+        forward.append(name)
+    if forward and credential_secret is None:
+        raise RenderError(
+            "request.forward_env is non-empty but no --credential-secret was supplied"
+        )
+    env_from = (
+        [{"secretRef": {"name": credential_secret}}]
+        if credential_secret is not None
+        else []
+    )
+    return environment, env_from
+
+
+def render_action_job(
+    request: dict[str, Any],
+    staging_map: dict[str, Any],
+    *,
+    job_id: str,
+    namespace: str,
+    pvc_claim: str,
+    credential_secret: str | None = None,
+    image_pull_secret: str | None = None,
+    ttl_seconds: int = 3600,
+    shm_size: str = "16Gi",
+    template_path: pathlib.Path = DEFAULT_TEMPLATE,
+) -> str:
+    """Validate inputs and return a complete Kubernetes Job manifest."""
+    if request.get("platform") != "kubernetes":
+        raise RenderError("request.platform must be 'kubernetes'")
+    job_id = _nonempty_string(job_id, "job id")
+    job_name = kubernetes_job_name(job_id)
+    namespace = _dns_name(namespace, "namespace", label_only=True)
+    pvc_claim = _dns_name(pvc_claim, "PVC claim")
+    if credential_secret is not None:
+        credential_secret = _dns_name(credential_secret, "credential secret")
+    if image_pull_secret is not None:
+        image_pull_secret = _dns_name(image_pull_secret, "image pull secret")
+    if (
+        not isinstance(ttl_seconds, int)
+        or isinstance(ttl_seconds, bool)
+        or not 0 <= ttl_seconds <= 604800
+    ):
+        raise RenderError("ttl_seconds must be an integer from 0 through 604800")
+    if QUANTITY_RE.fullmatch(shm_size) is None:
+        raise RenderError("shm_size must be a positive binary Kubernetes quantity such as 16Gi")
+
+    command, args, image, gpus = _command_bundle(request)
+    staged = _staged_sources(staging_map)
+    volume_mounts, source_modes = _mounts(request, staged)
+    _require_writable_outputs(request, source_modes)
+    environment, env_from = _environment(request, credential_secret)
+    image_pull_secrets = (
+        [{"name": image_pull_secret}] if image_pull_secret is not None else []
+    )
+
+    values: dict[str, Any] = {
+        "JOB_NAME_JSON": job_name,
+        "JOB_ID_JSON": job_id,
+        "NAMESPACE_JSON": namespace,
+        "TTL_SECONDS_JSON": ttl_seconds,
+        "IMAGE_PULL_SECRETS_JSON": image_pull_secrets,
+        "IMAGE_JSON": image,
+        "COMMAND_JSON": [command],
+        "ARGS_JSON": args,
+        "NUM_GPUS_JSON": str(gpus),
+        "ENV_FROM_JSON": env_from,
+        "ENV_JSON": environment,
+        "VOLUME_MOUNTS_JSON": volume_mounts,
+        "SHM_SIZE_JSON": shm_size,
+        "PVC_CLAIM_JSON": pvc_claim,
+    }
+    try:
+        rendered = template_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RenderError(f"cannot read Kubernetes action template: {exc}") from exc
+    for marker, value in values.items():
+        rendered = rendered.replace(f"@@{marker}@@", json.dumps(value, separators=(",", ":")))
+    remaining = MARKER_RE.findall(rendered)
+    if remaining:
+        raise RenderError(f"unresolved template markers: {sorted(set(remaining))}")
+    return rendered
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="operation", required=True)
+    name = commands.add_parser(
+        "name", help="print the deterministic Kubernetes name for a job-record id"
+    )
+    name.add_argument("--job-id", required=True)
+
+    render = commands.add_parser("render", help="render a complete Job manifest")
+    render.add_argument("--request", required=True, type=pathlib.Path)
+    render.add_argument("--staging-map", required=True, type=pathlib.Path)
+    render.add_argument("--job-id", required=True)
+    render.add_argument(
+        "--namespace", default=os.environ.get("TAO_K8S_NAMESPACE", "default")
+    )
+    render.add_argument("--pvc-claim", required=True)
+    render.add_argument("--credential-secret")
+    render.add_argument("--image-pull-secret")
+    render.add_argument("--ttl-seconds", type=int, default=3600)
+    render.add_argument("--shm-size", default="16Gi")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.operation == "name":
+            print(kubernetes_job_name(args.job_id))
+            return 0
+        request = _load_object(args.request, "action request")
+        staging_map = _load_object(args.staging_map, "staging map")
+        manifest = render_action_job(
+            request,
+            staging_map,
+            job_id=args.job_id,
+            namespace=args.namespace,
+            pvc_claim=args.pvc_claim,
+            credential_secret=args.credential_secret,
+            image_pull_secret=args.image_pull_secret,
+            ttl_seconds=args.ttl_seconds,
+            shm_size=args.shm_size,
+        )
+    except RenderError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    sys.stdout.write(manifest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py
+++ b/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py
@@ -21,11 +21,15 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import pathlib
 import posixpath
 import re
+import shlex
+import stat
 import sys
+import tempfile
 from typing import Any
 
 
@@ -40,6 +44,8 @@ DNS_SUBDOMAIN_RE = re.compile(
 QUANTITY_RE = re.compile(r"[1-9][0-9]*(?:Ki|Mi|Gi|Ti|Pi|Ei)")
 MAX_JOB_NAME = 52
 REQUEST_SCHEMA_VERSION = "1"
+CONFIG_FORMATS = {"json": "json", "toml": "toml", "yaml": "yaml"}
+SHELL_META = ("\n", ";", "&&", "||", "$(", "`", "|", ">", "<")
 
 
 class RenderError(ValueError):
@@ -121,20 +127,224 @@ def _safe_sub_path(value: Any, label: str) -> str:
     return path
 
 
-def _command_bundle(request: dict[str, Any]) -> tuple[str, list[str], str, int]:
+def _toml_key(value: Any) -> str:
+    key = _nonempty_string(value, "TOML key")
+    if re.fullmatch(r"[A-Za-z0-9_-]+", key):
+        return key
+    return json.dumps(key)
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise RenderError("TOML config values must be finite")
+        return repr(value)
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        return "{ " + ", ".join(
+            f"{_toml_key(key)} = {_toml_value(item)}"
+            for key, item in sorted(value.items())
+        ) + " }"
+    raise RenderError(f"no TOML representation for {type(value).__name__}")
+
+
+def _toml_document(spec: dict[str, Any], prefix: tuple[str, ...] = ()) -> str:
+    scalars: list[str] = []
+    tables: list[tuple[str, dict[str, Any]]] = []
+    for raw_key in sorted(spec):
+        key = _toml_key(raw_key)
+        value = spec[raw_key]
+        if isinstance(value, dict):
+            tables.append((key, value))
+        else:
+            scalars.append(f"{key} = {_toml_value(value)}")
+    sections: list[str] = []
+    if scalars:
+        sections.append("\n".join(scalars))
+    for key, value in tables:
+        name = ".".join((*prefix, key))
+        body = _toml_document(value, (*prefix, key)).rstrip("\n")
+        sections.append(f"[{name}]" + (f"\n{body}" if body else ""))
+    return "\n\n".join(sections) + "\n"
+
+
+def _config_content(bundle: dict[str, Any]) -> tuple[str, str, str]:
+    spec = bundle.get("spec")
+    if not isinstance(spec, dict):
+        raise RenderError("spec_bundle.spec must be a nested object for mode=config")
+    raw_format = bundle.get("config_format")
+    if raw_format not in CONFIG_FORMATS:
+        raise RenderError(
+            "spec_bundle.config_format must be one of json, toml, or yaml"
+        )
+    extension = CONFIG_FORMATS[raw_format]
+    try:
+        if raw_format == "toml":
+            content = _toml_document(spec)
+        else:
+            # JSON is valid YAML. Keeping both formats on the stdlib serializer
+            # avoids making Kubernetes submission depend on a host YAML package.
+            content = json.dumps(
+                spec, allow_nan=False, indent=2, sort_keys=True
+            ) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise RenderError(f"spec_bundle.spec is not {raw_format}-serializable: {exc}") from exc
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return content, extension, digest
+
+
+def _read_regular_file(path: pathlib.Path, label: str) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise RenderError(f"cannot open {label} {path}: {exc}") from exc
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise RenderError(f"{label} must be a regular non-symlink file: {path}")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            return handle.read()
+    except OSError as exc:
+        raise RenderError(f"cannot read {label} {path}: {exc}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def materialize_config(
+    request: dict[str, Any], output_dir: pathlib.Path
+) -> pathlib.Path:
+    """Write one content-addressed config file for later PVC staging."""
+    if request.get("schema_version") != REQUEST_SCHEMA_VERSION:
+        raise RenderError(
+            f"request.schema_version must be {REQUEST_SCHEMA_VERSION!r}"
+        )
+    if request.get("platform") != "kubernetes":
+        raise RenderError("request.platform must be 'kubernetes'")
     bundle = request.get("spec_bundle")
     if not isinstance(bundle, dict):
         raise RenderError("request.spec_bundle must be an object")
-    if bundle.get("mode") != "args":
-        raise RenderError("Kubernetes action rendering requires spec_bundle.mode=args")
-    command = _nonempty_string(bundle.get("command"), "spec_bundle.command")
-    raw_args = bundle.get("args")
-    if not isinstance(raw_args, list):
-        raise RenderError("spec_bundle.args must be an array")
-    args = [
-        _string_value(value, f"spec_bundle.args[{index}]")
-        for index, value in enumerate(raw_args)
-    ]
+    if bundle.get("mode") != "config":
+        raise RenderError("materialize-config requires spec_bundle.mode=config")
+    if "args" in bundle:
+        raise RenderError("spec_bundle.mode=config must not carry args")
+    content, extension, digest = _config_content(bundle)
+
+    raw_output_dir = output_dir.expanduser()
+    if raw_output_dir.is_symlink():
+        raise RenderError("config output directory must not be a symlink")
+    try:
+        raw_output_dir.mkdir(parents=True, exist_ok=True)
+        root = raw_output_dir.resolve(strict=True)
+    except OSError as exc:
+        raise RenderError(f"cannot prepare config output directory: {exc}") from exc
+    if root == pathlib.Path(root.anchor) or not root.is_dir():
+        raise RenderError("config output directory must be a non-root directory")
+
+    destination = root / f"tao-action-config-{digest}.{extension}"
+    encoded = content.encode("utf-8")
+    if destination.exists() or destination.is_symlink():
+        if _read_regular_file(destination, "materialized config") != encoded:
+            raise RenderError(f"materialized config content mismatch: {destination}")
+        return destination
+
+    temporary: pathlib.Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=destination.name + ".",
+            suffix=".tmp",
+            dir=root,
+            delete=False,
+        ) as handle:
+            temporary = pathlib.Path(handle.name)
+            os.fchmod(handle.fileno(), 0o600)
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            # link() publishes the complete file without ever replacing an
+            # existing path. Concurrent materializers either create the same
+            # content-addressed file or verify the winner below.
+            os.link(temporary, destination)
+        except FileExistsError:
+            if _read_regular_file(destination, "materialized config") != encoded:
+                raise RenderError(
+                    f"materialized config content mismatch: {destination}"
+                )
+    except OSError as exc:
+        raise RenderError(f"cannot materialize config in {root}: {exc}") from exc
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+    return destination
+
+
+def _is_shell_script(command: str) -> bool:
+    return any(marker in command for marker in SHELL_META)
+
+
+def _command_bundle(
+    request: dict[str, Any], config_path: str | None
+) -> tuple[list[str], list[str], str, int]:
+    bundle = request.get("spec_bundle")
+    if not isinstance(bundle, dict):
+        raise RenderError("request.spec_bundle must be an object")
+    mode = bundle.get("mode")
+    command_text = _nonempty_string(bundle.get("command"), "spec_bundle.command")
+    if mode == "args":
+        if "spec" in bundle or "config_format" in bundle:
+            raise RenderError(
+                "spec_bundle.mode=args must not carry spec or config_format"
+            )
+        if config_path is not None:
+            raise RenderError("--config-source must be omitted for spec_bundle.mode=args")
+        raw_args = bundle.get("args")
+        if not isinstance(raw_args, list):
+            raise RenderError("spec_bundle.args must be an array")
+        args = [
+            _string_value(value, f"spec_bundle.args[{index}]")
+            for index, value in enumerate(raw_args)
+        ]
+    elif mode == "config":
+        if "args" in bundle:
+            raise RenderError("spec_bundle.mode=config must not carry args")
+        _config_content(bundle)
+        if config_path is None:
+            raise RenderError(
+                "spec_bundle.mode=config requires --config-source; run "
+                "materialize-config, stage the returned file, then render"
+            )
+        if "{config_path}" not in command_text:
+            raise RenderError(
+                "spec_bundle.mode=config requires {config_path} in command"
+            )
+        command_text = command_text.replace("{config_path}", config_path)
+        args = []
+    else:
+        raise RenderError("spec_bundle.mode must be 'args' or 'config'")
+
+    if mode == "config" and _is_shell_script(command_text):
+        command = ["/bin/sh", "-c"]
+        args = [command_text, "tao-action", *args]
+    else:
+        try:
+            command = shlex.split(command_text)
+        except ValueError as exc:
+            raise RenderError(f"spec_bundle.command cannot be parsed: {exc}") from exc
+        if not command:
+            raise RenderError("spec_bundle.command must contain an executable")
     image = _nonempty_string(bundle.get("image"), "spec_bundle.image")
     workload_image = request.get("workload_image")
     if workload_image is not None and workload_image != image:
@@ -177,7 +387,9 @@ def _staged_sources(payload: dict[str, Any]) -> dict[str, str]:
 
 
 def _mounts(
-    request: dict[str, Any], staged: dict[str, str]
+    request: dict[str, Any],
+    staged: dict[str, str],
+    config_mount: tuple[str, str] | None = None,
 ) -> tuple[list[dict[str, Any]], list[tuple[pathlib.PurePosixPath, bool]]]:
     rows = request.get("mounts")
     if not isinstance(rows, list) or not rows:
@@ -211,10 +423,65 @@ def _mounts(
                 "readOnly": read_only,
             }
         )
+    if config_mount is not None:
+        source, target = config_mount
+        if source in used_sources:
+            raise RenderError(
+                "materialized config must have its own staged file source"
+            )
+        if source not in staged:
+            raise RenderError(
+                f"materialized config has no staged PVC subPath: {source}"
+            )
+        if target in targets:
+            raise RenderError(
+                f"materialized config repeats Kubernetes mount target: {target}"
+            )
+        used_sources.add(source)
+        targets.add(target)
+        rendered.append(
+            {
+                "name": "workspace",
+                "mountPath": target,
+                "subPath": staged[source],
+                "readOnly": True,
+            }
+        )
     extras = sorted(set(staged) - used_sources)
     if extras:
         raise RenderError("staging map contains undeclared mount sources: " + ", ".join(extras))
     return rendered, source_modes
+
+
+def _config_mount(
+    request: dict[str, Any],
+    staged: dict[str, str],
+    config_source: pathlib.Path | None,
+) -> tuple[str | None, tuple[str, str] | None]:
+    bundle = request.get("spec_bundle")
+    if not isinstance(bundle, dict):
+        raise RenderError("request.spec_bundle must be an object")
+    mode = bundle.get("mode")
+    if mode != "config":
+        if config_source is not None:
+            raise RenderError("--config-source is valid only for spec_bundle.mode=config")
+        return None, None
+    if config_source is None:
+        return None, None
+
+    lexical = config_source.expanduser()
+    source = _absolute_clean_path(str(lexical), "config source")
+    path = pathlib.Path(source)
+    content, extension, digest = _config_content(bundle)
+    if _read_regular_file(path, "config source") != content.encode("utf-8"):
+        raise RenderError(
+            "config source content does not match spec_bundle.spec; rerun "
+            "materialize-config and restage the returned file"
+        )
+    if source not in staged:
+        raise RenderError(f"materialized config has no staged PVC subPath: {source}")
+    target = f"/tao-action-config/spec-{digest}.{extension}"
+    return target, (source, target)
 
 
 def _require_writable_outputs(
@@ -298,6 +565,7 @@ def render_action_job(
     pvc_claim: str,
     credential_secret: str | None = None,
     image_pull_secret: str | None = None,
+    config_source: pathlib.Path | None = None,
     ttl_seconds: int = 3600,
     shm_size: str = "16Gi",
     template_path: pathlib.Path = DEFAULT_TEMPLATE,
@@ -326,9 +594,10 @@ def render_action_job(
     if QUANTITY_RE.fullmatch(shm_size) is None:
         raise RenderError("shm_size must be a positive binary Kubernetes quantity such as 16Gi")
 
-    command, args, image, gpus = _command_bundle(request)
     staged = _staged_sources(staging_map)
-    volume_mounts, source_modes = _mounts(request, staged)
+    config_path, config_mount = _config_mount(request, staged, config_source)
+    command, args, image, gpus = _command_bundle(request, config_path)
+    volume_mounts, source_modes = _mounts(request, staged, config_mount)
     _require_writable_outputs(request, source_modes)
     environment = _environment(request, credential_secret)
     image_pull_secrets = (
@@ -342,7 +611,7 @@ def render_action_job(
         "TTL_SECONDS_JSON": ttl_seconds,
         "IMAGE_PULL_SECRETS_JSON": image_pull_secrets,
         "IMAGE_JSON": image,
-        "COMMAND_JSON": [command],
+        "COMMAND_JSON": command,
         "ARGS_JSON": args,
         "NUM_GPUS_JSON": str(gpus),
         "ENV_JSON": environment,
@@ -370,6 +639,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     name.add_argument("--job-id", required=True)
 
+    materialize = commands.add_parser(
+        "materialize-config",
+        help="write a content-addressed mode=config file for PVC staging",
+    )
+    materialize.add_argument("--request", required=True, type=pathlib.Path)
+    materialize.add_argument("--output-dir", required=True, type=pathlib.Path)
+
     render = commands.add_parser("render", help="render a complete Job manifest")
     render.add_argument("--request", required=True, type=pathlib.Path)
     render.add_argument("--staging-map", required=True, type=pathlib.Path)
@@ -380,6 +656,7 @@ def build_parser() -> argparse.ArgumentParser:
     render.add_argument("--pvc-claim", required=True)
     render.add_argument("--credential-secret")
     render.add_argument("--image-pull-secret")
+    render.add_argument("--config-source", type=pathlib.Path)
     render.add_argument("--ttl-seconds", type=int, default=3600)
     render.add_argument("--shm-size", default="16Gi")
     return parser
@@ -392,6 +669,9 @@ def main(argv: list[str] | None = None) -> int:
             print(kubernetes_job_name(args.job_id))
             return 0
         request = _load_object(args.request, "action request")
+        if args.operation == "materialize-config":
+            print(materialize_config(request, args.output_dir))
+            return 0
         staging_map = _load_object(args.staging_map, "staging map")
         manifest = render_action_job(
             request,
@@ -401,6 +681,7 @@ def main(argv: list[str] | None = None) -> int:
             pvc_claim=args.pvc_claim,
             credential_secret=args.credential_secret,
             image_pull_secret=args.image_pull_secret,
+            config_source=args.config_source,
             ttl_seconds=args.ttl_seconds,
             shm_size=args.shm_size,
         )

--- a/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py
+++ b/skills/platform/tao-run-on-kubernetes/scripts/render_action_job.py
@@ -10,9 +10,10 @@ each source.  This renderer preserves every producer-declared target and access
 mode, including multiple target aliases for the same source, by mounting that
 PVC subPath once per target.
 
-Credentials are deliberately not accepted as values.  ``forward_env`` names
-are made available only through an optional, pre-created Secret reference, and
-registry authentication is an independent optional image-pull Secret.
+Credentials are deliberately not accepted as values.  Each ``forward_env``
+name is projected from the same key of an optional, pre-created Secret; keys
+that the producer did not approve are never imported.  Registry authentication
+is an independent optional image-pull Secret.
 """
 
 from __future__ import annotations
@@ -38,6 +39,7 @@ DNS_SUBDOMAIN_RE = re.compile(
 )
 QUANTITY_RE = re.compile(r"[1-9][0-9]*(?:Ki|Mi|Gi|Ti|Pi|Ei)")
 MAX_JOB_NAME = 52
+REQUEST_SCHEMA_VERSION = "1"
 
 
 class RenderError(ValueError):
@@ -242,11 +244,11 @@ def _require_writable_outputs(
 
 def _environment(
     request: dict[str, Any], credential_secret: str | None
-) -> tuple[list[dict[str, str]], list[dict[str, dict[str, str]]]]:
+) -> list[dict[str, Any]]:
     raw_environment = request.get("environment", {})
     if not isinstance(raw_environment, dict):
         raise RenderError("request.environment must be an object")
-    environment: list[dict[str, str]] = []
+    environment: list[dict[str, Any]] = []
     for name in sorted(raw_environment):
         if ENV_NAME_RE.fullmatch(name) is None:
             raise RenderError(f"invalid environment variable name: {name!r}")
@@ -270,12 +272,21 @@ def _environment(
         raise RenderError(
             "request.forward_env is non-empty but no --credential-secret was supplied"
         )
-    env_from = (
-        [{"secretRef": {"name": credential_secret}}]
-        if credential_secret is not None
-        else []
-    )
-    return environment, env_from
+    if not forward and credential_secret is not None:
+        raise RenderError(
+            "--credential-secret must be omitted when request.forward_env is empty"
+        )
+    if credential_secret is not None:
+        environment.extend(
+            {
+                "name": name,
+                "valueFrom": {
+                    "secretKeyRef": {"name": credential_secret, "key": name}
+                },
+            }
+            for name in forward
+        )
+    return environment
 
 
 def render_action_job(
@@ -292,6 +303,10 @@ def render_action_job(
     template_path: pathlib.Path = DEFAULT_TEMPLATE,
 ) -> str:
     """Validate inputs and return a complete Kubernetes Job manifest."""
+    if request.get("schema_version") != REQUEST_SCHEMA_VERSION:
+        raise RenderError(
+            f"request.schema_version must be {REQUEST_SCHEMA_VERSION!r}"
+        )
     if request.get("platform") != "kubernetes":
         raise RenderError("request.platform must be 'kubernetes'")
     job_id = _nonempty_string(job_id, "job id")
@@ -315,7 +330,7 @@ def render_action_job(
     staged = _staged_sources(staging_map)
     volume_mounts, source_modes = _mounts(request, staged)
     _require_writable_outputs(request, source_modes)
-    environment, env_from = _environment(request, credential_secret)
+    environment = _environment(request, credential_secret)
     image_pull_secrets = (
         [{"name": image_pull_secret}] if image_pull_secret is not None else []
     )
@@ -330,7 +345,6 @@ def render_action_job(
         "COMMAND_JSON": [command],
         "ARGS_JSON": args,
         "NUM_GPUS_JSON": str(gpus),
-        "ENV_FROM_JSON": env_from,
         "ENV_JSON": environment,
         "VOLUME_MOUNTS_JSON": volume_mounts,
         "SHM_SIZE_JSON": shm_size,

--- a/templates/k8s/action-job.yaml.tmpl
+++ b/templates/k8s/action-job.yaml.tmpl
@@ -31,7 +31,6 @@ spec:
           resources:
             limits:
               nvidia.com/gpu: @@NUM_GPUS_JSON@@
-          envFrom: @@ENV_FROM_JSON@@
           env: @@ENV_JSON@@
           volumeMounts: @@VOLUME_MOUNTS_JSON@@
       volumes:

--- a/templates/k8s/action-job.yaml.tmpl
+++ b/templates/k8s/action-job.yaml.tmpl
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kubernetes consumer template for a platform-neutral action request. Values are
+# JSON-encoded before substitution; JSON is a YAML subset, so argv, environment
+# values, mount paths, and secret names cannot change the manifest structure.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: @@JOB_NAME_JSON@@
+  namespace: @@NAMESPACE_JSON@@
+  annotations:
+    tao.nvidia.com/job-record-id: @@JOB_ID_JSON@@
+  labels:
+    tao-job: @@JOB_NAME_JSON@@
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: @@TTL_SECONDS_JSON@@
+  template:
+    metadata:
+      labels:
+        tao-job: @@JOB_NAME_JSON@@
+    spec:
+      restartPolicy: Never
+      imagePullSecrets: @@IMAGE_PULL_SECRETS_JSON@@
+      containers:
+        - name: tao
+          image: @@IMAGE_JSON@@
+          command: @@COMMAND_JSON@@
+          args: @@ARGS_JSON@@
+          resources:
+            limits:
+              nvidia.com/gpu: @@NUM_GPUS_JSON@@
+          envFrom: @@ENV_FROM_JSON@@
+          env: @@ENV_JSON@@
+          volumeMounts: @@VOLUME_MOUNTS_JSON@@
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: @@SHM_SIZE_JSON@@
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: @@PVC_CLAIM_JSON@@


### PR DESCRIPTION
## Issues

DEFT action requests need multiple producer-defined mounts, absolute-path aliases, safe argv, output coverage, and narrowly scoped credential forwarding. The fixed Kubernetes template collapsed these requirements into one PVC target. Review also reproduced two fail-open behaviors: a whole Secret was imported even when only one or no environment key was approved, and unsupported action-request schema versions were accepted.

Arif's review identified another contract gap: the renderer rejected every `spec_bundle.mode=config` request. That excluded DEFT AOI train/evaluate/inference/RCA and mining actions, plus Cosmos-RL train, even though config mode is a first-class producer/consumer contract.

## Original reproductions and observed failures

1. Prepare an IAA action request containing the run, config, patches, cache, and (for image actions) dataset mounts. The previous template cannot represent the producer's distinct targets/aliases.
2. Set `forward_env=[]` with a credential Secret, or `forward_env=["HF_TOKEN"]`. The previous template imports the whole Secret through `envFrom`.
3. Change `schema_version` to `999`. The previous renderer still renders it.
4. Change a valid action request to `mode=config`, supply a nested `spec`, `config_format=yaml`, and a command containing `{config_path}`. The renderer fails before launch with `Kubernetes action rendering requires spec_bundle.mode=args`.

## Root causes

- The Kubernetes consumer owned a fixed application-specific mount shape instead of rendering the producer's declared action contract.
- Credential rendering treated Secret existence as authorization for every key rather than projecting the approved allowlist.
- Only the staging-map shape was validated; the request envelope version was trusted.
- The consumer implemented only the args branch of the mode-discriminated spec-bundle contract. It had no owned step to serialize config content, stage the resulting file, mount it into the pod, or substitute its compute-frame path.

## Implementation

- Add a generic action-job renderer and template driven by the validated action request plus an explicit source-to-PVC staging map.
- Render every distinct mount and alias with the correct read-only flags; validate output coverage, command/argv, resource shape, paths, and Kubernetes names.
- Normalize invalid job IDs while preserving the original ID as an annotation.
- Project each approved credential key through individual `env[].valueFrom.secretKeyRef` entries; never use whole-Secret `envFrom`, and reject a Secret when the allowlist is empty.
- Fail closed on missing or unsupported request schema versions.
- Add `materialize-config` for `mode=config` bundles. It canonically serializes YAML/JSON/TOML specs into atomic, SHA-256-addressed, owner-only files.
- Require the exact generated file in the staging receipt, verify its bytes again at render time, reject symlinks/stale content, mount the staged file read-only at a content-addressed pod path, and substitute that path for `{config_path}`.
- Preserve simple commands as native Kubernetes argv. Preserve producer-owned multi-line config shell commands (including Cosmos-RL hook discovery and heredocs) verbatim under `/bin/sh -c`; config values are never interpolated as shell text.
- Add contract documentation and template validation coverage.

## Why this is a root-cause fix

The consumer now implements both branches of the producer/consumer abstraction. Config content stays producer-owned while serialization, placement, and compute-frame path substitution stay platform-owned. The rendered pod consumes the same bytes that were derived from the approved bundle, instead of relying on an unrelated path or mutable hand-authored file.

We intentionally avoided the shortcut of re-emitting config requests as `mode=args`, adding DEFT-stage special cases, trusting an arbitrary `--config-source`, or copying config values into shell text. Those approaches would mask the missing consumer behavior, weaken provenance, or introduce a second platform-specific action contract. The mount renderer remains application-neutral.

Credential authorization is enforced at key granularity, and version compatibility is enforced at the request boundary. We also avoided hardcoded mount counts, application-path conditionals, whole-Secret fallbacks, and permissive future-schema handling.

## Regression coverage and post-fix verification

- Focused Kubernetes action-renderer suite: **43 passed**.
- Kubernetes renderer plus adjacent single-pod and multi-node template suites: **72 passed**.
- Full `scripts/tests`: **302 passed, 2 skipped**.
- `scripts/validate-skills.sh`: **passed**.
- `scripts/stamp_versions.py --check`: **passed**.
- `git diff --check`: **passed**.
- The original config-mode CLI reproduction now materializes the spec, includes the generated file in the staging receipt, renders the Job, removes the literal `{config_path}`, and produces a verified read-only file mount.
- Variations cover YAML, JSON, nested TOML and inline-table arrays, TOML null rejection, atomic/idempotent materialization, full content hashes, altered/stale content, symlinks, missing staging entries, args/config mode mismatch, commands missing `{config_path}`, explicit args-mode shells, and Cosmos-RL-style multi-line shell commands.
- Existing IAA mount, output, naming, argv, environment, and Secret-projection regressions continue to pass.

## Residual risk

Live API-server validation remains unavailable in this environment because it has no Kubernetes client/cluster context, namespace, PVC, or S3 target. The manifest is parsed in regression tests, but `kubectl apply --dry-run=server`/`kubeconform` was skipped. No live Kubernetes execution claim is made. TOML has no null value, so a TOML config containing `null` fails closed rather than silently dropping or changing that value.
