### PR TITLE
[TAO-0][Bugfix] Virtualenv lifecycle trusted reusable process identities

### DIFF
--- a/skills/platform/tao-run-on-virtualenv/SKILL.md
+++ b/skills/platform/tao-run-on-virtualenv/SKILL.md
@@ -2,7 +2,7 @@
 name: tao-run-on-virtualenv
 description: Run a Python training/eval script directly in an existing local virtualenv — no docker, no container. Implements the four-verb consumer contract (submit/status/logs/cancel) over a vendored process-lifecycle runner with durable on-disk state, PID-reuse-safe identity, and process-group cleanup. Use for docker-free local execution, plain-Python model scripts, fast HPO/AutoML trial smokes, or hosts where containers are unavailable. Trigger phrases include "run in my venv", "no docker", "virtualenv execution", "local python training", "run this training script directly".
 license: Apache-2.0
-compatibility: Requires a local Python virtualenv (pyvenv.cfg + bin/python) with the training script's dependencies installed. Linux is first-class (/proc); macOS works for smokes with documented caveats. No nvidia-tao-sdk, no docker.
+compatibility: Requires a local Python virtualenv (pyvenv.cfg + bin/python) with the training script's dependencies installed. Linux with procfs and pidfd signaling is required for active job cancellation; other POSIX hosts can run jobs and prove empty groups but fail closed rather than signal numeric process IDs. No nvidia-tao-sdk, no docker.
 metadata:
   author: NVIDIA Corporation
   version: "0.1.0"
@@ -119,15 +119,17 @@ python3 "$RUNNER" cancel --job-dir "$RESULTS_DIR"
 ```
 
 Cancel marks first (a not-yet-started wrapper self-cancels at its start gate),
-verifies process identity (never kills a reused PID), then SIGTERM→SIGKILLs the
-whole process group. `already_terminal` in the reply means the job finished
-before the cancel — mark the record with the status it reports instead.
+then uses a durable group guardian and Linux pidfds for SIGTERM→SIGKILL. The
+guardian prevents PGID reuse during discovery; a pidfd pins each target across
+the observation/signal boundary. `already_terminal` in the reply means the job
+finished before the cancel — mark the record with the status it reports instead.
 
 ## Platform caveats
 
-- **Linux first-class.** Identity and group cleanup use `/proc`; on macOS the
-  runner falls back to `ps`/`pgrep` — fine for local smokes, but GPU training
-  targets are Linux hosts.
+- **Linux active cancellation.** Safe active-process termination requires
+  procfs, `pidfd_open`, and `pidfd_send_signal`. On another POSIX host the
+  `ps`/`pgrep` fallback can prove a group is empty, but cancellation of active
+  members returns `UNKNOWN` instead of risking a reused numeric PID or PGID.
 - **No multi-node, no image resolution** — there is no container. The "image"
   recorded is the venv's interpreter path.
 - The runner never downloads anything. Remote inputs are the agent's job to

--- a/skills/platform/tao-run-on-virtualenv/references/tests/test_virtualenv_runner.py
+++ b/skills/platform/tao-run-on-virtualenv/references/tests/test_virtualenv_runner.py
@@ -342,11 +342,15 @@ def test_terminate_process_group_treats_unreaped_zombie_as_dead():
         start_new_session=True,
     )
     try:
+        marker = vr._process_start_marker(process.pid)
+        assert marker is not None
         # Do not call poll(): it would reap our child and erase the condition.
         assert wait_for(lambda: not _pid_active(process.pid)), \
             "child did not reach zombie state"
         assert os.killpg(process.pid, 0) is None  # Group is still signalable.
-        assert vr._terminate_process_group(process.pid, timeout=0.1) == "terminated"
+        assert vr._terminate_process_group(
+            process.pid, {process.pid: marker}, timeout=0.1
+        ) == "terminated"
     finally:
         process.wait(timeout=5)
 
@@ -362,12 +366,91 @@ def test_terminate_process_group_escalates_for_live_sigterm_ignorer(tmp_path):
     process = subprocess.Popen([sys.executable, str(script)], start_new_session=True)
     try:
         assert wait_for(ready.exists), "SIGTERM-ignoring child never became ready"
-        assert vr._terminate_process_group(process.pid, timeout=0.1) == "terminated"
+        marker = vr._process_start_marker(process.pid)
+        assert marker is not None
+        assert vr._terminate_process_group(
+            process.pid, {process.pid: marker}, timeout=0.1
+        ) == "terminated"
         assert process.wait(timeout=5) == -signal.SIGKILL
     finally:
         if process.poll() is None:
             process.kill()
             process.wait()
+
+
+def test_permission_error_is_success_only_for_definitively_empty_group(monkeypatch):
+    """macOS may reject a signal to a zombie-only group with EPERM."""
+    probes = iter(([73], []))
+    monkeypatch.setattr(vr, "_active_process_group_members", lambda _pgid: next(probes))
+    monkeypatch.setattr(vr, "_identity_matches", lambda *_args: True)
+    monkeypatch.setattr(vr.os, "killpg", lambda *_args: (_ for _ in ()).throw(
+        PermissionError("zombie-only group")
+    ))
+
+    assert vr._terminate_process_group(73, {73: "start-1"}, timeout=0) == "terminated"
+
+
+def test_permission_error_with_live_or_indeterminate_members_is_not_success(monkeypatch):
+    for after_signal in ([74], None):
+        probes = iter(([74], after_signal))
+        monkeypatch.setattr(
+            vr, "_active_process_group_members", lambda _pgid, probes=probes: next(probes)
+        )
+        monkeypatch.setattr(vr, "_identity_matches", lambda *_args: True)
+        monkeypatch.setattr(vr.os, "killpg", lambda *_args: (_ for _ in ()).throw(
+            PermissionError("not signalable")
+        ))
+        with pytest.raises(RuntimeError, match="permission denied"):
+            vr._terminate_process_group(74, {74: "start-1"}, timeout=0)
+
+
+def test_reused_pgid_is_rejected_before_sigkill(monkeypatch):
+    """A marker change after SIGTERM must revoke authority to escalate."""
+    markers = iter((True, False))
+    signals = []
+    monkeypatch.setattr(vr, "_active_process_group_members", lambda _pgid: [75])
+    monkeypatch.setattr(vr, "_identity_matches", lambda *_args: next(markers))
+    monkeypatch.setattr(vr.os, "killpg", lambda pgid, sig: signals.append((pgid, sig)))
+
+    with pytest.raises(RuntimeError, match="no longer matches this job"):
+        vr._terminate_process_group(75, {75: "old-start"}, timeout=0)
+    assert signals == [(75, signal.SIGTERM)]  # The reused group never receives SIGKILL.
+
+
+@pytest.mark.parametrize("failure", ["malformed", "unreadable"])
+def test_relevant_proc_probe_failure_is_indeterminate(
+    monkeypatch, tmp_path, failure,
+):
+    proc_root = tmp_path / "proc"
+    entry = proc_root / "76"
+    entry.mkdir(parents=True)
+    stat_path = entry / "stat"
+    stat_path.write_text("not a proc stat", encoding="utf-8")
+    monkeypatch.setattr(vr.os, "getpgid", lambda _pid: 76)
+    if failure == "unreadable":
+        real_read_text = Path.read_text
+
+        def denied(path, *args, **kwargs):
+            if path == stat_path:
+                raise PermissionError("hidden proc entry")
+            return real_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", denied)
+
+    assert vr._active_process_group_members(76, proc_root=proc_root) is None
+
+
+def test_irrelevant_unreadable_proc_entry_does_not_poison_group_probe(
+    monkeypatch, tmp_path,
+):
+    proc_root = tmp_path / "proc"
+    entry = proc_root / "77"
+    entry.mkdir(parents=True)
+    stat_path = entry / "stat"
+    stat_path.write_text("not a proc stat", encoding="utf-8")
+    monkeypatch.setattr(vr.os, "getpgid", lambda _pid: 999)
+
+    assert vr._active_process_group_members(76, proc_root=proc_root) == []
 
 
 # ---------------------------------------------------------------------------

--- a/skills/platform/tao-run-on-virtualenv/references/tests/test_virtualenv_runner.py
+++ b/skills/platform/tao-run-on-virtualenv/references/tests/test_virtualenv_runner.py
@@ -270,11 +270,20 @@ def test_leaked_background_child_is_cleaned_up(capsys, venv, job_dir, tmp_path):
     final = wait_terminal(capsys, job_dir)
     assert final["status"] == "COMPLETE", final  # cleanup succeeded, exit stays 0
     child_pid = int((job_dir / "child.pid").read_text())
-    assert wait_for(lambda: not _pid_alive(child_pid), timeout=5), \
+    assert wait_for(lambda: not _pid_active(child_pid), timeout=5), \
         "background child leaked past job completion"
 
 
-def _pid_alive(pid):
+def _pid_active(pid):
+    """Whether a process can still execute (an unreaped zombie cannot)."""
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        fields = stat[stat.rfind(")") + 2:].split()
+        return fields[0] != "Z"
+    except FileNotFoundError:
+        return False
+    except (OSError, IndexError):
+        pass
     try:
         os.kill(pid, 0)
         return True
@@ -321,6 +330,44 @@ def test_marker_mismatch_rejects_group_leader(capsys, venv, job_dir):
     finally:
         foreign.kill()
         foreign.wait()
+
+
+@pytest.mark.skipif(
+    not Path("/proc").is_dir(), reason="deterministic zombie state needs /proc"
+)
+def test_terminate_process_group_treats_unreaped_zombie_as_dead():
+    """Signalability of a zombie group leader is not process liveness."""
+    process = subprocess.Popen(
+        [sys.executable, "-c", "pass"],
+        start_new_session=True,
+    )
+    try:
+        # Do not call poll(): it would reap our child and erase the condition.
+        assert wait_for(lambda: not _pid_active(process.pid)), \
+            "child did not reach zombie state"
+        assert os.killpg(process.pid, 0) is None  # Group is still signalable.
+        assert vr._terminate_process_group(process.pid, timeout=0.1) == "terminated"
+    finally:
+        process.wait(timeout=5)
+
+
+def test_terminate_process_group_escalates_for_live_sigterm_ignorer(tmp_path):
+    ready = tmp_path / "ready"
+    script = write_script(tmp_path, "ignore_term.py", (
+        "import pathlib, signal, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        f"pathlib.Path({str(ready)!r}).touch()\n"
+        "time.sleep(300)\n"
+    ))
+    process = subprocess.Popen([sys.executable, str(script)], start_new_session=True)
+    try:
+        assert wait_for(ready.exists), "SIGTERM-ignoring child never became ready"
+        assert vr._terminate_process_group(process.pid, timeout=0.1) == "terminated"
+        assert process.wait(timeout=5) == -signal.SIGKILL
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
 
 
 # ---------------------------------------------------------------------------
@@ -417,7 +464,8 @@ def test_orphaned_script_group_reports_running_and_cancel_kills_it(
     assert wait_for(lambda: len(script_child()) > 0), "script child never appeared"
     children = script_child()
     os.kill(wrapper_pid, signal.SIGKILL)
-    assert wait_for(lambda: not _pid_alive(wrapper_pid) or True, timeout=2)
+    assert wait_for(lambda: not _pid_active(wrapper_pid), timeout=2), \
+        "killed wrapper remained active"
 
     _, status = run_verb(capsys, "status", "--job-dir", str(job_dir))
     assert status["status"] == "RUNNING", status
@@ -426,7 +474,7 @@ def test_orphaned_script_group_reports_running_and_cancel_kills_it(
     rc, cancel = run_verb(capsys, "cancel", "--job-dir", str(job_dir))
     assert rc == 0 and cancel["result"] == "canceled", cancel
     for child in children:
-        assert wait_for(lambda: not _pid_alive(child), timeout=5), \
+        assert wait_for(lambda: not _pid_active(child), timeout=5), \
             f"orphaned child {child} survived cancel"
     _, after = run_verb(capsys, "status", "--job-dir", str(job_dir))
     assert after["status"] == "CANCELED", after

--- a/skills/platform/tao-run-on-virtualenv/references/tests/test_virtualenv_runner.py
+++ b/skills/platform/tao-run-on-virtualenv/references/tests/test_virtualenv_runner.py
@@ -21,6 +21,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import virtualenv_runner as vr  # noqa: E402
+import virtualenv_group_supervisor as vgs  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -237,11 +238,15 @@ def test_wrapper_honors_cancel_before_start_gate(venv, tmp_path):
     job.mkdir()
     wrapper = job / "launch_job.py"
     wrapper.write_text(vr.JOB_WRAPPER_SOURCE, encoding="utf-8")
+    supervisor = job / "supervise_group.py"
+    supervisor.write_bytes(vr.SUPERVISOR_SOURCE_PATH.read_bytes())
     exit_p, launch_p = job / "exit.json", job / "launcher.json"
     gate_p, cancel_p = job / "gate", job / "cancel"
+    guardian_release = job / "guardian-release"
     proc = subprocess.Popen(
         [str(venv / "bin" / "python"), str(wrapper), str(exit_p), str(launch_p),
-         str(gate_p), str(cancel_p), str(venv / "bin" / "python"), "-c", "print('nope')"],
+         str(gate_p), str(cancel_p), str(supervisor), str(guardian_release),
+         str(venv / "bin" / "python"), "-c", "print('nope')"],
         start_new_session=True,
     )
     assert wait_for(launch_p.exists)          # durable identity written immediately
@@ -304,8 +309,8 @@ def test_pid_reuse_is_not_treated_as_running(capsys, venv, job_dir):
         "pid": os.getpid(), "process_start_marker": "bogus-marker",
     })
     rc, status = run_verb(capsys, "status", "--job-dir", str(job_dir))
-    assert status["status"] == "ERROR"
-    assert "durable exit status" in status["message"]
+    assert status["status"] == "UNKNOWN"
+    assert "ownership is indeterminate" in status["message"]
 
 
 def test_marker_mismatch_rejects_group_leader(capsys, venv, job_dir):
@@ -323,7 +328,7 @@ def test_marker_mismatch_rejects_group_leader(capsys, venv, job_dir):
             "pid": foreign.pid, "process_start_marker": "definitely-wrong",
         })
         rc, status = run_verb(capsys, "status", "--job-dir", str(job_dir))
-        assert status["status"] == "ERROR"
+        assert status["status"] == "UNKNOWN"
         # And cancel must refuse to signal it: the foreign process survives.
         run_verb(capsys, "cancel", "--job-dir", str(job_dir))
         assert foreign.poll() is None, "cancel killed an innocent process"
@@ -335,86 +340,133 @@ def test_marker_mismatch_rejects_group_leader(capsys, venv, job_dir):
 @pytest.mark.skipif(
     not Path("/proc").is_dir(), reason="deterministic zombie state needs /proc"
 )
-def test_terminate_process_group_treats_unreaped_zombie_as_dead():
-    """Signalability of a zombie group leader is not process liveness."""
-    process = subprocess.Popen(
-        [sys.executable, "-c", "pass"],
-        start_new_session=True,
+def test_pidfd_supervisor_treats_unreaped_zombie_as_dead(tmp_path):
+    """A zombie child is not a target while its guardian anchors the PGID."""
+    child_path = tmp_path / "child.pid"
+    guardian_script = write_script(tmp_path, "zombie_guardian.py", (
+        "import os, pathlib, time\n"
+        "child = os.fork()\n"
+        "if child == 0: os._exit(0)\n"
+        f"pathlib.Path({str(child_path)!r}).write_text(str(child))\n"
+        "time.sleep(300)\n"
+    ))
+    guardian = subprocess.Popen(
+        [sys.executable, str(guardian_script)], start_new_session=True
     )
     try:
-        marker = vr._process_start_marker(process.pid)
+        assert wait_for(child_path.exists)
+        child_pid = int(child_path.read_text())
+        marker = vr._process_start_marker(guardian.pid)
         assert marker is not None
-        # Do not call poll(): it would reap our child and erase the condition.
-        assert wait_for(lambda: not _pid_active(process.pid)), \
+        assert wait_for(lambda: not _pid_active(child_pid)), \
             "child did not reach zombie state"
-        assert os.killpg(process.pid, 0) is None  # Group is still signalable.
-        assert vr._terminate_process_group(
-            process.pid, {process.pid: marker}, timeout=0.1
-        ) == "terminated"
+        result = vgs.supervise(
+            pgid=guardian.pid,
+            guardian_pid=guardian.pid,
+            guardian_marker=marker,
+            excludes={},  # guardian exclusion is enforced by the abstraction
+            term_timeout=0.1,
+            kill_timeout=0.2,
+        )
+        assert result["result"] in {"empty", "terminated"}
+        assert guardian.poll() is None
     finally:
-        process.wait(timeout=5)
+        guardian.kill()
+        guardian.wait(timeout=5)
 
 
-def test_terminate_process_group_escalates_for_live_sigterm_ignorer(tmp_path):
-    ready = tmp_path / "ready"
-    script = write_script(tmp_path, "ignore_term.py", (
-        "import pathlib, signal, time\n"
-        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+def _guardian_with_child(tmp_path, child_source):
+    child_path = tmp_path / "child.pid"
+    ready = tmp_path / "child.ready"
+    script = write_script(tmp_path, "guardian.py", (
+        "import os, pathlib, sys, time\n"
+        "child = os.fork()\n"
+        "if child == 0:\n"
+        f"    os.execv(sys.executable, [sys.executable, '-c', {child_source!r}])\n"
+        f"pathlib.Path({str(child_path)!r}).write_text(str(child))\n"
         f"pathlib.Path({str(ready)!r}).touch()\n"
         "time.sleep(300)\n"
     ))
-    process = subprocess.Popen([sys.executable, str(script)], start_new_session=True)
+    guardian = subprocess.Popen([sys.executable, str(script)], start_new_session=True)
+    assert wait_for(ready.exists)
+    return guardian, int(child_path.read_text())
+
+
+def test_pidfd_supervisor_escalates_for_live_sigterm_ignorer(tmp_path):
+    guardian, child_pid = _guardian_with_child(
+        tmp_path,
+        "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(300)",
+    )
     try:
-        assert wait_for(ready.exists), "SIGTERM-ignoring child never became ready"
-        marker = vr._process_start_marker(process.pid)
+        marker = vr._process_start_marker(guardian.pid)
         assert marker is not None
-        assert vr._terminate_process_group(
-            process.pid, {process.pid: marker}, timeout=0.1
-        ) == "terminated"
-        assert process.wait(timeout=5) == -signal.SIGKILL
-    finally:
-        if process.poll() is None:
-            process.kill()
-            process.wait()
-
-
-def test_permission_error_is_success_only_for_definitively_empty_group(monkeypatch):
-    """macOS may reject a signal to a zombie-only group with EPERM."""
-    probes = iter(([73], []))
-    monkeypatch.setattr(vr, "_active_process_group_members", lambda _pgid: next(probes))
-    monkeypatch.setattr(vr, "_identity_matches", lambda *_args: True)
-    monkeypatch.setattr(vr.os, "killpg", lambda *_args: (_ for _ in ()).throw(
-        PermissionError("zombie-only group")
-    ))
-
-    assert vr._terminate_process_group(73, {73: "start-1"}, timeout=0) == "terminated"
-
-
-def test_permission_error_with_live_or_indeterminate_members_is_not_success(monkeypatch):
-    for after_signal in ([74], None):
-        probes = iter(([74], after_signal))
-        monkeypatch.setattr(
-            vr, "_active_process_group_members", lambda _pgid, probes=probes: next(probes)
+        result = vgs.supervise(
+            pgid=guardian.pid,
+            guardian_pid=guardian.pid,
+            guardian_marker=marker,
+            excludes={guardian.pid: marker},
+            term_timeout=0.1,
+            kill_timeout=1.0,
         )
-        monkeypatch.setattr(vr, "_identity_matches", lambda *_args: True)
-        monkeypatch.setattr(vr.os, "killpg", lambda *_args: (_ for _ in ()).throw(
-            PermissionError("not signalable")
-        ))
-        with pytest.raises(RuntimeError, match="permission denied"):
-            vr._terminate_process_group(74, {74: "start-1"}, timeout=0)
+        assert result["result"] == "terminated"
+        assert wait_for(lambda: not _pid_active(child_pid))
+        assert guardian.poll() is None
+    finally:
+        guardian.kill()
+        guardian.wait()
 
 
-def test_reused_pgid_is_rejected_before_sigkill(monkeypatch):
-    """A marker change after SIGTERM must revoke authority to escalate."""
-    markers = iter((True, False))
-    signals = []
-    monkeypatch.setattr(vr, "_active_process_group_members", lambda _pgid: [75])
-    monkeypatch.setattr(vr, "_identity_matches", lambda *_args: next(markers))
-    monkeypatch.setattr(vr.os, "killpg", lambda pgid, sig: signals.append((pgid, sig)))
+def test_pidfd_permission_error_with_live_member_is_not_success(
+    monkeypatch, tmp_path,
+):
+    guardian, child_pid = _guardian_with_child(tmp_path, "import time; time.sleep(300)")
+    marker = vr._process_start_marker(guardian.pid)
+    assert marker is not None
+    monkeypatch.setattr(
+        vgs.signal,
+        "pidfd_send_signal",
+        lambda *_args: (_ for _ in ()).throw(PermissionError("not signalable")),
+    )
+    try:
+        with pytest.raises(vgs.SupervisionError, match="permission denied"):
+            vgs.supervise(
+                pgid=guardian.pid,
+                guardian_pid=guardian.pid,
+                guardian_marker=marker,
+                excludes={guardian.pid: marker},
+                term_timeout=0,
+                kill_timeout=0,
+            )
+        assert _pid_active(child_pid)
+    finally:
+        os.kill(child_pid, signal.SIGKILL)
+        guardian.kill()
+        guardian.wait()
 
-    with pytest.raises(RuntimeError, match="no longer matches this job"):
-        vr._terminate_process_group(75, {75: "old-start"}, timeout=0)
-    assert signals == [(75, signal.SIGTERM)]  # The reused group never receives SIGKILL.
+
+def test_pidfd_open_rejects_identity_change_before_any_signal(monkeypatch):
+    before = vgs.ProcFact(75, "S", 75, "old-start")
+    after = vgs.ProcFact(75, "S", 75, "reused-start")
+    fd = os.open("/dev/null", os.O_RDONLY)
+    monkeypatch.setattr(vgs, "_pidfd_capable", lambda: True)
+    monkeypatch.setattr(vgs, "_pidfd_open", lambda _pid: fd)
+    monkeypatch.setattr(vgs, "_pidfd_dead", lambda _fd: False)
+    monkeypatch.setattr(vgs, "_proc_fact", lambda _pid: after)
+    with pytest.raises(vgs.OwnershipError, match="changed identity"):
+        vgs._open_verified_pidfd(before)
+
+
+def test_pidfd_open_accepts_normal_process_state_transition(monkeypatch):
+    before = vgs.ProcFact(75, "R", 75, "same-start")
+    after = vgs.ProcFact(75, "S", 75, "same-start")
+    fd = os.open("/dev/null", os.O_RDONLY)
+    monkeypatch.setattr(vgs, "_pidfd_capable", lambda: True)
+    monkeypatch.setattr(vgs, "_pidfd_open", lambda _pid: fd)
+    monkeypatch.setattr(vgs, "_pidfd_dead", lambda _fd: False)
+    monkeypatch.setattr(vgs, "_proc_fact", lambda _pid: after)
+    opened = vgs._open_verified_pidfd(before)
+    assert opened == fd
+    os.close(opened)
 
 
 @pytest.mark.parametrize("failure", ["malformed", "unreadable"])
@@ -426,7 +478,7 @@ def test_relevant_proc_probe_failure_is_indeterminate(
     entry.mkdir(parents=True)
     stat_path = entry / "stat"
     stat_path.write_text("not a proc stat", encoding="utf-8")
-    monkeypatch.setattr(vr.os, "getpgid", lambda _pid: 76)
+    monkeypatch.setattr(vgs.os, "getpgid", lambda _pid: 76)
     if failure == "unreadable":
         real_read_text = Path.read_text
 
@@ -437,6 +489,8 @@ def test_relevant_proc_probe_failure_is_indeterminate(
 
         monkeypatch.setattr(Path, "read_text", denied)
 
+    with pytest.raises(vgs.SupervisionError):
+        vgs.group_facts(76, proc_root=proc_root)
     assert vr._active_process_group_members(76, proc_root=proc_root) is None
 
 
@@ -448,9 +502,51 @@ def test_irrelevant_unreadable_proc_entry_does_not_poison_group_probe(
     entry.mkdir(parents=True)
     stat_path = entry / "stat"
     stat_path.write_text("not a proc stat", encoding="utf-8")
-    monkeypatch.setattr(vr.os, "getpgid", lambda _pid: 999)
+    monkeypatch.setattr(vgs.os, "getpgid", lambda _pid: 999)
 
+    assert vgs.group_facts(76, proc_root=proc_root) == []
     assert vr._active_process_group_members(76, proc_root=proc_root) == []
+
+
+def test_fallback_group_probe_failure_is_indeterminate(monkeypatch):
+    monkeypatch.setattr(
+        vgs.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 2, "", "denied"),
+    )
+    with pytest.raises(vgs.SupervisionError, match="pgrep failed"):
+        vgs._fallback_group_facts(76)
+
+
+def test_fallback_process_state_probe_failure_is_indeterminate(monkeypatch):
+    probes = iter((
+        subprocess.CompletedProcess([], 0, "77\n", ""),
+        subprocess.CompletedProcess([], 2, "", "denied"),
+    ))
+    monkeypatch.setattr(
+        vgs.subprocess, "run", lambda *_args, **_kwargs: next(probes),
+    )
+    monkeypatch.setattr(vgs.os, "getpgid", lambda _pid: 76)
+
+    with pytest.raises(vgs.SupervisionError, match="indeterminate"):
+        vgs._fallback_group_facts(76)
+
+
+def test_active_non_pidfd_group_is_never_signaled_by_number(monkeypatch):
+    guardian = vgs.ProcFact(76, "S", 76, "guardian-start")
+    workload = vgs.ProcFact(77, "S", 76, "workload-start")
+    monkeypatch.setattr(vgs, "group_facts", lambda _pgid: [guardian, workload])
+    monkeypatch.setattr(vgs, "_pidfd_capable", lambda: False)
+
+    with pytest.raises(vgs.SupervisionError, match="require Linux pidfd"):
+        vgs.supervise(
+            pgid=76,
+            guardian_pid=76,
+            guardian_marker="guardian-start",
+            excludes={},
+            term_timeout=0,
+            kill_timeout=0,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -471,6 +567,23 @@ def test_orphaned_pending_grace_then_error(capsys, job_dir):
 def test_status_unknown_on_empty_dir(capsys, job_dir):
     _, payload = run_verb(capsys, "status", "--job-dir", str(job_dir))
     assert payload["status"] == "UNKNOWN"
+
+    rc, canceled = run_verb(capsys, "cancel", "--job-dir", str(job_dir))
+    assert rc == 1
+    assert canceled["result"] == "error" and canceled["status"] == "UNKNOWN"
+
+
+def test_late_cancel_marker_does_not_relabel_natural_exit(capsys, job_dir):
+    paths = vr.RunnerPaths(job_dir)
+    paths.runner_dir.mkdir(parents=True)
+    vr._atomic_write_json(paths.exit_status, {
+        "return_code": 0,
+        "canceled": False,
+    })
+    vr._atomic_write_json(paths.cancel_marker, {"timeout": 1.0})
+
+    _, status = run_verb(capsys, "status", "--job-dir", str(job_dir))
+    assert status["status"] == "COMPLETE"
 
 
 def test_double_submit_is_refused(capsys, venv, job_dir, tmp_path):
@@ -541,11 +654,19 @@ def test_orphaned_script_group_reports_running_and_cancel_kills_it(
                        "--script", str(script))
     assert rc == 0
     wrapper_pid = sub["pid"]
-    # Wait until the script child exists inside the group, then kill ONLY the wrapper.
-    def script_child():
-        return [p for p in vr._group_members(wrapper_pid, str(script)) if p != wrapper_pid]
-    assert wait_for(lambda: len(script_child()) > 0), "script child never appeared"
-    children = script_child()
+    paths = vr.RunnerPaths(job_dir)
+
+    def durable_workload():
+        record = vr._read_json(paths.launcher_status) or {}
+        return (
+            record.get("workload_pid"),
+            record.get("workload_start_marker"),
+        )
+
+    assert wait_for(lambda: all(durable_workload())), \
+        "direct workload identity was not persisted"
+    workload_pid, workload_marker = durable_workload()
+    assert vr._identity_matches(workload_pid, workload_marker, wrapper_pid) is True
     os.kill(wrapper_pid, signal.SIGKILL)
     assert wait_for(lambda: not _pid_active(wrapper_pid), timeout=2), \
         "killed wrapper remained active"
@@ -556,11 +677,52 @@ def test_orphaned_script_group_reports_running_and_cancel_kills_it(
 
     rc, cancel = run_verb(capsys, "cancel", "--job-dir", str(job_dir))
     assert rc == 0 and cancel["result"] == "canceled", cancel
-    for child in children:
-        assert wait_for(lambda: not _pid_active(child), timeout=5), \
-            f"orphaned child {child} survived cancel"
+    assert wait_for(lambda: not _pid_active(workload_pid), timeout=5), \
+        f"orphaned workload {workload_pid} survived cancel"
     _, after = run_verb(capsys, "status", "--job-dir", str(job_dir))
     assert after["status"] == "CANCELED", after
+
+
+def test_exec_replaced_workload_remains_owned_after_wrapper_death(
+    capsys, venv, job_dir, tmp_path,
+):
+    """The persisted start identity, not submitted cmdline text, binds execve."""
+    ready = tmp_path / "replacement.ready"
+    replacement = (
+        "import pathlib,time; "
+        f"pathlib.Path({str(ready)!r}).touch(); "
+        "time.sleep(300)"
+    )
+    script = write_script(tmp_path, "replace.py", (
+        "import os, sys\n"
+        f"os.execv(sys.executable, [sys.executable, '-c', {replacement!r}])\n"
+    ))
+    rc, submitted = run_verb(
+        capsys, "submit", "--job-dir", str(job_dir), "--venv", str(venv),
+        "--script", str(script),
+    )
+    assert rc == 0
+    wrapper_pid = submitted["pid"]
+    paths = vr.RunnerPaths(job_dir)
+    assert wait_for(ready.exists), "exec-replaced workload never became ready"
+    launch = vr._read_json(paths.launcher_status)
+    workload_pid = launch["workload_pid"]
+    workload_marker = launch["workload_start_marker"]
+    cmdline = Path(f"/proc/{workload_pid}/cmdline").read_bytes().split(b"\0")
+    assert os.fsencode(str(script)) not in cmdline, "workload did not exec-replace"
+    assert vr._identity_matches(workload_pid, workload_marker, wrapper_pid) is True
+
+    os.kill(wrapper_pid, signal.SIGKILL)
+    assert wait_for(lambda: not _pid_active(wrapper_pid), timeout=2)
+    _, orphaned = run_verb(capsys, "status", "--job-dir", str(job_dir))
+    assert orphaned["status"] == "RUNNING" and orphaned["orphaned"] is True
+
+    rc, canceled = run_verb(capsys, "cancel", "--job-dir", str(job_dir))
+    assert rc == 0 and canceled["result"] == "canceled", canceled
+    assert wait_for(lambda: not _pid_active(workload_pid), timeout=5)
+    assert wait_for(
+        lambda: not _pid_active(launch["guardian_pid"]), timeout=5,
+    ), "durable guardian did not release after cancellation"
 
 
 def test_wrapper_gate_timeout_writes_durable_error(venv, tmp_path):
@@ -569,11 +731,15 @@ def test_wrapper_gate_timeout_writes_durable_error(venv, tmp_path):
     job.mkdir()
     wrapper = job / "launch_job.py"
     wrapper.write_text(vr.JOB_WRAPPER_SOURCE, encoding="utf-8")
+    supervisor = job / "supervise_group.py"
+    supervisor.write_bytes(vr.SUPERVISOR_SOURCE_PATH.read_bytes())
     exit_p, launch_p = job / "exit.json", job / "launcher.json"
+    guardian_release = job / "guardian-release"
     env = {**os.environ, "TAO_RUNNER_GATE_TIMEOUT": "1"}
     proc = subprocess.Popen(
         [str(venv / "bin" / "python"), str(wrapper), str(exit_p), str(launch_p),
          str(job / "gate"), str(job / "cancel"),
+         str(supervisor), str(guardian_release),
          str(venv / "bin" / "python"), "-c", "print('never runs')"],
         start_new_session=True, env=env,
     )

--- a/skills/platform/tao-run-on-virtualenv/references/virtualenv_group_supervisor.py
+++ b/skills/platform/tao-run-on-virtualenv/references/virtualenv_group_supervisor.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed process-group supervision for virtualenv-native jobs.
+
+The caller supplies a durable guardian identity that remains alive in the job
+process group for the whole operation.  On Linux, every destructive signal is
+sent through a pidfd, never a numeric PID or PGID.  The live guardian prevents
+the numeric group id from being reused while members are discovered, and the
+pidfds pin each target across the observation/signal boundary.
+
+On another POSIX platform this helper may prove that no target remains, but it
+refuses to signal because there is no equivalent kernel-held process handle in
+the Python standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import json
+import os
+import platform
+import select
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class SupervisionError(RuntimeError):
+    """The target group could not be observed or signaled safely."""
+
+
+class OwnershipError(SupervisionError):
+    """The durable guardian no longer owns the recorded process group."""
+
+
+@dataclass(frozen=True)
+class ProcFact:
+    pid: int
+    state: str
+    pgid: int
+    start_marker: str
+
+    @property
+    def active(self) -> bool:
+        return self.state != "Z"
+
+
+def _proc_fact(pid: int, *, proc_root: Path = Path("/proc")) -> ProcFact | None:
+    """Read one Linux identity atomically enough to validate a later pidfd.
+
+    ``None`` means the process is gone.  Any other observation failure is
+    indeterminate and therefore raises instead of being converted to absence.
+    """
+    try:
+        raw = (proc_root / str(pid) / "stat").read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        try:
+            os.getpgid(pid)
+        except ProcessLookupError:
+            return None
+        except OSError:
+            pass
+        raise SupervisionError(f"cannot read /proc/{pid}/stat: {exc}") from exc
+    closing = raw.rfind(")")
+    if closing < 0:
+        raise SupervisionError(f"malformed /proc/{pid}/stat: missing comm terminator")
+    fields = raw[closing + 2 :].split()
+    if len(fields) <= 19:
+        raise SupervisionError(f"malformed /proc/{pid}/stat: truncated fields")
+    try:
+        return ProcFact(
+            pid=pid,
+            state=fields[0],
+            pgid=int(fields[2]),
+            start_marker=fields[19],
+        )
+    except (TypeError, ValueError) as exc:
+        raise SupervisionError(f"malformed /proc/{pid}/stat: invalid fields") from exc
+
+
+def _linux_group_facts(
+    pgid: int, *, proc_root: Path = Path("/proc"),
+) -> list[ProcFact]:
+    root = proc_root
+    try:
+        entries = list(root.iterdir())
+    except OSError as exc:
+        raise SupervisionError(f"cannot enumerate /proc: {exc}") from exc
+    facts: list[ProcFact] = []
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        try:
+            fact = _proc_fact(pid, proc_root=proc_root)
+        except SupervisionError:
+            # An unreadable unrelated process must not poison an otherwise
+            # observable same-UID job.  getpgid is the only safe discriminator.
+            try:
+                observed_group = os.getpgid(pid)
+            except ProcessLookupError:
+                continue
+            except OSError as exc:
+                raise SupervisionError(
+                    f"cannot determine whether unreadable process {pid} belongs "
+                    f"to process group {pgid}: {exc}"
+                ) from exc
+            if observed_group != pgid:
+                continue
+            raise
+        if fact is not None and fact.pgid == pgid:
+            facts.append(fact)
+    return sorted(facts, key=lambda item: item.pid)
+
+
+def _fallback_group_facts(pgid: int) -> list[ProcFact]:
+    """Portable empty-group proof; active members cannot be signaled safely."""
+    try:
+        found = subprocess.run(
+            ["pgrep", "-g", str(pgid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
+            check=False,
+        )
+    except Exception as exc:
+        raise SupervisionError(f"cannot enumerate process group {pgid}: {exc}") from exc
+    if found.returncode == 1:
+        return []
+    if found.returncode != 0:
+        raise SupervisionError(
+            f"pgrep failed while enumerating process group {pgid} "
+            f"(exit {found.returncode})"
+        )
+    facts: list[ProcFact] = []
+    for token in found.stdout.split():
+        if not token.isdigit():
+            raise SupervisionError(f"pgrep returned an invalid pid: {token!r}")
+        pid = int(token)
+        try:
+            group = os.getpgid(pid)
+        except ProcessLookupError:
+            continue
+        except OSError as exc:
+            raise SupervisionError(f"cannot inspect process {pid}: {exc}") from exc
+        if group != pgid:
+            continue
+        try:
+            probed = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "stat=", "-o", "lstart="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
+                check=False,
+            )
+        except Exception as exc:
+            raise SupervisionError(f"cannot inspect process {pid}: {exc}") from exc
+        text = probed.stdout.strip()
+        if probed.returncode != 0 or not text:
+            try:
+                os.getpgid(pid)
+            except ProcessLookupError:
+                continue
+            except OSError as exc:
+                raise SupervisionError(f"cannot inspect process {pid}: {exc}") from exc
+            raise SupervisionError(f"state of process {pid} is indeterminate")
+        state, _, marker = text.partition(" ")
+        facts.append(ProcFact(pid, state, pgid, marker.strip()))
+    return sorted(facts, key=lambda item: item.pid)
+
+
+def group_facts(
+    pgid: int, *, proc_root: Path | None = None,
+) -> list[ProcFact]:
+    if pgid <= 0:
+        raise SupervisionError("process-group id must be positive")
+    if proc_root is not None:
+        return _linux_group_facts(pgid, proc_root=proc_root)
+    if Path("/proc/self/stat").is_file():
+        return _linux_group_facts(pgid)
+    return _fallback_group_facts(pgid)
+
+
+def _pidfd_capable() -> bool:
+    return (
+        sys.platform.startswith("linux")
+        and (hasattr(os, "pidfd_open") or _pidfd_open_syscall_number() is not None)
+        and hasattr(signal, "pidfd_send_signal")
+        and Path("/proc/self/stat").is_file()
+    )
+
+
+def _pidfd_open_syscall_number() -> int | None:
+    """Linux assigned pidfd_open 434 on the supported TAO architectures.
+
+    Some packaged Python builds omit ``os.pidfd_open`` even when the kernel
+    supports it.  Calling the kernel API through libc retains the same
+    kernel-held identity guarantee; unknown architectures fail closed.
+    """
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64", "aarch64", "arm64", "riscv64"}:
+        return 434
+    return None
+
+
+def _pidfd_open(pid: int) -> int:
+    if hasattr(os, "pidfd_open"):
+        return os.pidfd_open(pid, 0)
+    number = _pidfd_open_syscall_number()
+    if number is None:
+        raise OSError(errno.ENOSYS, "pidfd_open syscall number is unknown")
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.syscall.restype = ctypes.c_long
+    fd = int(libc.syscall(number, int(pid), 0))
+    if fd < 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return fd
+
+
+def _pidfd_dead(fd: int) -> bool:
+    poller = select.poll()
+    poller.register(fd, select.POLLIN | select.POLLHUP | select.POLLERR)
+    return bool(poller.poll(0))
+
+
+def _open_verified_pidfd(fact: ProcFact, *, expected_marker: str | None = None) -> int | None:
+    """Open a kernel process handle and prove it names the observed identity."""
+    if not _pidfd_capable():
+        raise SupervisionError(
+            "safe signaling requires Linux /proc, pidfd_open support, and "
+            "signal.pidfd_send_signal"
+        )
+    if expected_marker is not None and fact.start_marker != expected_marker:
+        raise OwnershipError(
+            f"process {fact.pid} start marker no longer matches durable identity"
+        )
+    try:
+        fd = _pidfd_open(fact.pid)
+    except ProcessLookupError:
+        return None
+    except OSError as exc:
+        raise SupervisionError(f"cannot open pidfd for process {fact.pid}: {exc}") from exc
+    try:
+        after = _proc_fact(fact.pid)
+        if after is None or _pidfd_dead(fd):
+            os.close(fd)
+            return None
+        if (
+            after.pid != fact.pid
+            or after.pgid != fact.pgid
+            or after.start_marker != fact.start_marker
+        ):
+            raise OwnershipError(
+                f"process {fact.pid} changed identity while its pidfd was opened"
+            )
+        return fd
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+
+
+def _send_pidfd(fd: int, pid: int, sig: int) -> None:
+    try:
+        signal.pidfd_send_signal(fd, sig, None, 0)
+    except ProcessLookupError:
+        return
+    except PermissionError as exc:
+        if _pidfd_dead(fd):
+            return
+        raise SupervisionError(
+            f"permission denied signaling process {pid} through its pidfd"
+        ) from exc
+    except OSError as exc:
+        if _pidfd_dead(fd):
+            return
+        raise SupervisionError(
+            f"failed signaling process {pid} through its pidfd: {exc}"
+        ) from exc
+
+
+def _parse_excludes(values: list[str]) -> dict[int, str]:
+    excludes: dict[int, str] = {}
+    for value in values:
+        pid_text, separator, marker = value.partition(":")
+        if not separator or not pid_text.isdigit() or not marker:
+            raise SupervisionError(
+                f"--exclude must be PID:START_MARKER, got {value!r}"
+            )
+        excludes[int(pid_text)] = marker
+    return excludes
+
+
+def supervise(
+    *,
+    pgid: int,
+    guardian_pid: int,
+    guardian_marker: str,
+    excludes: dict[int, str],
+    term_timeout: float,
+    kill_timeout: float,
+) -> dict[str, object]:
+    """Terminate every active member except durable, identity-bound excludes."""
+    if term_timeout < 0 or kill_timeout < 0:
+        raise SupervisionError("timeouts must be non-negative")
+    facts = group_facts(pgid)
+    guardian = next((item for item in facts if item.pid == guardian_pid), None)
+    if guardian is None or not guardian.active:
+        raise OwnershipError("durable guardian is gone; refusing group supervision")
+    if guardian.pgid != pgid or guardian.start_marker != guardian_marker:
+        raise OwnershipError("durable guardian identity no longer owns this group")
+
+    # The guardian is an invariant of this abstraction, not a caller option.
+    # Always bind and exclude it even if a future caller omits it from excludes.
+    excludes = {**excludes, guardian_pid: guardian_marker}
+
+    if not _pidfd_capable():
+        targets = [
+            item.pid
+            for item in facts
+            if item.active
+            and not (
+                item.pid in excludes
+                and excludes[item.pid] == item.start_marker
+            )
+        ]
+        if targets:
+            raise SupervisionError(
+                "active group members require Linux pidfd supervision; refusing "
+                f"to signal numeric pids on {sys.platform}: {targets}"
+            )
+        return {"result": "empty", "terminated": []}
+
+    guardian_fd = _open_verified_pidfd(guardian, expected_marker=guardian_marker)
+    if guardian_fd is None:
+        raise OwnershipError("durable guardian exited before supervision started")
+    handles: dict[tuple[int, str], int] = {}
+    terminated: set[int] = set()
+
+    def close_dead_handles() -> None:
+        for identity, fd in list(handles.items()):
+            if _pidfd_dead(fd):
+                os.close(fd)
+                handles.pop(identity, None)
+                terminated.add(identity[0])
+
+    def discover() -> int:
+        if _pidfd_dead(guardian_fd):
+            raise OwnershipError("durable guardian exited during supervision")
+        observed = group_facts(pgid)
+        if _pidfd_dead(guardian_fd):
+            raise OwnershipError("durable guardian exited during group discovery")
+        added = 0
+        for fact in observed:
+            if not fact.active:
+                continue
+            if fact.pid in excludes and excludes[fact.pid] == fact.start_marker:
+                continue
+            identity = (fact.pid, fact.start_marker)
+            if identity in handles:
+                continue
+            fd = _open_verified_pidfd(fact)
+            if fd is None:
+                continue
+            if _pidfd_dead(guardian_fd):
+                os.close(fd)
+                raise OwnershipError("durable guardian exited before target binding")
+            handles[identity] = fd
+            added += 1
+        return added
+
+    try:
+        discover()
+        for (pid, _), fd in list(handles.items()):
+            _send_pidfd(fd, pid, signal.SIGTERM)
+
+        term_deadline = time.monotonic() + term_timeout
+        while time.monotonic() < term_deadline:
+            close_dead_handles()
+            before = set(handles)
+            discover()
+            for identity, fd in list(handles.items()):
+                if identity not in before:
+                    _send_pidfd(fd, identity[0], signal.SIGTERM)
+            if not handles and discover() == 0:
+                return {"result": "terminated", "terminated": sorted(terminated)}
+            time.sleep(0.02)
+
+        # Escalation is still pidfd-only.  Repeated discovery catches workers
+        # forked during graceful shutdown while the guardian anchors the group.
+        kill_deadline = time.monotonic() + kill_timeout
+        while True:
+            close_dead_handles()
+            discover()
+            for (pid, _), fd in list(handles.items()):
+                _send_pidfd(fd, pid, signal.SIGKILL)
+            close_dead_handles()
+            if not handles and discover() == 0:
+                return {"result": "terminated", "terminated": sorted(terminated)}
+            if time.monotonic() >= kill_deadline:
+                remaining = sorted({pid for pid, _ in handles})
+                raise SupervisionError(
+                    f"process group {pgid} still has live members after pidfd "
+                    f"SIGKILL: {remaining}"
+                )
+            time.sleep(0.02)
+    finally:
+        for fd in handles.values():
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        os.close(guardian_fd)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pgid", required=True, type=int)
+    parser.add_argument("--guardian-pid", required=True, type=int)
+    parser.add_argument("--guardian-marker", required=True)
+    parser.add_argument("--exclude", action="append", default=[])
+    parser.add_argument("--term-timeout", type=float, default=1.0)
+    parser.add_argument("--kill-timeout", type=float, default=2.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        result = supervise(
+            pgid=args.pgid,
+            guardian_pid=args.guardian_pid,
+            guardian_marker=args.guardian_marker,
+            excludes=_parse_excludes(args.exclude),
+            term_timeout=args.term_timeout,
+            kill_timeout=args.kill_timeout,
+        )
+    except (OSError, SupervisionError, ValueError) as exc:
+        print(json.dumps({"result": "error", "message": str(exc)}, sort_keys=True))
+        return 2
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/platform/tao-run-on-virtualenv/references/virtualenv_runner.py
+++ b/skills/platform/tao-run-on-virtualenv/references/virtualenv_runner.py
@@ -312,7 +312,46 @@ def _coerce_pid(value) -> int:
     return pid if pid > 0 else 0
 
 
-def _active_process_group_members(pgid: int) -> list[int] | None:
+def _proc_entry_group_state(entry: Path, pgid: int) -> str:
+    """Classify one Linux proc entry for a target group.
+
+    The result is ``active``, ``zombie``, ``other``, ``gone``, or
+    ``indeterminate``.  A malformed or unreadable stat file is harmless when
+    ``getpgid`` proves the process belongs to another group, but it must not be
+    silently treated as gone when it may be one of this job's processes.
+    """
+    pid = int(entry.name)
+    try:
+        stat = (entry / "stat").read_text(encoding="utf-8")
+        closing = stat.rfind(")")
+        if closing < 0:
+            raise ValueError("missing comm terminator")
+        fields = stat[closing + 2:].split()
+        if len(fields) < 3:
+            raise ValueError("truncated proc stat")
+        state = fields[0]
+        process_group = int(fields[2])
+    except FileNotFoundError:
+        return "gone"
+    except (PermissionError, OSError, ValueError, IndexError):
+        # Reading stat can race process exit.  getpgid distinguishes that case
+        # and, crucially, tells us whether unreadable evidence is relevant to
+        # this group rather than silently converting uncertainty into success.
+        try:
+            process_group = os.getpgid(pid)
+        except ProcessLookupError:
+            return "gone"
+        except (PermissionError, OSError, ValueError):
+            return "indeterminate"
+        return "indeterminate" if process_group == pgid else "other"
+    if process_group != pgid:
+        return "other"
+    return "zombie" if state == "Z" else "active"
+
+
+def _active_process_group_members(
+    pgid: int, *, proc_root: Path | None = None,
+) -> list[int] | None:
     """Return non-zombie members of ``pgid``; ``None`` means indeterminate.
 
     ``killpg(pgid, 0)`` only proves that a process-group entry still exists.
@@ -327,7 +366,7 @@ def _active_process_group_members(pgid: int) -> list[int] | None:
     if pgid <= 0:
         return []
 
-    proc_root = Path("/proc")
+    proc_root = Path("/proc") if proc_root is None else proc_root
     if proc_root.is_dir():
         members: list[int] = []
         try:
@@ -335,19 +374,10 @@ def _active_process_group_members(pgid: int) -> list[int] | None:
             for entry in entries:
                 if not entry.name.isdigit():
                     continue
-                try:
-                    stat = (entry / "stat").read_text(encoding="utf-8")
-                    fields = stat[stat.rfind(")") + 2:].split()
-                    state = fields[0]
-                    process_group = int(fields[2])
-                except (FileNotFoundError, PermissionError):
-                    # Processes can exit during the scan.  On hidepid mounts,
-                    # unrelated users' entries can also be visible but unreadable;
-                    # this runner's same-UID job processes remain inspectable.
-                    continue
-                except (OSError, ValueError, IndexError):
-                    continue
-                if process_group == pgid and state != "Z":
+                state = _proc_entry_group_state(entry, pgid)
+                if state == "indeterminate":
+                    return None
+                if state == "active":
                     members.append(int(entry.name))
             return sorted(members)
         except OSError:
@@ -383,36 +413,139 @@ def _active_process_group_members(pgid: int) -> list[int] | None:
             )
         except Exception:
             return None
-        if state_probe.returncode != 0:
+        state = state_probe.stdout.strip()
+        if state_probe.returncode != 0 or not state:
             try:
-                os.kill(pid, 0)
+                process_group = os.getpgid(pid)
             except ProcessLookupError:
                 continue  # Process exited between pgrep and ps.
-            except (PermissionError, ValueError):
+            except (PermissionError, OSError, ValueError):
                 return None
-            return None  # Still signalable, but its state is indeterminate.
-        state = state_probe.stdout.strip()
-        if not state:
-            continue
+            if process_group != pgid:
+                continue
+            return None  # Still in this group, but state is indeterminate.
         if not state.startswith("Z"):
             members.append(pid)
     return sorted(members)
 
 
-def _group_members(pgid: int, identity_hint: str | None) -> list[int]:
-    """POSITIVELY-identified surviving members of ``pgid`` (leader excluded).
+def _identity_matches(pid: int, marker: str, pgid: int) -> bool | None:
+    """Tri-state durable identity check for one active group member."""
+    try:
+        if os.getpgid(pid) != pgid:
+            return False
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError, ValueError):
+        return None
+    marker_now = _process_start_marker(pid)
+    if marker_now is None:
+        # The member may have exited between getpgid and the marker read.
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except (PermissionError, OSError, ValueError):
+            return None
+        return None
+    return marker_now == marker
+
+
+def _capture_group_identities(
+    pgid: int, members: list[int],
+) -> dict[int, str] | None:
+    """Capture start identities for known-active members of an owned group."""
+    identities: dict[int, str] = {}
+    for member_pid in members:
+        try:
+            if os.getpgid(member_pid) != pgid:
+                continue
+        except ProcessLookupError:
+            continue
+        except (PermissionError, OSError, ValueError):
+            return None
+        marker = _process_start_marker(member_pid)
+        if marker is None:
+            # An exited member is benign; a still-live unidentifiable member is
+            # not safe to use as authority for a later group signal.
+            try:
+                os.kill(member_pid, 0)
+            except ProcessLookupError:
+                continue
+            except (PermissionError, OSError, ValueError):
+                return None
+            return None
+        identities[member_pid] = str(marker)
+    return identities
+
+
+def _observe_owned_group(
+    pgid: int, identities: dict[int, str],
+) -> tuple[str, list[int]]:
+    """Observe a group without allowing a reused PGID to inherit ownership.
+
+    Returns ``owned``, ``empty``, ``indeterminate``, or ``ownership_lost``.
+    While at least one previously bound identity is live, any newly observed
+    member belongs to the same still-existing POSIX process group and can be
+    safely added to the durable identity set for later escalation.
+    """
+    members = _active_process_group_members(pgid)
+    if members is None:
+        return "indeterminate", []
+    if not members:
+        return "empty", []
+
+    matched = []
+    indeterminate = False
+    for member_pid, marker in list(identities.items()):
+        if member_pid not in members:
+            continue
+        match = _identity_matches(member_pid, marker, pgid)
+        if match is True:
+            matched.append(member_pid)
+        elif match is None:
+            indeterminate = True
+    if not matched:
+        return ("indeterminate" if indeterminate else "ownership_lost"), members
+
+    unbound = [member_pid for member_pid in members if member_pid not in identities]
+    captured = _capture_group_identities(pgid, unbound)
+    if captured is None:
+        return "indeterminate", members
+    identities.update(captured)
+    return "owned", members
+
+
+def _group_member_identities(
+    pgid: int, identity_hint: str | None,
+) -> dict[int, str] | None:
+    """POSITIVELY identify surviving members (leader excluded).
 
     Used when the launcher is dead: a surviving training script must not be
     reported terminal or left unkillable. Only members whose cmdline matches
-    ``identity_hint`` count — a recycled pgid of foreign processes never does.
+    ``identity_hint`` count, and every returned PID is bound to its process
+    start marker. ``None`` means the probe itself was indeterminate.
     """
     candidates = _active_process_group_members(pgid)
     if candidates is None:
-        return []
+        return None
     members = [pid for pid in candidates if pid != pgid]
     if not identity_hint:
-        return []
-    return [pid for pid in members if _cmdline_probe(pid, identity_hint) is True]
+        return {}
+    matched: list[int] = []
+    for member_pid in members:
+        cmdline_match = _cmdline_probe(member_pid, identity_hint)
+        if cmdline_match is None:
+            return None
+        if cmdline_match:
+            matched.append(member_pid)
+    return _capture_group_identities(pgid, matched)
+
+
+def _group_members(pgid: int, identity_hint: str | None) -> list[int]:
+    """Compatibility view used by status displays and tests."""
+    identities = _group_member_identities(pgid, identity_hint)
+    return [] if identities is None else sorted(identities)
 
 
 def _cmdline_probe(pid: int, needle: str) -> bool | None:
@@ -474,7 +607,7 @@ def _process_matches(pid: int, expected_marker: str | None, wrapper_path: str | 
     The bias is the inverse of _launcher_state: this gates SIGNALING, so an
     indeterminate probe means "do not kill".
     """
-    if pid <= 0:
+    if pid <= 0 or not expected_marker:
         return False
     try:
         os.kill(pid, 0)
@@ -482,56 +615,96 @@ def _process_matches(pid: int, expected_marker: str | None, wrapper_path: str | 
             return False
     except (OSError, ValueError):
         return False
-    if expected_marker and _process_start_marker(pid) != str(expected_marker):
+    if _process_start_marker(pid) != str(expected_marker):
         return False
     if wrapper_path and _cmdline_probe(pid, wrapper_path) is not True:
         return False
     return True
 
 
-def _terminate_process_group(pid: int, timeout: float = 5.0) -> str:
+def _terminate_process_group(
+    pid: int,
+    expected_identities: dict[int, str],
+    timeout: float = 5.0,
+) -> str:
     """SIGTERM then SIGKILL the group. Returns 'gone' | 'terminated' | raises.
 
-    Callers verify process identity first, so this never signals a foreign
-    group. Completion means no non-zombie group member remains; an unreaped
-    zombie is already dead and must not turn a successful cancellation into a
-    timeout.  An indeterminate membership probe or a permission failure is not
-    reported as success.
+    Every signal is preceded by a durable start-identity check. A PGID that is
+    reused after this job's members exit can therefore never inherit authority
+    from the old job record. Completion means no non-zombie group member
+    remains; an unreaped zombie is already dead and must not turn a successful
+    cancellation into a timeout. An indeterminate membership probe or a real
+    permission failure is not reported as success.
     """
+    identities = {
+        _coerce_pid(member_pid): str(marker)
+        for member_pid, marker in expected_identities.items()
+        if _coerce_pid(member_pid) and marker
+    }
+    if not identities:
+        raise RuntimeError(
+            f"refusing to signal process group {pid} without a durable process identity"
+        )
+
+    def observe_or_raise() -> tuple[str, list[int]]:
+        ownership, members = _observe_owned_group(pid, identities)
+        if ownership == "indeterminate":
+            raise RuntimeError(
+                f"could not establish process-group {pid} membership safely"
+            )
+        if ownership == "ownership_lost":
+            raise RuntimeError(
+                f"process group {pid} no longer matches this job; refusing to signal it"
+            )
+        return ownership, members
+
+    ownership, _ = observe_or_raise()
+    if ownership == "empty":
+        return "terminated"
 
     try:
         os.killpg(pid, signal.SIGTERM)
     except ProcessLookupError:
         return "gone"
     except PermissionError as exc:
+        members = _active_process_group_members(pid)
+        if members == []:
+            return "terminated"
         raise RuntimeError(
             f"permission denied signaling process group {pid} with SIGTERM"
         ) from exc
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        members = _active_process_group_members(pid)
-        if members == []:
+        ownership, _ = observe_or_raise()
+        if ownership == "empty":
             return "terminated"
         time.sleep(0.05)
+
+    # Revalidate immediately before escalation. In particular, a new process
+    # group that reused the old numeric PGID must not receive this SIGKILL.
+    ownership, _ = observe_or_raise()
+    if ownership == "empty":
+        return "terminated"
     try:
         os.killpg(pid, signal.SIGKILL)
     except ProcessLookupError:
         return "terminated"
     except PermissionError as exc:
+        members = _active_process_group_members(pid)
+        if members == []:
+            return "terminated"
         raise RuntimeError(
             f"permission denied signaling process group {pid} with SIGKILL"
         ) from exc
     kill_deadline = time.monotonic() + max(1.0, timeout)
     while time.monotonic() < kill_deadline:
-        members = _active_process_group_members(pid)
-        if members == []:
+        ownership, _ = observe_or_raise()
+        if ownership == "empty":
             return "terminated"
         time.sleep(0.05)
-    members = _active_process_group_members(pid)
-    if members is None:
-        raise RuntimeError(
-            f"could not verify that process group {pid} terminated after SIGKILL"
-        )
+    ownership, members = observe_or_raise()
+    if ownership == "empty":
+        return "terminated"
     raise RuntimeError(
         f"process group {pid} still has live members after SIGKILL: {members}"
     )
@@ -759,6 +932,7 @@ def cmd_submit(args: argparse.Namespace) -> int:
             log_file.close()  # Popen duplicated the descriptor for the child.
     except OSError as exc:
         return _fail(f"Failed to launch the wrapper: {exc}")
+    spawned_marker = _process_start_marker(process.pid)
 
     # Wait for the wrapper's durable identity record, then open the gate. A
     # wrapper that never writes it means the interpreter/env is broken — kill
@@ -773,10 +947,16 @@ def cmd_submit(args: argparse.Namespace) -> int:
             break
         time.sleep(0.05)
     if not launcher or not launcher.get("pid"):
-        try:
-            _terminate_process_group(process.pid)
-        except RuntimeError:
-            pass
+        # The marker captured immediately after Popen binds cleanup to this
+        # exact process. If it was unavailable, let the wrapper's closed gate
+        # time out rather than risk signaling a subsequently reused PGID.
+        if spawned_marker:
+            try:
+                _terminate_process_group(
+                    process.pid, {process.pid: str(spawned_marker)}
+                )
+            except RuntimeError:
+                pass
         tail = _read_tail(paths.log_path, 40) if paths.log_path.exists() else ""
         return _fail(
             "Launcher never wrote its durable identity record "
@@ -857,7 +1037,14 @@ def _derive_status(paths: RunnerPaths) -> tuple[str, str, dict]:
         argv = (submit_meta or {}).get("argv") or []
         if len(argv) > 1:
             script_hint = argv[1]
-        survivors = _group_members(pid, script_hint)
+        survivor_identities = _group_member_identities(pid, script_hint)
+        if survivor_identities is None:
+            return (
+                VOCAB_UNKNOWN,
+                "Launcher ended and surviving process identity is indeterminate",
+                {"pid": pid},
+            )
+        survivors = sorted(survivor_identities)
         if survivors:
             message = (
                 f"Launcher {pid} died but the script group is still running "
@@ -936,7 +1123,9 @@ def cmd_cancel(args: argparse.Namespace) -> int:
     if pid and _process_matches(pid, marker, wrapper_path):
         signaled = True
         try:
-            outcome = _terminate_process_group(pid, timeout=args.timeout)
+            outcome = _terminate_process_group(
+                pid, {pid: str(marker)}, timeout=args.timeout
+            )
         except RuntimeError as exc:
             return _fail(str(exc), status=VOCAB_UNKNOWN)
     else:
@@ -947,10 +1136,18 @@ def cmd_cancel(args: argparse.Namespace) -> int:
         # children of a killed wrapper). Kill positively-identified survivors.
         argv = (submit_meta or {}).get("argv") or []
         script_hint = argv[1] if len(argv) > 1 else None
-        if _group_members(pid, script_hint):
+        survivor_identities = _group_member_identities(pid, script_hint)
+        if survivor_identities is None:
+            return _fail(
+                f"could not establish surviving process identities for group {pid}",
+                status=VOCAB_UNKNOWN,
+            )
+        if survivor_identities:
             signaled = True
             try:
-                _terminate_process_group(pid, timeout=args.timeout)
+                _terminate_process_group(
+                    pid, survivor_identities, timeout=args.timeout
+                )
             except RuntimeError as exc:
                 return _fail(str(exc), status=VOCAB_UNKNOWN)
 

--- a/skills/platform/tao-run-on-virtualenv/references/virtualenv_runner.py
+++ b/skills/platform/tao-run-on-virtualenv/references/virtualenv_runner.py
@@ -312,6 +312,93 @@ def _coerce_pid(value) -> int:
     return pid if pid > 0 else 0
 
 
+def _active_process_group_members(pgid: int) -> list[int] | None:
+    """Return non-zombie members of ``pgid``; ``None`` means indeterminate.
+
+    ``killpg(pgid, 0)`` only proves that a process-group entry still exists.
+    In particular, it succeeds for an unreaped zombie even though that process
+    cannot execute or receive a signal.  Lifecycle waits therefore need an
+    explicit state-aware membership probe rather than signalability.
+
+    Linux uses ``/proc`` (the first-class platform).  The fallback uses
+    ``pgrep`` plus ``ps`` and deliberately returns ``None`` when it cannot
+    establish state: callers may then decline to signal or report success.
+    """
+    if pgid <= 0:
+        return []
+
+    proc_root = Path("/proc")
+    if proc_root.is_dir():
+        members: list[int] = []
+        try:
+            entries = proc_root.iterdir()
+            for entry in entries:
+                if not entry.name.isdigit():
+                    continue
+                try:
+                    stat = (entry / "stat").read_text(encoding="utf-8")
+                    fields = stat[stat.rfind(")") + 2:].split()
+                    state = fields[0]
+                    process_group = int(fields[2])
+                except (FileNotFoundError, PermissionError):
+                    # Processes can exit during the scan.  On hidepid mounts,
+                    # unrelated users' entries can also be visible but unreadable;
+                    # this runner's same-UID job processes remain inspectable.
+                    continue
+                except (OSError, ValueError, IndexError):
+                    continue
+                if process_group == pgid and state != "Z":
+                    members.append(int(entry.name))
+            return sorted(members)
+        except OSError:
+            pass
+
+    try:
+        completed = subprocess.run(
+            ["pgrep", "-g", str(pgid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
+        )
+    except Exception:
+        return None
+    if completed.returncode == 1:
+        return []
+    if completed.returncode != 0:
+        return None
+
+    members = []
+    for token in completed.stdout.split():
+        if not token.isdigit():
+            continue
+        pid = int(token)
+        try:
+            state_probe = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "stat="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
+            )
+        except Exception:
+            return None
+        if state_probe.returncode != 0:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                continue  # Process exited between pgrep and ps.
+            except (PermissionError, ValueError):
+                return None
+            return None  # Still signalable, but its state is indeterminate.
+        state = state_probe.stdout.strip()
+        if not state:
+            continue
+        if not state.startswith("Z"):
+            members.append(pid)
+    return sorted(members)
+
+
 def _group_members(pgid: int, identity_hint: str | None) -> list[int]:
     """POSITIVELY-identified surviving members of ``pgid`` (leader excluded).
 
@@ -319,27 +406,9 @@ def _group_members(pgid: int, identity_hint: str | None) -> list[int]:
     reported terminal or left unkillable. Only members whose cmdline matches
     ``identity_hint`` count — a recycled pgid of foreign processes never does.
     """
-    candidates: list[int] = []
-    if Path("/proc").exists():
-        for entry in Path("/proc").iterdir():
-            if not entry.name.isdigit():
-                continue
-            try:
-                stat = (entry / "stat").read_text(encoding="utf-8")
-                fields = stat[stat.rfind(")") + 2:].split()
-                if int(fields[2]) == pgid and fields[0] != "Z":
-                    candidates.append(int(entry.name))
-            except (OSError, ValueError, IndexError):
-                continue
-    else:
-        try:
-            out = subprocess.run(
-                ["pgrep", "-g", str(pgid)],
-                capture_output=True, text=True, timeout=5,
-            ).stdout.split()
-            candidates = [int(t) for t in out if t.isdigit()]
-        except Exception:
-            candidates = []
+    candidates = _active_process_group_members(pgid)
+    if candidates is None:
+        return []
     members = [pid for pid in candidates if pid != pgid]
     if not identity_hint:
         return []
@@ -424,43 +493,48 @@ def _terminate_process_group(pid: int, timeout: float = 5.0) -> str:
     """SIGTERM then SIGKILL the group. Returns 'gone' | 'terminated' | raises.
 
     Callers verify process identity first, so this never signals a foreign
-    group. PermissionError on a real signal is treated as terminated: it
-    happens when only unreaped zombies remain in the group (observed on
-    macOS), which cannot be signaled and are already dead.
+    group. Completion means no non-zombie group member remains; an unreaped
+    zombie is already dead and must not turn a successful cancellation into a
+    timeout.  An indeterminate membership probe or a permission failure is not
+    reported as success.
     """
-
-    def group_exists() -> bool:
-        try:
-            os.killpg(pid, 0)
-            return True
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
 
     try:
         os.killpg(pid, signal.SIGTERM)
     except ProcessLookupError:
         return "gone"
-    except PermissionError:
-        return "terminated"
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"permission denied signaling process group {pid} with SIGTERM"
+        ) from exc
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if not group_exists():
+        members = _active_process_group_members(pid)
+        if members == []:
             return "terminated"
         time.sleep(0.05)
     try:
         os.killpg(pid, signal.SIGKILL)
     except ProcessLookupError:
         return "terminated"
-    except PermissionError:
-        return "terminated"
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"permission denied signaling process group {pid} with SIGKILL"
+        ) from exc
     kill_deadline = time.monotonic() + max(1.0, timeout)
     while time.monotonic() < kill_deadline:
-        if not group_exists():
+        members = _active_process_group_members(pid)
+        if members == []:
             return "terminated"
         time.sleep(0.05)
-    raise RuntimeError(f"process group {pid} survived SIGKILL")
+    members = _active_process_group_members(pid)
+    if members is None:
+        raise RuntimeError(
+            f"could not verify that process group {pid} terminated after SIGKILL"
+        )
+    raise RuntimeError(
+        f"process group {pid} still has live members after SIGKILL: {members}"
+    )
 
 
 def _read_tail(path: Path, line_count: int, max_bytes: int = LOG_TAIL_MAX_BYTES) -> str:

--- a/skills/platform/tao-run-on-virtualenv/references/virtualenv_runner.py
+++ b/skills/platform/tao-run-on-virtualenv/references/virtualenv_runner.py
@@ -12,7 +12,7 @@ session, with a durable on-disk lifecycle that survives the launching process:
     submit  --job-dir D --venv V --script S [--arg TOKEN]... -> prints {pid,...}
     status  --job-dir D            -> {status: PENDING|RUNNING|COMPLETE|ERROR|CANCELED|UNKNOWN}
     logs    --job-dir D [--tail N] -> bounded tail of the job log
-    cancel  --job-dir D            -> SIGTERM->SIGKILL the whole process group
+    cancel  --job-dir D            -> pidfd SIGTERM->SIGKILL for job processes
 
 Job records are NOT written here — the agent owns them via tao_job_record.py
 (open binds results_dir BEFORE submit; mark records the states this CLI
@@ -21,17 +21,18 @@ reports). The runner's own durable truth lives under ``<job-dir>/.tao_runner/``:
 moment it starts: pid + start marker), ``exit_status.json`` (fsync'd atomic
 write on exit), a ``start_authorized`` gate, and a ``cancel_requested`` marker.
 
-Correctness properties ported from the reviewed upstream implementation:
+Correctness properties:
 - The wrapper blocks on the start gate, so a submit that fails bookkeeping can
   abort before the training script ever runs.
-- Process identity is (pid, pgid-leader, process start marker, wrapper path in
-  cmdline) — a reused PID is never treated as the job, and cancel can never
-  kill an innocent process.
+- The wrapper, a durable guardian, and the direct workload are persisted with
+  start markers before waiting. The guardian anchors the original process group
+  even after the workload exec-replaces its submitted command line.
 - After the script exits, leftover process-group members are SIGTERM/SIGKILLed
-  so background DataLoader workers cannot leak (exit code 126 if any survive
-  a clean run).
-- Linux is first-class (/proc); on other POSIX systems `ps`/`pgrep` fallbacks
-  keep the verbs functional for local smokes.
+  through Linux pidfds so background DataLoader workers cannot leak and reused
+  numeric IDs cannot be signaled.
+- Observation is tri-state and fail-closed. Other POSIX systems can prove an
+  empty group, but active cancellation is refused without an equivalent
+  kernel-held process identity.
 """
 
 from __future__ import annotations
@@ -45,6 +46,13 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+
+from virtualenv_group_supervisor import (
+    OwnershipError,
+    SupervisionError,
+    group_facts,
+    supervise,
+)
 
 VOCAB_PENDING = "PENDING"
 VOCAB_RUNNING = "RUNNING"
@@ -61,10 +69,14 @@ LAUNCHER_RECORD_TIMEOUT_SECONDS = 10.0
 PENDING_LAUNCH_GRACE_SECONDS = LAUNCHER_RECORD_TIMEOUT_SECONDS + 5.0
 GATE_WAIT_TIMEOUT_SECONDS = 30.0  # wrapper gives up if submit dies pre-gate
 _PLACEHOLDER_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+SUPERVISOR_SOURCE_PATH = Path(__file__).resolve().with_name(
+    "virtualenv_group_supervisor.py"
+)
 
 # ---------------------------------------------------------------------------
 # The wrapper written into the job dir and executed as
-#   <venv>/bin/python launch_job.py <exit_status> <launcher_status> <gate> <cancel> <command...>
+#   <venv>/bin/python launch_job.py <exit> <launcher> <gate> <cancel>
+#       <supervisor> <guardian-release> <command...>
 # It must stay self-contained (stdlib only) and portable.
 # ---------------------------------------------------------------------------
 JOB_WRAPPER_SOURCE = r'''
@@ -75,6 +87,21 @@ import subprocess
 import sys
 import time
 import traceback
+
+
+GUARDIAN_SOURCE = r"""
+import os
+import signal
+import sys
+import time
+
+for name in ("SIGTERM", "SIGINT", "SIGHUP"):
+    if hasattr(signal, name):
+        signal.signal(getattr(signal, name), signal.SIG_IGN)
+release_path = sys.argv[1]
+while not os.path.exists(release_path):
+    time.sleep(0.02)
+"""
 
 
 def _write_status(path, payload):
@@ -88,102 +115,80 @@ def _write_status(path, payload):
 
 
 def _probe(argv):
-    """Run a ps/pgrep probe OUTSIDE our process group so membership scans
-    never see the probe itself. Locale/TZ pinned so `ps lstart` markers are
-    invocation-invariant."""
     return subprocess.run(
         argv, capture_output=True, text=True, timeout=5, start_new_session=True,
-        env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
+        env={**os.environ, "LC_ALL": "C", "TZ": "UTC"}, check=False,
     ).stdout
 
 
-def _start_marker():
+def _start_marker(pid):
     try:
-        with open(f"/proc/{os.getpid()}/stat", encoding="utf-8") as stream:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as stream:
             stat = stream.read()
-        fields = stat[stat.rfind(")") + 2:].split()
+        closing = stat.rfind(")")
+        fields = stat[closing + 2:].split() if closing >= 0 else []
         return fields[19] if len(fields) > 19 else None
     except OSError:
         pass
     try:
-        out = _probe(["ps", "-p", str(os.getpid()), "-o", "lstart="]).strip()
+        out = _probe(["ps", "-p", str(pid), "-o", "lstart="]).strip()
         return out or None
     except Exception:
         return None
 
 
-def _active_group_members():
-    """Return non-zombie members of this launcher's process group (not us)."""
-    own_pid = os.getpid()
-    group_id = os.getpgrp()
-    members = []
-    try:
-        proc_entries = os.scandir("/proc")
-    except OSError:
-        proc_entries = None
-    if proc_entries is not None:
-        with proc_entries:
-            for entry in proc_entries:
-                if not entry.name.isdigit():
-                    continue
-                pid = int(entry.name)
-                if pid == own_pid:
-                    continue
-                try:
-                    with open(f"/proc/{pid}/stat", encoding="utf-8") as stream:
-                        stat = stream.read()
-                    fields = stat[stat.rfind(")") + 2:].split()
-                    state = fields[0]
-                    process_group = int(fields[2])
-                except (OSError, ValueError, IndexError):
-                    continue
-                if process_group == group_id and state != "Z":
-                    members.append(pid)
-        return members
-    # Non-/proc fallback (macOS): pgrep by process group, filter zombies via ps.
-    try:
-        out = _probe(["pgrep", "-g", str(group_id)]).split()
-    except Exception:
-        return members
-    for token in out:
-        try:
-            pid = int(token)
-        except ValueError:
-            continue
-        if pid == own_pid:
-            continue
-        try:
-            state = _probe(["ps", "-p", str(pid), "-o", "stat="]).strip()
-        except Exception:
-            state = ""
-        if state and not state.startswith("Z"):
-            members.append(pid)
-    return members
+def _release_guardian(path, guardian):
+    open(path, "a", encoding="utf-8").close()
+    guardian.wait(timeout=5)
 
 
-def _stop_remaining_group_members(timeout=1.0):
-    """Prevent a finished script from leaking background workers."""
-    members = _active_group_members()
-    for pid in members:
+def _release_guardian_reliably(path, guardian, launch_path=None,
+                               launch_record=None):
+    """Do not publish terminal state while the durable group anchor is live."""
+    failed = False
+    while True:
         try:
-            os.kill(pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-    deadline = time.monotonic() + timeout
-    while members and time.monotonic() < deadline:
-        time.sleep(0.05)
-        members = _active_group_members()
-    for pid in members:
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-    kill_deadline = time.monotonic() + max(1.0, timeout)
-    while members and time.monotonic() < kill_deadline:
-        time.sleep(0.05)
-        members = _active_group_members()
-    if members:
-        raise RuntimeError(f"process group still has live members: {members}")
+            _release_guardian(path, guardian)
+            return failed
+        except BaseException as exc:
+            failed = True
+            if launch_path and launch_record is not None:
+                launch_record["cleanup_error"] = (
+                    f"Guardian release failed: {type(exc).__name__}: {exc}"
+                )
+                _write_status(launch_path, launch_record)
+            time.sleep(1.0)
+
+
+def _cancel_timeout(path):
+    try:
+        with open(path, encoding="utf-8") as stream:
+            value = json.load(stream).get("timeout", 1.0)
+        return max(0.0, float(value))
+    except (OSError, ValueError, TypeError, AttributeError):
+        return 1.0
+
+
+def _supervise(supervisor_path, guardian_pid, guardian_marker, wrapper_marker,
+               timeout):
+    command = [
+        sys.executable, supervisor_path,
+        "--pgid", str(os.getpgrp()),
+        "--guardian-pid", str(guardian_pid),
+        "--guardian-marker", str(guardian_marker),
+        "--exclude", f"{guardian_pid}:{guardian_marker}",
+        "--exclude", f"{os.getpid()}:{wrapper_marker}",
+        "--term-timeout", str(timeout),
+        "--kill-timeout", str(max(1.0, timeout)),
+    ]
+    completed = subprocess.run(
+        command, capture_output=True, text=True,
+        timeout=max(10.0, timeout * 2 + 5.0), start_new_session=True,
+        env={**os.environ, "LC_ALL": "C", "TZ": "UTC"}, check=False,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stdout or completed.stderr).strip()
+        raise RuntimeError(detail or f"group supervisor exited {completed.returncode}")
 
 
 def main():
@@ -191,30 +196,61 @@ def main():
     launch_path = sys.argv[2]
     start_gate_path = sys.argv[3]
     cancel_path = sys.argv[4]
-    command = sys.argv[5:]
+    supervisor_path = sys.argv[5]
+    guardian_release_path = sys.argv[6]
+    command = sys.argv[7:]
     started_at = time.time()
-    _write_status(launch_path, {
+    wrapper_marker = _start_marker(os.getpid())
+    guardian = subprocess.Popen(
+        [sys.executable, "-c", GUARDIAN_SOURCE, guardian_release_path],
+        stdin=subprocess.DEVNULL,
+    )
+    guardian_marker = _start_marker(guardian.pid)
+    if not wrapper_marker or not guardian_marker:
+        _release_guardian_reliably(guardian_release_path, guardian)
+        _write_status(status_path, {
+            "return_code": 127,
+            "canceled": False,
+            "error": "Could not establish wrapper/guardian process identity",
+            "started_at": started_at,
+            "finished_at": time.time(),
+        })
+        return 127
+    launch_record = {
         "pid": os.getpid(),
-        "process_start_marker": _start_marker(),
+        "process_start_marker": wrapper_marker,
+        "guardian_pid": guardian.pid,
+        "guardian_start_marker": guardian_marker,
         "started_at": started_at,
-    })
-    # A healthy submit opens the gate within one poll of reading our record;
-    # if it died first, give up with a durable record instead of spinning as
-    # a phantom RUNNING job forever.
+    }
+    _write_status(launch_path, launch_record)
+
     gate_timeout = float(os.environ.get("TAO_RUNNER_GATE_TIMEOUT", "30"))
     gate_deadline = time.monotonic() + gate_timeout
     while not os.path.exists(start_gate_path):
         if time.monotonic() > gate_deadline:
+            _release_guardian_reliably(
+                guardian_release_path, guardian, launch_path, launch_record,
+            )
+            launch_record.pop("cleanup_error", None)
+            _write_status(launch_path, launch_record)
             _write_status(status_path, {
                 "return_code": 125,
+                "canceled": False,
                 "error": "Start was never authorized (submit died before opening the gate)",
                 "started_at": started_at,
                 "finished_at": time.time(),
             })
             return 125
         if os.path.exists(cancel_path):
+            _release_guardian_reliably(
+                guardian_release_path, guardian, launch_path, launch_record,
+            )
+            launch_record.pop("cleanup_error", None)
+            _write_status(launch_path, launch_record)
             _write_status(status_path, {
                 "return_code": -signal.SIGTERM,
+                "canceled": True,
                 "error": "Canceled before the script started",
                 "started_at": started_at,
                 "finished_at": time.time(),
@@ -222,30 +258,93 @@ def main():
             return 128 + signal.SIGTERM
         time.sleep(0.02)
     if os.path.exists(cancel_path):
+        _release_guardian_reliably(
+            guardian_release_path, guardian, launch_path, launch_record,
+        )
+        launch_record.pop("cleanup_error", None)
+        _write_status(launch_path, launch_record)
         _write_status(status_path, {
             "return_code": -signal.SIGTERM,
+            "canceled": True,
             "error": "Canceled before the script started",
             "started_at": started_at,
             "finished_at": time.time(),
         })
         return 128 + signal.SIGTERM
+
     error = None
+    canceled = False
     try:
-        return_code = subprocess.call(command)
-    except BaseException as exc:  # Preserve a durable failure record.
-        traceback.print_exc()
-        return_code = 127
-        error = f"{type(exc).__name__}: {exc}"
-    try:
-        _stop_remaining_group_members()
+        workload = subprocess.Popen(command, stdin=subprocess.DEVNULL)
     except BaseException as exc:
         traceback.print_exc()
-        cleanup_error = f"{type(exc).__name__}: {exc}"
+        workload = None
+        return_code = 127
+        error = f"{type(exc).__name__}: {exc}"
+    if workload is not None:
+        workload_marker = _start_marker(workload.pid)
+        if not workload_marker:
+            # This Popen object is still the unreaped parent-owned child, so its
+            # pid cannot be reused before wait; requesting termination is safe.
+            workload.terminate()
+            try:
+                workload.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                workload.kill()
+                workload.wait()
+            return_code = 127
+            error = "Could not establish direct workload process identity"
+        else:
+            launch_record.update({
+                "workload_pid": workload.pid,
+                "workload_start_marker": workload_marker,
+            })
+            _write_status(launch_path, launch_record)
+            while workload.poll() is None:
+                if os.path.exists(cancel_path):
+                    canceled = True
+                    break
+                time.sleep(0.05)
+            if not canceled:
+                return_code = workload.returncode
+
+    # The same checked-in supervisor copied by submit owns every cleanup path.
+    # Keep wrapper+guardian alive on indeterminate evidence and retry rather
+    # than writing a false terminal record while workers may still execute.
+    cleanup_failed = False
+    while True:
+        try:
+            timeout = _cancel_timeout(cancel_path) if canceled else 1.0
+            _supervise(
+                supervisor_path, guardian.pid, guardian_marker, wrapper_marker,
+                timeout,
+            )
+            break
+        except BaseException as exc:
+            cleanup_failed = True
+            launch_record["cleanup_error"] = f"{type(exc).__name__}: {exc}"
+            _write_status(launch_path, launch_record)
+            time.sleep(1.0)
+
+    if workload is not None and workload.poll() is None:
+        workload.wait()
+    cleanup_failed = _release_guardian_reliably(
+        guardian_release_path, guardian, launch_path, launch_record,
+    ) or cleanup_failed
+    launch_record.pop("cleanup_error", None)
+    _write_status(launch_path, launch_record)
+    if canceled:
+        return_code = -signal.SIGTERM
+        error = "Canceled by process-group supervisor"
+    elif cleanup_failed:
+        cleanup_error = "Process-group cleanup was temporarily indeterminate"
         error = f"{error}; {cleanup_error}" if error else cleanup_error
         if return_code == 0:
             return_code = 126
+
     _write_status(status_path, {
         "return_code": return_code,
+        "canceled": canceled,
         "error": error,
         "started_at": started_at,
         "finished_at": time.time(),
@@ -312,43 +411,6 @@ def _coerce_pid(value) -> int:
     return pid if pid > 0 else 0
 
 
-def _proc_entry_group_state(entry: Path, pgid: int) -> str:
-    """Classify one Linux proc entry for a target group.
-
-    The result is ``active``, ``zombie``, ``other``, ``gone``, or
-    ``indeterminate``.  A malformed or unreadable stat file is harmless when
-    ``getpgid`` proves the process belongs to another group, but it must not be
-    silently treated as gone when it may be one of this job's processes.
-    """
-    pid = int(entry.name)
-    try:
-        stat = (entry / "stat").read_text(encoding="utf-8")
-        closing = stat.rfind(")")
-        if closing < 0:
-            raise ValueError("missing comm terminator")
-        fields = stat[closing + 2:].split()
-        if len(fields) < 3:
-            raise ValueError("truncated proc stat")
-        state = fields[0]
-        process_group = int(fields[2])
-    except FileNotFoundError:
-        return "gone"
-    except (PermissionError, OSError, ValueError, IndexError):
-        # Reading stat can race process exit.  getpgid distinguishes that case
-        # and, crucially, tells us whether unreadable evidence is relevant to
-        # this group rather than silently converting uncertainty into success.
-        try:
-            process_group = os.getpgid(pid)
-        except ProcessLookupError:
-            return "gone"
-        except (PermissionError, OSError, ValueError):
-            return "indeterminate"
-        return "indeterminate" if process_group == pgid else "other"
-    if process_group != pgid:
-        return "other"
-    return "zombie" if state == "Z" else "active"
-
-
 def _active_process_group_members(
     pgid: int, *, proc_root: Path | None = None,
 ) -> list[int] | None:
@@ -359,74 +421,17 @@ def _active_process_group_members(
     cannot execute or receive a signal.  Lifecycle waits therefore need an
     explicit state-aware membership probe rather than signalability.
 
-    Linux uses ``/proc`` (the first-class platform).  The fallback uses
-    ``pgrep`` plus ``ps`` and deliberately returns ``None`` when it cannot
-    establish state: callers may then decline to signal or report success.
+    This delegates to the same scanner used by destructive supervision so
+    status and cancellation cannot disagree about missing or malformed evidence.
     """
     if pgid <= 0:
         return []
 
-    proc_root = Path("/proc") if proc_root is None else proc_root
-    if proc_root.is_dir():
-        members: list[int] = []
-        try:
-            entries = proc_root.iterdir()
-            for entry in entries:
-                if not entry.name.isdigit():
-                    continue
-                state = _proc_entry_group_state(entry, pgid)
-                if state == "indeterminate":
-                    return None
-                if state == "active":
-                    members.append(int(entry.name))
-            return sorted(members)
-        except OSError:
-            pass
-
     try:
-        completed = subprocess.run(
-            ["pgrep", "-g", str(pgid)],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
-        )
-    except Exception:
+        facts = group_facts(pgid, proc_root=proc_root)
+    except SupervisionError:
         return None
-    if completed.returncode == 1:
-        return []
-    if completed.returncode != 0:
-        return None
-
-    members = []
-    for token in completed.stdout.split():
-        if not token.isdigit():
-            continue
-        pid = int(token)
-        try:
-            state_probe = subprocess.run(
-                ["ps", "-p", str(pid), "-o", "stat="],
-                capture_output=True,
-                text=True,
-                timeout=5,
-                env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
-            )
-        except Exception:
-            return None
-        state = state_probe.stdout.strip()
-        if state_probe.returncode != 0 or not state:
-            try:
-                process_group = os.getpgid(pid)
-            except ProcessLookupError:
-                continue  # Process exited between pgrep and ps.
-            except (PermissionError, OSError, ValueError):
-                return None
-            if process_group != pgid:
-                continue
-            return None  # Still in this group, but state is indeterminate.
-        if not state.startswith("Z"):
-            members.append(pid)
-    return sorted(members)
+    return [fact.pid for fact in facts if fact.active]
 
 
 def _identity_matches(pid: int, marker: str, pgid: int) -> bool | None:
@@ -479,73 +484,49 @@ def _capture_group_identities(
     return identities
 
 
-def _observe_owned_group(
-    pgid: int, identities: dict[int, str],
-) -> tuple[str, list[int]]:
-    """Observe a group without allowing a reused PGID to inherit ownership.
+def _durably_owned_survivors(
+    pgid: int, launcher: dict,
+) -> dict[int, str] | None:
+    """Return active survivors while a persisted job identity anchors the PGID.
 
-    Returns ``owned``, ``empty``, ``indeterminate``, or ``ownership_lost``.
-    While at least one previously bound identity is live, any newly observed
-    member belongs to the same still-existing POSIX process group and can be
-    safely added to the durable identity set for later escalation.
+    Guardian ownership is preferred.  The direct workload identity is retained
+    as a read-only fallback so an externally killed guardian cannot make a live
+    workload look terminal.  ``None`` means active membership could not be
+    attributed safely; callers must report UNKNOWN and must not signal.
     """
     members = _active_process_group_members(pgid)
     if members is None:
-        return "indeterminate", []
-    if not members:
-        return "empty", []
-
-    matched = []
-    indeterminate = False
-    for member_pid, marker in list(identities.items()):
-        if member_pid not in members:
-            continue
-        match = _identity_matches(member_pid, marker, pgid)
-        if match is True:
-            matched.append(member_pid)
-        elif match is None:
-            indeterminate = True
-    if not matched:
-        return ("indeterminate" if indeterminate else "ownership_lost"), members
-
-    unbound = [member_pid for member_pid in members if member_pid not in identities]
-    captured = _capture_group_identities(pgid, unbound)
-    if captured is None:
-        return "indeterminate", members
-    identities.update(captured)
-    return "owned", members
-
-
-def _group_member_identities(
-    pgid: int, identity_hint: str | None,
-) -> dict[int, str] | None:
-    """POSITIVELY identify surviving members (leader excluded).
-
-    Used when the launcher is dead: a surviving training script must not be
-    reported terminal or left unkillable. Only members whose cmdline matches
-    ``identity_hint`` count, and every returned PID is bound to its process
-    start marker. ``None`` means the probe itself was indeterminate.
-    """
-    candidates = _active_process_group_members(pgid)
-    if candidates is None:
         return None
-    members = [pid for pid in candidates if pid != pgid]
-    if not identity_hint:
+    if not members:
         return {}
-    matched: list[int] = []
-    for member_pid in members:
-        cmdline_match = _cmdline_probe(member_pid, identity_hint)
-        if cmdline_match is None:
-            return None
-        if cmdline_match:
-            matched.append(member_pid)
-    return _capture_group_identities(pgid, matched)
 
+    anchors: list[tuple[int, str]] = []
+    guardian = _guardian_identity(launcher)
+    if guardian is not None:
+        anchors.append(guardian)
+    workload_pid = _coerce_pid(launcher.get("workload_pid"))
+    workload_marker = launcher.get("workload_start_marker")
+    if workload_pid and isinstance(workload_marker, str) and workload_marker:
+        anchors.append((workload_pid, workload_marker))
 
-def _group_members(pgid: int, identity_hint: str | None) -> list[int]:
-    """Compatibility view used by status displays and tests."""
-    identities = _group_member_identities(pgid, identity_hint)
-    return [] if identities is None else sorted(identities)
+    owned = False
+    indeterminate = False
+    for anchor_pid, anchor_marker in anchors:
+        match = _identity_matches(anchor_pid, anchor_marker, pgid)
+        if match is True:
+            owned = True
+            break
+        if match is None:
+            indeterminate = True
+    if not owned:
+        return None if members or indeterminate else {}
+
+    excluded = {pgid}
+    if guardian is not None:
+        excluded.add(guardian[0])
+    return _capture_group_identities(
+        pgid, [member for member in members if member not in excluded]
+    )
 
 
 def _cmdline_probe(pid: int, needle: str) -> bool | None:
@@ -601,6 +582,34 @@ def _launcher_state(pid: int, expected_marker: str | None, wrapper_path: str | N
     return "running"
 
 
+def _recorded_launcher_reused(pid: int, expected_marker: str | None) -> bool | None:
+    """Whether a still-live numeric PID is provably not the recorded launcher.
+
+    ``False`` includes a process that is definitively gone. ``None`` means the
+    identity probe is indeterminate and must not support a terminal result.
+    """
+    if pid <= 0 or not expected_marker:
+        return None
+    try:
+        process_group = os.getpgid(pid)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError, ValueError):
+        return None
+    if process_group != pid:
+        return True
+    marker_now = _process_start_marker(pid)
+    if marker_now is None:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except (PermissionError, OSError, ValueError):
+            return None
+        return None
+    return marker_now != str(expected_marker)
+
+
 def _process_matches(pid: int, expected_marker: str | None, wrapper_path: str | None) -> bool:
     """True only if ``pid`` is POSITIVELY this job's launcher (PID-reuse safe).
 
@@ -622,92 +631,49 @@ def _process_matches(pid: int, expected_marker: str | None, wrapper_path: str | 
     return True
 
 
-def _terminate_process_group(
-    pid: int,
-    expected_identities: dict[int, str],
-    timeout: float = 5.0,
-) -> str:
-    """SIGTERM then SIGKILL the group. Returns 'gone' | 'terminated' | raises.
+def _guardian_identity(launcher: dict | None) -> tuple[int, str] | None:
+    if not isinstance(launcher, dict):
+        return None
+    pid = _coerce_pid(launcher.get("guardian_pid"))
+    marker = launcher.get("guardian_start_marker")
+    if not pid or not isinstance(marker, str) or not marker:
+        return None
+    return pid, marker
 
-    Every signal is preceded by a durable start-identity check. A PGID that is
-    reused after this job's members exit can therefore never inherit authority
-    from the old job record. Completion means no non-zombie group member
-    remains; an unreaped zombie is already dead and must not turn a successful
-    cancellation into a timeout. An indeterminate membership probe or a real
-    permission failure is not reported as success.
+
+def _supervise_orphan(
+    paths: "RunnerPaths", launcher: dict, timeout: float,
+) -> dict[str, object]:
+    """Terminate an orphaned group through the shared pidfd supervisor.
+
+    The guardian is deliberately excluded and released only after every other
+    active member is gone, so the numeric process-group id cannot be reused
+    during discovery. No destructive signal in this process uses a raw PID or
+    PGID.
     """
-    identities = {
-        _coerce_pid(member_pid): str(marker)
-        for member_pid, marker in expected_identities.items()
-        if _coerce_pid(member_pid) and marker
-    }
-    if not identities:
-        raise RuntimeError(
-            f"refusing to signal process group {pid} without a durable process identity"
-        )
-
-    def observe_or_raise() -> tuple[str, list[int]]:
-        ownership, members = _observe_owned_group(pid, identities)
-        if ownership == "indeterminate":
-            raise RuntimeError(
-                f"could not establish process-group {pid} membership safely"
-            )
-        if ownership == "ownership_lost":
-            raise RuntimeError(
-                f"process group {pid} no longer matches this job; refusing to signal it"
-            )
-        return ownership, members
-
-    ownership, _ = observe_or_raise()
-    if ownership == "empty":
-        return "terminated"
-
-    try:
-        os.killpg(pid, signal.SIGTERM)
-    except ProcessLookupError:
-        return "gone"
-    except PermissionError as exc:
-        members = _active_process_group_members(pid)
-        if members == []:
-            return "terminated"
-        raise RuntimeError(
-            f"permission denied signaling process group {pid} with SIGTERM"
-        ) from exc
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        ownership, _ = observe_or_raise()
-        if ownership == "empty":
-            return "terminated"
-        time.sleep(0.05)
-
-    # Revalidate immediately before escalation. In particular, a new process
-    # group that reused the old numeric PGID must not receive this SIGKILL.
-    ownership, _ = observe_or_raise()
-    if ownership == "empty":
-        return "terminated"
-    try:
-        os.killpg(pid, signal.SIGKILL)
-    except ProcessLookupError:
-        return "terminated"
-    except PermissionError as exc:
-        members = _active_process_group_members(pid)
-        if members == []:
-            return "terminated"
-        raise RuntimeError(
-            f"permission denied signaling process group {pid} with SIGKILL"
-        ) from exc
-    kill_deadline = time.monotonic() + max(1.0, timeout)
-    while time.monotonic() < kill_deadline:
-        ownership, _ = observe_or_raise()
-        if ownership == "empty":
-            return "terminated"
-        time.sleep(0.05)
-    ownership, members = observe_or_raise()
-    if ownership == "empty":
-        return "terminated"
-    raise RuntimeError(
-        f"process group {pid} still has live members after SIGKILL: {members}"
+    identity = _guardian_identity(launcher)
+    if identity is None:
+        raise SupervisionError("orphaned job lacks a durable guardian identity")
+    guardian_pid, guardian_marker = identity
+    result = supervise(
+        pgid=_coerce_pid(launcher.get("pid")),
+        guardian_pid=guardian_pid,
+        guardian_marker=guardian_marker,
+        excludes={guardian_pid: guardian_marker},
+        term_timeout=max(0.0, timeout),
+        kill_timeout=max(1.0, timeout),
     )
+    paths.guardian_release.touch()
+    release_deadline = time.monotonic() + 5.0
+    while time.monotonic() < release_deadline:
+        facts = group_facts(_coerce_pid(launcher.get("pid")))
+        guardian = next((fact for fact in facts if fact.pid == guardian_pid), None)
+        if guardian is None or not guardian.active:
+            return result
+        if guardian.start_marker != guardian_marker:
+            raise OwnershipError("guardian identity changed during release")
+        time.sleep(0.02)
+    raise SupervisionError("durable guardian did not exit after release")
 
 
 def _read_tail(path: Path, line_count: int, max_bytes: int = LOG_TAIL_MAX_BYTES) -> str:
@@ -742,11 +708,13 @@ class RunnerPaths:
         self.job_dir = job_dir
         self.runner_dir = job_dir / RUNNER_DIR_NAME
         self.wrapper = self.runner_dir / "launch_job.py"
+        self.supervisor = self.runner_dir / "supervise_group.py"
         self.submit_meta = self.runner_dir / "submit_meta.json"
         self.launcher_status = self.runner_dir / "launcher_status.json"
         self.exit_status = self.runner_dir / "exit_status.json"
         self.start_gate = self.runner_dir / "start_authorized"
         self.cancel_marker = self.runner_dir / "cancel_requested"
+        self.guardian_release = self.runner_dir / "guardian_release"
         self.log_path = job_dir / "logs" / "job.log"
 
 
@@ -868,6 +836,26 @@ def cmd_submit(args: argparse.Namespace) -> int:
     with os.fdopen(wrapper_fd, "w", encoding="utf-8") as stream:
         stream.write(JOB_WRAPPER_SOURCE)
 
+    supervisor_created = False
+    try:
+        supervisor_source = SUPERVISOR_SOURCE_PATH.read_bytes()
+        supervisor_fd = os.open(
+            paths.supervisor,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+        )
+        supervisor_created = True
+        with os.fdopen(supervisor_fd, "wb") as stream:
+            stream.write(supervisor_source)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except OSError as exc:
+        if supervisor_created:
+            paths.supervisor.unlink(missing_ok=True)
+        paths.wrapper.unlink(missing_ok=True)
+        paths.submit_meta.unlink(missing_ok=True)
+        return _fail(f"Could not install group supervisor {paths.supervisor}: {exc}")
+
     script_argv = [str(python_path), str(script_path), *rendered_args]
     launcher_argv = [
         str(python_path),
@@ -876,6 +864,8 @@ def cmd_submit(args: argparse.Namespace) -> int:
         str(paths.launcher_status),
         str(paths.start_gate),
         str(paths.cancel_marker),
+        str(paths.supervisor),
+        str(paths.guardian_release),
         *script_argv,
     ]
 
@@ -906,6 +896,7 @@ def cmd_submit(args: argparse.Namespace) -> int:
             "argv": script_argv,
             "venv_path": str(venv_path),
             "wrapper_path": str(paths.wrapper),
+            "supervisor_path": str(paths.supervisor),
             "cwd": str(cwd),
             "log_path": str(paths.log_path),
             "gpu_ids": gpu_ids,
@@ -932,8 +923,6 @@ def cmd_submit(args: argparse.Namespace) -> int:
             log_file.close()  # Popen duplicated the descriptor for the child.
     except OSError as exc:
         return _fail(f"Failed to launch the wrapper: {exc}")
-    spawned_marker = _process_start_marker(process.pid)
-
     # Wait for the wrapper's durable identity record, then open the gate. A
     # wrapper that never writes it means the interpreter/env is broken — kill
     # the group and report, before the script has had any chance to run.
@@ -947,16 +936,11 @@ def cmd_submit(args: argparse.Namespace) -> int:
             break
         time.sleep(0.05)
     if not launcher or not launcher.get("pid"):
-        # The marker captured immediately after Popen binds cleanup to this
-        # exact process. If it was unavailable, let the wrapper's closed gate
-        # time out rather than risk signaling a subsequently reused PGID.
-        if spawned_marker:
-            try:
-                _terminate_process_group(
-                    process.pid, {process.pid: str(spawned_marker)}
-                )
-            except RuntimeError:
-                pass
+        # The wrapper may not yet have created its durable guardian. Request a
+        # gate self-cancel and never signal the numeric Popen pid: a process can
+        # fork between this timeout and a signal, and there is no persisted
+        # supervision anchor to own those descendants yet.
+        _atomic_write_json(paths.cancel_marker, {"timeout": 1.0})
         tail = _read_tail(paths.log_path, 40) if paths.log_path.exists() else ""
         return _fail(
             "Launcher never wrote its durable identity record "
@@ -987,7 +971,11 @@ def _status_from_exit_record(paths: RunnerPaths) -> tuple[str, str, dict] | None
     code = exit_record.get("return_code")
     if not isinstance(code, int) or isinstance(code, bool):
         return None
-    if paths.cancel_marker.exists():
+    canceled = exit_record.get("canceled")
+    # Records predating the explicit field retain their historical behavior.
+    # New records make the wrapper's observed outcome authoritative so a late
+    # cancel marker cannot relabel a natural exit as canceled.
+    if canceled is True or (canceled is None and paths.cancel_marker.exists()):
         return VOCAB_CANCELED, "Process group was canceled", {"return_code": code}
     if code == 0:
         return VOCAB_COMPLETE, "Process exited successfully", {"return_code": 0}
@@ -1019,6 +1007,12 @@ def _derive_status(paths: RunnerPaths) -> tuple[str, str, dict]:
         pid = _coerce_pid(launcher.get("pid"))
         marker = launcher.get("process_start_marker")
         if _launcher_state(pid, marker, wrapper_path) == "running":
+            if launcher.get("cleanup_error"):
+                return (
+                    VOCAB_UNKNOWN,
+                    "Process-group cleanup is indeterminate; supervision remains active",
+                    {"pid": pid, "cleanup_error": launcher.get("cleanup_error")},
+                )
             message = f"Process {pid} is running"
             if canceled:
                 message += " (cancel requested)"
@@ -1030,18 +1024,14 @@ def _derive_status(paths: RunnerPaths) -> tuple[str, str, dict]:
         from_record = _status_from_exit_record(paths)
         if from_record is not None:
             return from_record
-        # A dead launcher does NOT mean a dead job: the training script is a
-        # same-group child that survives a wrapper-only SIGKILL/OOM. Probe for
-        # positively-identified survivors before declaring anything terminal.
-        script_hint = None
-        argv = (submit_meta or {}).get("argv") or []
-        if len(argv) > 1:
-            script_hint = argv[1]
-        survivor_identities = _group_member_identities(pid, script_hint)
+        # A direct workload may have exec-replaced the submitted Python script,
+        # so cmdline text is not identity. The durable guardian anchors the
+        # original PGID and the persisted workload start marker survives exec.
+        survivor_identities = _durably_owned_survivors(pid, launcher)
         if survivor_identities is None:
             return (
                 VOCAB_UNKNOWN,
-                "Launcher ended and surviving process identity is indeterminate",
+                "Launcher ended and process-group ownership is indeterminate",
                 {"pid": pid},
             )
         survivors = sorted(survivor_identities)
@@ -1053,6 +1043,13 @@ def _derive_status(paths: RunnerPaths) -> tuple[str, str, dict]:
             if canceled:
                 message += " (cancel requested)"
             return VOCAB_RUNNING, message, {"pid": pid, "orphaned": True}
+        reused = _recorded_launcher_reused(pid, marker)
+        if reused is not False:
+            return (
+                VOCAB_UNKNOWN,
+                "Launcher ended and process-group ownership is indeterminate",
+                {"pid": pid},
+            )
         if canceled:
             return (
                 VOCAB_CANCELED,
@@ -1107,79 +1104,63 @@ def cmd_cancel(args: argparse.Namespace) -> int:
     status, message, extra = _derive_status(paths)
     if status in (VOCAB_COMPLETE, VOCAB_ERROR, VOCAB_CANCELED):
         return _emit(result="already_terminal", status=status, message=message, **extra)
-    if status == VOCAB_UNKNOWN:
-        return _fail(message)
 
-    # Mark first so a wrapper still waiting on the gate self-cancels, then
-    # verify identity before signaling anything.
-    paths.cancel_marker.touch()
     launcher = _read_json(paths.launcher_status)
+    submit_meta = _read_json(paths.submit_meta)
+    if launcher is None and submit_meta is None:
+        return _fail(message, status=VOCAB_UNKNOWN)
+
+    # Mark first so a healthy wrapper performs supervision while its durable
+    # guardian anchors the PGID. The timeout value is non-secret control data.
+    try:
+        _atomic_write_json(
+            paths.cancel_marker, {"timeout": max(0.0, args.timeout)},
+        )
+    except OSError as exc:
+        return _fail(
+            f"could not persist cancel request: {exc}", status=VOCAB_UNKNOWN,
+        )
     pid = _coerce_pid(launcher.get("pid")) if launcher else 0
     marker = (launcher or {}).get("process_start_marker")
-    submit_meta = _read_json(paths.submit_meta)
     wrapper_path = (submit_meta or {}).get("wrapper_path") or str(paths.wrapper)
 
-    signaled = False
     if pid and _process_matches(pid, marker, wrapper_path):
-        signaled = True
-        try:
-            outcome = _terminate_process_group(
-                pid, {pid: str(marker)}, timeout=args.timeout
-            )
-        except RuntimeError as exc:
-            return _fail(str(exc), status=VOCAB_UNKNOWN)
-    else:
-        outcome = "gone"
-
-    if outcome == "gone" and pid:
-        # Launcher gone, but the script group may have survived it (orphaned
-        # children of a killed wrapper). Kill positively-identified survivors.
-        argv = (submit_meta or {}).get("argv") or []
-        script_hint = argv[1] if len(argv) > 1 else None
-        survivor_identities = _group_member_identities(pid, script_hint)
-        if survivor_identities is None:
-            return _fail(
-                f"could not establish surviving process identities for group {pid}",
-                status=VOCAB_UNKNOWN,
-            )
-        if survivor_identities:
-            signaled = True
-            try:
-                _terminate_process_group(
-                    pid, survivor_identities, timeout=args.timeout
-                )
-            except RuntimeError as exc:
-                return _fail(str(exc), status=VOCAB_UNKNOWN)
-
-    if outcome == "gone" and not signaled:
-        # Nothing was signaled by this cancel: any landed exit record is a
-        # NATURAL exit that beat the cancel — undo the cancel claim rather
-        # than mislabel it (the one exception: the wrapper's gate self-cancel
-        # record, which only exists because of OUR marker).
-        deadline = time.monotonic() + 2.0
-        exit_record = _read_json(paths.exit_status)
-        while exit_record is None and time.monotonic() < deadline:
+        # No external destructive signal is needed: the wrapper sees the
+        # marker, invokes the same copied pidfd supervisor, writes status, and
+        # releases the guardian. Wait a bounded interval for that durable path.
+        deadline = time.monotonic() + max(3.0, args.timeout * 2 + 2.0)
+        while time.monotonic() < deadline:
+            status, message, extra = _derive_status(paths)
+            if status in (VOCAB_COMPLETE, VOCAB_ERROR, VOCAB_CANCELED):
+                result = "canceled" if status == VOCAB_CANCELED else "already_terminal"
+                return _emit(result=result, status=status, message=message, **extra)
             time.sleep(0.05)
-            exit_record = _read_json(paths.exit_status)
-        code = (exit_record or {}).get("return_code")
-        if isinstance(code, int) and not isinstance(code, bool):
-            self_canceled = (
-                (exit_record or {}).get("error") == "Canceled before the script started"
-            )
-            if not self_canceled:
-                paths.cancel_marker.unlink(missing_ok=True)
-                status, message, extra = _derive_status(paths)
-                return _emit(
-                    result="already_terminal", status=status, message=message, **extra
-                )
+        status, message, extra = _derive_status(paths)
+        if status == VOCAB_UNKNOWN:
+            return _fail(message, status=VOCAB_UNKNOWN, **extra)
+        return _emit(result="cancel_requested", status=status, message=message, **extra)
 
-    status, message, extra = _derive_status(paths)
-    result = "canceled"
-    if not signaled and status in (VOCAB_PENDING, VOCAB_RUNNING):
-        # Honest reply: the marker is set (a gated wrapper will self-cancel)
-        # but nothing live was signaled — the caller should re-run cancel.
-        result = "cancel_requested"
-    return _emit(result=result, status=status, message=message, **extra)
+    if pid and launcher:
+        try:
+            _supervise_orphan(paths, launcher, args.timeout)
+        except (OSError, OwnershipError, SupervisionError, ValueError) as exc:
+            return _fail(str(exc), status=VOCAB_UNKNOWN)
+        deadline = time.monotonic() + max(2.0, args.timeout)
+        while time.monotonic() < deadline:
+            status, message, extra = _derive_status(paths)
+            if status == VOCAB_CANCELED:
+                return _emit(result="canceled", status=status, message=message, **extra)
+            time.sleep(0.05)
+        return _fail(
+            "guardian did not release after orphan supervision",
+            status=VOCAB_UNKNOWN,
+        )
+
+    # A pre-launch wrapper will consume the marker if it appears. Without any
+    # durable launcher/guardian identity there is nothing safe to signal.
+    if status == VOCAB_PENDING:
+        return _emit(result="cancel_requested", status=status, message=message, **extra)
+    return _fail(message, status=VOCAB_UNKNOWN)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Reported issue

The virtualenv platform runner could misclassify process groups containing zombies, lose ownership of an exec-replaced workload after its launcher died, or signal a reused numeric PID/PGID during cancellation and cleanup.

## Original reproduction

1. Submit a virtualenv job whose workload creates process-group children.
2. Exercise natural exit, wrapper death, an `execve` replacement, zombie-only membership, late cancellation, or PID/PGID reuse at the observation-to-signal boundary.
3. Query `status` or invoke `cancel` through the platform's four-verb runner.

Before this fix, zombie-only groups could remain falsely RUNNING, orphaned exec-replaced workloads could be lost, late cancellation could relabel a natural exit, and check-then-signal logic depended on reusable numeric identities.

## Root cause

The lifecycle design treated PID/PGID numbers plus best-effort `/proc` or command-line observations as durable authority. Those observations did not pin the kernel process object across signaling, and command-line identity did not survive `execve`. The wrapper also used a separate, weaker cleanup path, so status and cancellation did not share one fail-closed ownership model.

## Implementation

- Added a durable guardian that anchors the original process group for the complete operation.
- Added Linux pidfd-only signaling after start-marker and group verification; no destructive signal uses a raw PID or PGID.
- Persisted wrapper, guardian, and workload identities before waiting so ownership survives `execve`.
- Consolidated wrapper cleanup, orphan supervision, status, and cancellation around one fail-closed scanner.
- Writes terminal state only after guardian shutdown and prevents a late marker from relabeling a natural exit.
- Returns `UNKNOWN` when identity or observation is unreadable, malformed, reused, or otherwise unbound.
- Documented that active cancellation requires Linux procfs and pidfds; other POSIX hosts can prove an empty group but do not signal reusable numeric IDs.

This is a root-cause fix because the process identity abstraction itself now holds kernel-backed identities through the signal boundary. It does not add PID-specific exceptions or make a narrow reproduction pass. We intentionally avoided raw `killpg`, command-line matching as authority, fail-open `ps`/`pgrep` fallbacks, and test-only timing workarounds.

## Regression coverage

Coverage includes zombie groups, malformed/unreadable proc data, PID reuse, PGID reuse, guardian loss, wrapper death, exec-replaced workloads, worker cleanup, start-gate cancellation, late cancellation, natural exit, signal escalation, and non-Linux fail-closed behavior.

## Verification

- Lifecycle suite: `35 passed`
- All explicitly discovered repository tests: `505 passed, 2 skipped, 34 subtests passed`
- `scripts/tests`: `258 passed, 2 skipped`
- Skill validator: passed
- Pre-commit checks: passed
- `git diff --check origin/main...HEAD`: passed

Bare repository-root pytest discovery still follows a pre-existing recursive `plugins/tao-skill-bank` symlink. Every discovered test file was passed explicitly to avoid that unrelated collection issue.

## Residual risk

Active cancellation intentionally fails closed on systems without Linux procfs and pidfd signaling. Such jobs can run and empty groups can be proven, but active members are not signaled by reusable numeric IDs.
