### PR TITLE
[TAO-0000][Bugfix] Guard post-DEFT AutoML against FAR regression

### DIFF
--- a/README_AOI_AUTOML.md
+++ b/README_AOI_AUTOML.md
@@ -55,3 +55,46 @@ Bayesian/BFBO, and `enable_llm_range_narrowing` is a no-op outside hybrid).
 - **Fixed-spec training via pinning** uses epsilon-width ranges
   (`launch_fixed_train`): degenerate min==max pins are rewritten ×1.1/×0.9 by
   the value generator's boundary clamp.
+
+## Reproducing the guarded post-DEFT campaign
+
+Build deterministic, duplicate-free 50% and 100% DEFT mixtures first:
+
+```bash
+python prepare_post_deft_data.py \
+  --source /path/to/train_combined_final.csv \
+  --output-dir /path/to/post_deft_data \
+  --ratios 0.50,1.00 \
+  --seed 20260814
+```
+
+Stage those CSVs and the DEFT incumbent checkpoint where SLURM workers can
+read them. Then inspect the exact four-arm campaign without launching:
+
+```bash
+python aoi_post_deft_campaign.py \
+  --campaign-dir /path/to/local/campaign \
+  --mix50-csv /remote/data/train_unique_mix_050.csv \
+  --mix100-csv /remote/data/train_unique_mix_100.csv \
+  --images-dir /remote/aoi/workspace \
+  --incumbent-checkpoint /remote/checkpoints/deft_winner.pth \
+  --incumbent-far 16.096636665087637 \
+  --dry-run
+```
+
+Remove `--dry-run` only after the normal TAO launch preflight and review. The
+launcher writes `campaign_manifest.json` before submission, runs warm-full,
+warm-head, scratch-mix50, and scratch-mix100 concurrently, and preserves each
+branch summary independently for recovery.
+
+The search objective is global validation FAR. `far_eval_calibrated.py`
+calibrates the 100%-recall threshold on validation and applies it unchanged to
+the KPI inference output. `max_regression=0` keeps the incumbent when a final
+challenger metric is missing, non-finite, or worse. A bad fine-tune can still
+occur; it cannot replace the incumbent through this guarded path.
+
+The study used eight GPUs per trial with per-GPU batch size 2, giving the same
+effective batch size of 16 as the prior one-GPU runs. The default campaign
+contains 8 recommendations for each warm-start arm and 16 for each scratch
+arm. Every path, incumbent FAR, seed, and bound is materialized in the written
+manifest so a run can be audited or reproduced on another machine.

--- a/aoi_post_deft_campaign.py
+++ b/aoi_post_deft_campaign.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the incumbent-preserving four-arm AOI post-DEFT campaign.
+
+The launcher keeps site paths on the command line, writes the fully resolved
+configuration before submitting work, and runs the two conservative warm-start
+arms plus the two from-scratch-on-DEFT-data arms used by the 2026-08-14 study.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import copy
+import importlib
+import json
+import os
+import traceback
+from pathlib import Path
+
+
+WARM_PARAMS = [
+    "train.num_epochs",
+    "train.optim.lr",
+    "train.optim.weight_decay",
+    "train.optim.momentum",
+    "dataset.classify.fpratio_sampling",
+    "train.classify.cls_weight[1]",
+]
+WARM_RANGES = {
+    "train.num_epochs": {"valid_min": 1, "valid_max": 5},
+    "train.optim.lr": {"valid_min": 1e-8, "valid_max": 2e-6},
+    "train.optim.weight_decay": {"valid_min": 0.0, "valid_max": 0.03},
+    "train.optim.momentum": {"valid_min": 0.85, "valid_max": 0.95},
+    "dataset.classify.fpratio_sampling": {"valid_min": 0.15, "valid_max": 0.45},
+    "train.classify.cls_weight[1]": {"valid_min": 2.0, "valid_max": 15.0},
+}
+WARM_INITIAL = {
+    "train.num_epochs": 1,
+    "train.optim.lr": 2e-7,
+    "train.optim.weight_decay": 0.01,
+    "train.optim.momentum": 0.9,
+    "dataset.classify.fpratio_sampling": 0.2,
+    "train.classify.cls_weight[1]": 10.0,
+}
+
+SCRATCH_PARAMS = [
+    "train.classify.cls_weight[1]",
+    "dataset.classify.fpratio_sampling",
+    "train.optim.lr",
+    "train.optim.weight_decay",
+    "train.optim.momentum",
+    "model.classify.learnable_difference_modules",
+    "model.classify.train_margin_euclid",
+    "model.classify.eval_margin",
+    "dataset.classify.augmentation_config.random_color.brightness",
+    "dataset.classify.augmentation_config.random_color.contrast",
+    "dataset.classify.augmentation_config.random_color.saturation",
+    "dataset.classify.augmentation_config.random_color.hue",
+    "dataset.classify.augmentation_config.random_rotate.rotate_probability",
+    "dataset.classify.augmentation_config.random_flip.hflip_probability",
+    "dataset.classify.augmentation_config.random_flip.vflip_probability",
+]
+SCRATCH_RANGES = {
+    "train.classify.cls_weight[1]": {"valid_min": 2.0, "valid_max": 25.0},
+    "dataset.classify.fpratio_sampling": {"valid_min": 0.15, "valid_max": 0.98},
+    "train.optim.lr": {"valid_min": 5e-6, "valid_max": 2e-4},
+    "train.optim.weight_decay": {"valid_min": 0.005, "valid_max": 1.0},
+    "train.optim.momentum": {"valid_min": 0.1, "valid_max": 0.95},
+    "model.classify.learnable_difference_modules": {"valid_min": 1, "valid_max": 4},
+    "model.classify.train_margin_euclid": {"valid_min": 1.0, "valid_max": 3.0},
+    "model.classify.eval_margin": {"valid_min": 0.2, "valid_max": 2.5},
+    "dataset.classify.augmentation_config.random_color.brightness": {
+        "valid_min": 0.1,
+        "valid_max": 2.0,
+    },
+    "dataset.classify.augmentation_config.random_color.contrast": {
+        "valid_min": 0.1,
+        "valid_max": 2.0,
+    },
+    "dataset.classify.augmentation_config.random_color.saturation": {
+        "valid_min": 0.1,
+        "valid_max": 2.0,
+    },
+    "dataset.classify.augmentation_config.random_color.hue": {
+        "valid_min": 1e-7,
+        "valid_max": 0.3,
+    },
+    "dataset.classify.augmentation_config.random_rotate.rotate_probability": {
+        "valid_min": 0.1,
+        "valid_max": 0.8,
+    },
+    "dataset.classify.augmentation_config.random_flip.hflip_probability": {
+        "valid_min": 0.3,
+        "valid_max": 0.7,
+    },
+    "dataset.classify.augmentation_config.random_flip.vflip_probability": {
+        "valid_min": 0.3,
+        "valid_max": 0.7,
+    },
+}
+SCRATCH50_INITIAL = {
+    "train.classify.cls_weight[1]": 2.2,
+    "dataset.classify.fpratio_sampling": 0.33,
+    "train.optim.lr": 0.000014194559202602006,
+    "train.optim.weight_decay": 0.055,
+    "train.optim.momentum": 0.11,
+    "model.classify.learnable_difference_modules": 1,
+    "model.classify.train_margin_euclid": 2.0,
+    "model.classify.eval_margin": 0.3,
+    "dataset.classify.augmentation_config.random_color.brightness": 0.54,
+    "dataset.classify.augmentation_config.random_color.contrast": 0.32757810179178865,
+    "dataset.classify.augmentation_config.random_color.saturation": 0.54,
+    "dataset.classify.augmentation_config.random_color.hue": 1e-7,
+    "dataset.classify.augmentation_config.random_rotate.rotate_probability": 0.45,
+    "dataset.classify.augmentation_config.random_flip.hflip_probability": 0.33,
+    "dataset.classify.augmentation_config.random_flip.vflip_probability": 0.33,
+}
+SCRATCH100_INITIAL = {
+    "train.classify.cls_weight[1]": 20.37832545008366,
+    "dataset.classify.fpratio_sampling": 0.33,
+    "train.optim.lr": 5.5e-6,
+    "train.optim.weight_decay": 0.9,
+    "train.optim.momentum": 0.5803693883720338,
+    "model.classify.learnable_difference_modules": 4,
+    "model.classify.train_margin_euclid": 2.0,
+    "model.classify.eval_margin": 0.3,
+    "dataset.classify.augmentation_config.random_color.brightness": 0.11,
+    "dataset.classify.augmentation_config.random_color.contrast": 0.11,
+    "dataset.classify.augmentation_config.random_color.saturation": 0.13702394749695712,
+    "dataset.classify.augmentation_config.random_color.hue": 1e-7,
+    "dataset.classify.augmentation_config.random_rotate.rotate_probability": 0.4233215549737651,
+    "dataset.classify.augmentation_config.random_flip.hflip_probability": 0.33,
+    "dataset.classify.augmentation_config.random_flip.vflip_probability": 0.63,
+}
+
+
+def _deep_merge(target: dict, override: dict) -> None:
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = copy.deepcopy(value)
+
+
+def _atomic_json(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, default=str) + "\n")
+    temporary.replace(path)
+
+
+def build_tasks(args: argparse.Namespace) -> list[dict]:
+    common = {
+        "algorithm": "bfbo",
+        "incumbent": {
+            "name": args.incumbent_name,
+            "metric_value": args.incumbent_far,
+            "checkpoint": args.incumbent_checkpoint,
+            "metric_protocol": "validation threshold frozen and applied to KPI",
+        },
+        "max_regression": args.max_regression,
+        "images_dir": args.images_dir,
+        "seed": args.seed,
+    }
+    branches = [
+        {
+            "tag": "postdeft_warm_full_mix050",
+            "mode": "warm",
+            "freeze_backbone": False,
+            "csv": args.mix50_csv,
+            "sample_count": args.mix50_sample_count,
+            "recommendations": args.warm_recommendations,
+            "params": WARM_PARAMS,
+            "ranges": WARM_RANGES,
+            "initial": WARM_INITIAL,
+            "interval_cap": 1,
+        },
+        {
+            "tag": "postdeft_warm_head_mix050",
+            "mode": "warm",
+            "freeze_backbone": True,
+            "csv": args.mix50_csv,
+            "sample_count": args.mix50_sample_count,
+            "recommendations": args.warm_recommendations,
+            "params": WARM_PARAMS,
+            "ranges": WARM_RANGES,
+            "initial": WARM_INITIAL,
+            "interval_cap": 1,
+        },
+        {
+            "tag": "postdeft_scratch_mix050",
+            "mode": "scratch",
+            "freeze_backbone": False,
+            "csv": args.mix50_csv,
+            "sample_count": args.mix50_sample_count,
+            "recommendations": args.scratch_recommendations,
+            "params": SCRATCH_PARAMS,
+            "ranges": SCRATCH_RANGES,
+            "initial": SCRATCH50_INITIAL,
+            "interval_cap": 10,
+        },
+        {
+            "tag": "postdeft_scratch_mix100",
+            "mode": "scratch",
+            "freeze_backbone": False,
+            "csv": args.mix100_csv,
+            "sample_count": args.mix100_sample_count,
+            "recommendations": args.scratch_recommendations,
+            "params": SCRATCH_PARAMS,
+            "ranges": SCRATCH_RANGES,
+            "initial": SCRATCH100_INITIAL,
+            "interval_cap": 10,
+        },
+    ]
+    return [{**copy.deepcopy(common), **branch} for branch in branches]
+
+
+def _task_spec(task: dict) -> dict:
+    if task["mode"] == "warm":
+        return {
+            "train": {
+                "num_epochs": 5,
+                "validation_interval": 1,
+                "checkpoint_interval": 1,
+                "pretrained_model_path": task["incumbent"]["checkpoint"],
+                "seed": task["seed"],
+                "classify": {"loss": "ce", "cls_weight": [1.0, 10.0]},
+                "optim": {
+                    "optim": "adamw",
+                    "policy": "linear",
+                    "lr": 2e-7,
+                    "weight_decay": 0.01,
+                    "momentum": 0.9,
+                },
+            },
+            "model": {
+                "backbone": {"freeze_backbone": task["freeze_backbone"]},
+                "classify": {
+                    "learnable_difference_modules": 4,
+                    "train_margin_euclid": 2.0,
+                    "eval_margin": 0.3,
+                },
+            },
+        }
+    return {
+        "train": {
+            "num_epochs": 100,
+            "validation_interval": 10,
+            "checkpoint_interval": 10,
+            "pretrained_model_path": None,
+            "seed": task["seed"],
+        },
+        "model": {"backbone": {"freeze_backbone": False}},
+    }
+
+
+def run_branch(campaign_dir: str, task: dict) -> dict:
+    campaign = Path(campaign_dir)
+    tag = task["tag"]
+    try:
+        runner = importlib.import_module("automl_vcn_slurm_v2")
+        runner.WORKSPACE = campaign / "branches" / tag
+        runner.BASE_SPEC = copy.deepcopy(runner.BASE_SPEC)
+        _deep_merge(runner.BASE_SPEC, _task_spec(task))
+        runner.BASE_SPEC["dataset"]["classify"]["train_dataset"] = {
+            "csv_path": task["csv"],
+            "images_dir": task["images_dir"],
+        }
+        config = {
+            "algorithm": task["algorithm"],
+            "settings": {
+                "num_recommendations": task["recommendations"],
+                "train_sample_count": task["sample_count"],
+                "metric": "far_pct",
+                "run_baseline": False,
+            },
+            "metric": "far_pct",
+            "direction": "minimize",
+            "use_val_far_eval_fn": True,
+            "hyperparameters": task["params"],
+            "ranges": task["ranges"],
+            "forced_initial_overrides": task["initial"],
+            "interval_cap": task["interval_cap"],
+            "incumbent": task["incumbent"],
+            "max_regression": task["max_regression"],
+        }
+        result = runner.launch_one(
+            tag,
+            config,
+            str(campaign / "search_summaries"),
+        )
+        outcome = {
+            "tag": tag,
+            "status": "complete",
+            "best": (result or {}).get("best"),
+            "final_evaluation": (result or {}).get("final_evaluation"),
+            "promotion": (result or {}).get("promotion"),
+        }
+    except Exception as error:  # Preserve every branch result for recovery.
+        outcome = {
+            "tag": tag,
+            "status": "error",
+            "error": str(error),
+            "traceback": traceback.format_exc(),
+        }
+    _atomic_json(campaign / "branch_summaries" / f"{tag}.json", outcome)
+    return outcome
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--campaign-dir", required=True, type=Path)
+    parser.add_argument("--mix50-csv", required=True)
+    parser.add_argument("--mix100-csv", required=True)
+    parser.add_argument("--images-dir", required=True)
+    parser.add_argument("--incumbent-checkpoint", required=True)
+    parser.add_argument("--incumbent-far", required=True, type=float)
+    parser.add_argument("--incumbent-name", default="deft_winner")
+    parser.add_argument("--mix50-sample-count", type=int, default=309)
+    parser.add_argument("--mix100-sample-count", type=int, default=404)
+    parser.add_argument("--warm-recommendations", type=int, default=8)
+    parser.add_argument("--scratch-recommendations", type=int, default=16)
+    parser.add_argument("--max-regression", type=float, default=0.0)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--max-workers", type=int, default=4)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write the resolved manifest without submitting any jobs.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.max_workers < 1:
+        raise ValueError("--max-workers must be positive")
+    tasks = build_tasks(args)
+    manifest = {
+        "launcher": str(Path(__file__).resolve()),
+        "pid": os.getpid(),
+        "branches": len(tasks),
+        "recommendations": sum(task["recommendations"] for task in tasks),
+        "max_concurrent_branches": args.max_workers,
+        "gpus_per_trial": 8,
+        "nodes_per_trial": 1,
+        "tasks": tasks,
+    }
+    _atomic_json(args.campaign_dir / "campaign_manifest.json", manifest)
+    if args.dry_run:
+        print(json.dumps(manifest, indent=2))
+        return 0
+
+    results: list[dict] = []
+    with concurrent.futures.ProcessPoolExecutor(max_workers=args.max_workers) as pool:
+        futures = {
+            pool.submit(run_branch, str(args.campaign_dir), task): task
+            for task in tasks
+        }
+        for future in concurrent.futures.as_completed(futures):
+            results.append(future.result())
+            _atomic_json(args.campaign_dir / "campaign_progress.json", results)
+    _atomic_json(args.campaign_dir / "campaign_complete.json", results)
+    return 0 if all(item["status"] == "complete" for item in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/automl_vcn_slurm_v2.py
+++ b/automl_vcn_slurm_v2.py
@@ -20,7 +20,7 @@ Usage:
   python automl_vcn_slurm_v2.py --far-only   # just score the bayesian winner
 """
 
-import os, sys, argparse, logging, json
+import os, sys, argparse, logging, json, math
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -33,7 +33,11 @@ SKILL_DIR  = SB / "skills" / "models" / "tao-train-visual-changenet"
 WORKSPACE  = Path(os.environ.get("AOI_WORKSPACE", "./workspace"))
 LOCAL_KPI  = WORKSPACE / "kpi" / "testing_set.csv"
 
-IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"
+# Allow SLURM campaigns to bind a pre-validated SquashFS image directly.  The
+# registry URI remains the portable default for Docker and uncached launches.
+IMAGE = os.environ.get(
+    "TAO_VCN_IMAGE", "nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt"
+)
 
 # ── Lustre paths (from env set by the v1 run) ─────────────────────────────────
 LUSTRE_AOI_ROOT = (
@@ -68,8 +72,14 @@ BASE_SPEC = {
     "encryption_key": "tlt_encode",
     "task": "classify",
     "train": {
+        # SLURM polar3 allocates full 8-GPU nodes.  Keep the effective batch
+        # equal to the prior 1-GPU champion (16) by using batch_size=2 below.
+        "num_gpus": 8,
+        "gpu_ids": list(range(8)),
         "num_epochs": 100,
         "num_nodes": 1,
+        "use_distributed_sampler": True,
+        "sync_batchnorm": True,
         "validation_interval": 10,
         "checkpoint_interval": 10,  # clamped per-rec to min(10, rung epochs) by on_recommendation
         # In-training FAR selection: the patched nvidia_tao_pytorch (PYTHONPATH
@@ -102,7 +112,7 @@ BASE_SPEC = {
             "validation_dataset": {"csv_path": LUSTRE_VAL_CSV,    "images_dir": LUSTRE_IMAGES_DIR},
             "test_dataset":       {"csv_path": LUSTRE_VAL_CSV,    "images_dir": LUSTRE_IMAGES_DIR},
             "infer_dataset":      {"csv_path": LUSTRE_KPI_CSV,    "images_dir": LUSTRE_IMAGES_DIR},
-            "batch_size": 16, "workers": 2, "fpratio_sampling": 0.2,
+            "batch_size": 2, "workers": 2, "fpratio_sampling": 0.2,
             "num_input": 1, "input_map": {"SolderLight": 0},
             "concat_type": "linear", "image_width": 224, "image_height": 224,
             "image_ext": ".jpg", "grid_map": {"x": 2, "y": 2}, "num_classes": 2,
@@ -252,7 +262,8 @@ ALGO_CONFIGS = {
     # defect-class CE weight (schema-gated as automl_enabled=false on the list;
     # exposed via a scalar cls_weight[1] property added to the model skill schema
     # — verified end-to-end via generate_hyperparams_to_search dry-run).
-    # batch_size needed no schema edit (only explicit false blocks a param).
+    # Batch size is deliberately fixed at 2/GPU for the 8-GPU campaign so
+    # every arm retains the prior champion's global batch size of 16.
     "bfbo_llm_40_unblocked": {
         "algorithm": "bfbo",
         "settings": _bayesian_settings(
@@ -261,7 +272,6 @@ ALGO_CONFIGS = {
         "metric": "far_pct", "direction": "minimize", "use_far_eval_fn": True,
         "hyperparameters": [
             "train.classify.cls_weight[1]",
-            "dataset.classify.batch_size",
             "dataset.classify.fpratio_sampling",
             "train.optim.lr",
             "train.optim.weight_decay",
@@ -278,8 +288,6 @@ ALGO_CONFIGS = {
         "ranges": {
             # Defect-class CE weight — the direct loss-level imbalance lever.
             "train.classify.cls_weight[1]": {"valid_min": 2.0, "valid_max": 60.0},
-            # Schema max is inf — bound it. Small data, sampler interaction.
-            "dataset.classify.batch_size": {"valid_min": 8, "valid_max": 32},
             "dataset.classify.fpratio_sampling": {"valid_min": 0.3, "valid_max": 0.98},
             "train.optim.lr": {"valid_min": 5e-6, "valid_max": 1e-4},
             "train.optim.weight_decay": {"valid_min": 0.05, "valid_max": 1.0},
@@ -412,7 +420,28 @@ def make_sdk():
     from tao_sdk.platforms.slurm import SlurmSDK
     # SlurmSDK reads all credentials from env (SLURM_USER, SLURM_HOSTNAME,
     # SSH_KEY_PATH, SLURM_BASE_RESULTS_DIR, SLURM_PARTITION, SLURM_ACCOUNT, NGC_KEY …)
-    return SlurmSDK()
+    sdk = SlurmSDK()
+
+    # The SDK's remote-command timeout is intentionally generous, but it also
+    # uses that value as OpenSSH's ConnectTimeout.  A dead login node would
+    # therefore block for five minutes before the SDK tried the next hostname
+    # from SLURM_HOSTNAME.  Keep the remote-command timeout untouched and only
+    # shorten connection establishment.  Patch the option factory as well so
+    # hostname failover does not restore the long connect timeout.
+    handler = getattr(sdk, "_handler", None)
+    if handler is not None and hasattr(handler, "_get_ssh_options"):
+        original_get_ssh_options = handler._get_ssh_options
+
+        def _responsive_ssh_options():
+            options = original_get_ssh_options()
+            return [
+                "ConnectTimeout=15" if option.startswith("ConnectTimeout=") else option
+                for option in options
+            ]
+
+        handler._get_ssh_options = _responsive_ssh_options
+        handler.ssh_options = _responsive_ssh_options()
+    return sdk
 
 
 def far_eval_fn(rec, train_job_id, sdk, results_dir):
@@ -596,12 +625,81 @@ def score_bayesian_winner():
     return far
 
 
+def select_incumbent_or_challenger(
+    incumbent,
+    challenger,
+    *,
+    direction="minimize",
+    max_regression=0.0,
+):
+    """Return a promotion decision that always keeps an eligible incumbent.
+
+    ``metric_value`` is required on the incumbent. A missing/non-finite
+    challenger metric is an automatic rollback. With the default zero
+    tolerance, a challenger is promoted only when it is no worse under the
+    exact same final-evaluation protocol.
+    """
+    if direction not in {"minimize", "maximize"}:
+        raise ValueError(f"unsupported direction: {direction}")
+    if max_regression < 0:
+        raise ValueError("max_regression must be >= 0")
+
+    incumbent_metric = float(incumbent["metric_value"])
+    if not math.isfinite(incumbent_metric):
+        raise ValueError("incumbent metric_value must be finite")
+    raw_challenger_metric = challenger.get("metric_value")
+    try:
+        challenger_metric = float(raw_challenger_metric)
+    except (TypeError, ValueError):
+        challenger_metric = math.nan
+
+    if not math.isfinite(challenger_metric):
+        promoted = False
+        regression = None
+        reason = "challenger final evaluation is missing or non-finite"
+    else:
+        regression = (
+            challenger_metric - incumbent_metric
+            if direction == "minimize"
+            else incumbent_metric - challenger_metric
+        )
+        promoted = regression <= max_regression
+        reason = (
+            "challenger passed promotion gate"
+            if promoted
+            else "challenger regressed beyond promotion tolerance"
+        )
+
+    selected = challenger if promoted else incumbent
+    return {
+        "selected": "challenger" if promoted else "incumbent",
+        "promoted": promoted,
+        "reason": reason,
+        "direction": direction,
+        "max_regression": max_regression,
+        "incumbent_metric": incumbent_metric,
+        "challenger_metric": (
+            challenger_metric if math.isfinite(challenger_metric) else None
+        ),
+        "regression": regression,
+        "selected_artifact": dict(selected),
+    }
+
+
 def launch_one(algo_name, cfg, log_dir):
     from tao_automl.runner import AutoMLRunner
     sdk = make_sdk()
     import datetime
-    run_ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    workspace_dir = str(WORKSPACE / f"automl_{algo_name}_{run_ts}")
+    resume_workspace = cfg.get("resume_workspace")
+    if resume_workspace:
+        workspace_dir = str(resume_workspace)
+        resume = True
+        log.info("[%s] resuming durable AutoML workspace %s",
+                 algo_name, workspace_dir)
+    else:
+        run_ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        workspace_dir = str(WORKSPACE / f"automl_{algo_name}_{run_ts}")
+        resume = False
     runner = AutoMLRunner(sdk=sdk, skill_dir=str(SKILL_DIR), action="train")
 
     log.info("Launching AutoML [%s] — algo=%s recs=%s metric=%s",
@@ -610,6 +708,14 @@ def launch_one(algo_name, cfg, log_dir):
              cfg["metric"])
 
     settings = {"algorithm": cfg["algorithm"], **cfg["settings"]}
+    # A durable resume must reopen the original AutoML session. Without the
+    # persisted ID the SDK creates a new controller/brain namespace, then
+    # refuses to attach an old job whose recommendation is absent there.
+    if cfg.get("resume_session_id"):
+        settings["session_id"] = cfg["resume_session_id"]
+        settings["experiment_id"] = cfg["resume_session_id"]
+        log.info("[%s] reopening AutoML session %s",
+                 algo_name, cfg["resume_session_id"])
     # CRITICAL: direction must live inside automl_settings. Without it, the
     # runner's implicit rule maximizes any metric whose name lacks 'loss' —
     # which would make the brain actively maximize far_pct.
@@ -617,22 +723,46 @@ def launch_one(algo_name, cfg, log_dir):
 
     merged_overrides = dict(BASE_SPEC)
 
+    first_recommendation = {"seen": False}
+    interval_cap = int(cfg.get("interval_cap", 10))
+    if interval_cap < 1:
+        raise ValueError(f"[{algo_name}] interval_cap must be >= 1")
+
     def _clamp_intervals(rec):
         """Per-rec safety: BOHB rung overrides set train.num_epochs but never
         touch intervals (brain passes interval=None). TAO asserts
         checkpoint_interval <= num_epochs, so clamp both intervals to the
         rec's actual epoch budget. Full-fidelity recs keep interval 10."""
+        # A fresh run's first callback is the reviewed initial batch even when
+        # an AutoML backend uses a non-zero or opaque recommendation id.  Do
+        # not replay it on resume, where the first callback can be a later rec.
+        if not first_recommendation["seen"] and forced_initial and not resume:
+            rec.specs.update(forced_initial)
+            log.info(
+                "[%s] first recommendation (id=%s) pinned to reviewed initial config",
+                algo_name,
+                getattr(rec, "id", "unknown"),
+            )
+        first_recommendation["seen"] = True
         n_ep = rec.specs.get("train.num_epochs")
         n_ep = int(n_ep) if n_ep else BASE_SPEC["train"]["num_epochs"]
-        rec.specs["train.checkpoint_interval"] = min(10, n_ep)
-        rec.specs["train.validation_interval"] = min(10, n_ep)
+        rec.specs["train.checkpoint_interval"] = min(interval_cap, n_ep)
+        rec.specs["train.validation_interval"] = min(interval_cap, n_ep)
 
     # Attach FAR eval_fn when requested (bayesian_far config)
     eval_fn = None
+    final_eval_fn = None
     if cfg.get("use_val_far_eval_fn"):
         eval_fn = make_val_far_eval_fn(sdk)
+        final_eval_fn = make_far_eval_fn(
+            sdk,
+            IMAGE,
+            ACCOUNT,
+            f"{LUSTRE_AOI_ROOT}/far_eval_automl/{algo_name}/final",
+        )
         log.info("[%s] STRICT protocol: brain sees validation FAR only; "
-                 "KPI reserved for one final scoring", algo_name)
+                 "KPI reserved for one final scoring of the selected winner",
+                 algo_name)
     elif cfg.get("use_far_eval_fn"):
         lustre_far_root = f"{LUSTRE_AOI_ROOT}/far_eval_automl/{algo_name}"
         eval_fn = make_far_eval_fn(sdk, IMAGE, ACCOUNT, lustre_far_root)
@@ -641,6 +771,16 @@ def launch_one(algo_name, cfg, log_dir):
     # Per-config HP space; None ranges → schema-default bounds.
     hp_list = cfg.get("hyperparameters", AUTOML_HPS)
     hp_ranges = cfg.get("ranges", CUSTOM_RANGES) if "ranges" in cfg else CUSTOM_RANGES
+    forced_initial = cfg.get("forced_initial_overrides") or {}
+    unknown_initial = sorted(set(forced_initial) - set(hp_list))
+    if unknown_initial:
+        raise ValueError(
+            f"[{algo_name}] forced initial overrides are not searched params: "
+            f"{unknown_initial}"
+        )
+    if forced_initial:
+        log.info("[%s] recommendation 0 reuses %d reviewed overrides",
+                 algo_name, len(forced_initial))
     log.info("[%s] search space: %d params, custom ranges: %s",
              algo_name, len(hp_list), "yes" if hp_ranges else "schema defaults")
 
@@ -651,29 +791,70 @@ def launch_one(algo_name, cfg, log_dir):
         automl_hyperparameters=hp_list,
         custom_param_ranges=hp_ranges,
         workspace_path=workspace_dir,
+        resume=resume,
         eval_fn=eval_fn,
+        final_eval_fn=final_eval_fn,
         on_recommendation=_clamp_intervals,
         account=ACCOUNT or None,
+        gpu_count=8,
         num_nodes=1,
         env_vars={"PYTHONPATH": f"{LUSTRE_AOI_ROOT}/patches/valfar"},
     )
 
     best = result.get("best", {})
+    # AutoMLRunner returns the recommendation record shape (``result`` /
+    # ``objective_score`` and ``specs``), while older runners returned
+    # ``metric`` and ``spec_overrides``.  Normalize both shapes here so the
+    # durable summary never silently drops the winning metric or parameters.
+    best_metric = best.get("metric")
+    if best_metric is None:
+        best_metric = best.get("objective_score", best.get("result"))
+    best_specs = best.get("spec_overrides") or best.get("specs") or {}
     log.info("[%s] DONE — best metric=%s HPs=%s",
-             algo_name, best.get("metric"), best.get("spec_overrides"))
+             algo_name, best_metric, best_specs)
+
+    promotion = None
+    if cfg.get("incumbent"):
+        final_evaluation = result.get("final_evaluation") or {}
+        challenger = {
+            "metric_value": final_evaluation.get("metric_value"),
+            "job_id": best.get("job_id"),
+            "specs": best_specs,
+            "workspace": workspace_dir,
+            "record_path": final_evaluation.get("record_path"),
+        }
+        promotion = select_incumbent_or_challenger(
+            cfg["incumbent"],
+            challenger,
+            direction=cfg.get("direction", "minimize"),
+            max_regression=float(cfg.get("max_regression", 0.0)),
+        )
+        result["promotion"] = promotion
+        log.info(
+            "[%s] promotion: selected=%s incumbent=%s challenger=%s reason=%s",
+            algo_name,
+            promotion["selected"],
+            promotion["incumbent_metric"],
+            promotion["challenger_metric"],
+            promotion["reason"],
+        )
 
     # Write summary
     summary = {
         "algorithm": algo_name,
         "best_metric_name": cfg["metric"],
-        "best_metric_value": best.get("metric"),
-        "best_spec_overrides": best.get("spec_overrides", {}),
+        "best_metric_value": best_metric,
+        "best_spec_overrides": best_specs,
         "best_job_id": best.get("job_id"),
+        "final_evaluation": result.get("final_evaluation"),
+        "promotion": promotion,
         "workspace": workspace_dir,
     }
-    out = Path(log_dir) / f"summary_{algo_name}.json"
+    summary_dir = Path(log_dir)
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    out = summary_dir / f"summary_{algo_name}.json"
     out.write_text(json.dumps(summary, indent=2))
-    print(f"\n[{algo_name}] Best {cfg['metric']}: {best.get('metric')} | "
+    print(f"\n[{algo_name}] Best {cfg['metric']}: {best_metric} | "
           f"Summary: {out}")
     return result
 
@@ -830,9 +1011,22 @@ def make_val_far_eval_fn(sdk):
         except Exception as e:
             log.warning("[val_eval] rec=%s: cannot read status.json: %s", rec_id, e)
             return None
+        # AOI validation has 211 PASS and 38 defect rows.  Requiring the
+        # provenance written by the global DDP implementation prevents an old
+        # rank-0-only status.json from silently re-entering the search.
+        global_markers = len(_re.findall(r'"val_far_global":\s*true', status))
+        pass_markers = len(_re.findall(r'"val_far_num_pass":\s*211\b', status))
+        defect_markers = len(_re.findall(r'"val_far_num_defect":\s*38\b', status))
         vals = [float(v) for v in _re.findall(r'"val_far":\s*([0-9.]+)', status)]
         if not vals:
             log.warning("[val_eval] rec=%s: no val_far entries in status.json", rec_id)
+            return None
+        if min(global_markers, pass_markers, defect_markers) < len(vals):
+            log.error(
+                "[val_eval] rec=%s: rejecting non-global FAR provenance "
+                "(far=%d global=%d pass211=%d defect38=%d)",
+                rec_id, len(vals), global_markers, pass_markers, defect_markers,
+            )
             return None
         best = min(vals)
         log.info("[val_eval] rec=%s: val FAR@100%%R = %.2f%% "
@@ -846,19 +1040,19 @@ def make_far_eval_fn(sdk, image, account, lustre_far_root):
     """
     Returns an eval_fn(rec, train_job_id) that:
       1. Finds the best checkpoint from the training job on Lustre
-      2. Submits a SLURM inference job on the KPI test set (7.0.1-pyt, cached SQSH)
-      3. Polls for completion
-      4. Runs the FAR script on Lustre and reads metric_result.json
+      2. Runs validation inference and calibrates the 100%-recall threshold
+      3. Runs KPI inference and applies that threshold unchanged
+      4. Reads the calibrated metric_result.json
       Returns FAR value (lower = better) or None on failure.
     """
     import subprocess as _sp, time as _time, yaml as _yaml, pathlib as _pl
 
-    FAR_IMAGE = "nvcr.io/nvidia/tao/tao-toolkit:7.0.1-pyt"
-    FAR_SCRIPT_LOCAL = str(SB / "far_eval_inline.py")
-
-    # Write FAR computation script once
-    from far_eval import _FAR_INLINE_PY
-    _pl.Path(FAR_SCRIPT_LOCAL).write_text(_FAR_INLINE_PY)
+    FAR_IMAGE = os.environ.get(
+        "TAO_VCN_FAR_IMAGE", "nvcr.io/nvidia/tao/tao-toolkit:7.0.1-pyt"
+    )
+    FAR_SCRIPT_LOCAL = str(SB / "far_eval_calibrated.py")
+    if not _pl.Path(FAR_SCRIPT_LOCAL).is_file():
+        raise FileNotFoundError(FAR_SCRIPT_LOCAL)
 
     def _ssh(cmd):
         key  = os.environ.get("SSH_KEY_PATH", "")
@@ -934,25 +1128,46 @@ def make_far_eval_fn(sdk, image, account, lustre_far_root):
         m = _re.search(r"model_best_(\d+)", ckpt)
         best_epoch = int(m.group(1)) if m else None
 
+        import copy as _copy
         lustre_out = f"{lustre_far_root}/rec_{rec_id}"
+        val_out    = f"{lustre_out}/validation"
         infer_out  = f"{lustre_out}/inference"
         far_out    = f"{lustre_out}/far"
-        spec["dataset"]["classify"]["infer_dataset"] = {
+        val_spec = _copy.deepcopy(spec)
+        val_spec["dataset"]["classify"]["infer_dataset"] = {
+            "csv_path": LUSTRE_VAL_CSV, "images_dir": LUSTRE_IMAGES_DIR,
+        }
+        val_spec["inference"] = {
+            "checkpoint": ckpt, "batch_size": 16,
+            "results_dir": val_out, "num_gpus": 1, "gpu_ids": [0], "num_nodes": 1,
+        }
+        val_spec["results_dir"] = val_out
+
+        kpi_spec = _copy.deepcopy(spec)
+        kpi_spec["dataset"]["classify"]["infer_dataset"] = {
             "csv_path": LUSTRE_KPI_CSV, "images_dir": LUSTRE_IMAGES_DIR,
         }
-        spec["inference"] = {
+        kpi_spec["inference"] = {
             "checkpoint": ckpt, "batch_size": 16,
             "results_dir": infer_out, "num_gpus": 1, "gpu_ids": [0], "num_nodes": 1,
         }
-        spec["results_dir"] = infer_out
+        kpi_spec["results_dir"] = infer_out
 
-        local_spec = f"/tmp/far_eval_rec_{rec_id}.yaml"
-        lustre_spec   = f"{lustre_out}/infer_spec.yaml"
+        local_val_spec = f"/tmp/far_eval_val_rec_{rec_id}.yaml"
+        local_kpi_spec = f"/tmp/far_eval_kpi_rec_{rec_id}.yaml"
+        lustre_val_spec = f"{lustre_out}/validation_spec.yaml"
+        lustre_kpi_spec = f"{lustre_out}/kpi_spec.yaml"
         lustre_script = f"{lustre_out}/far_compute.py"
-        _pl.Path(local_spec).write_text(_yaml.dump(spec, default_flow_style=False))
+        _pl.Path(local_val_spec).write_text(
+            _yaml.dump(val_spec, default_flow_style=False)
+        )
+        _pl.Path(local_kpi_spec).write_text(
+            _yaml.dump(kpi_spec, default_flow_style=False)
+        )
         try:
-            _ssh(f"mkdir -p {lustre_out} {infer_out} {far_out}")
-            _scp(local_spec, lustre_spec)
+            _ssh(f"mkdir -p {lustre_out} {val_out} {infer_out} {far_out}")
+            _scp(local_val_spec, lustre_val_spec)
+            _scp(local_kpi_spec, lustre_kpi_spec)
             _scp(FAR_SCRIPT_LOCAL, lustre_script)
         except Exception as e:
             log.warning("[eval_fn] rec=%s: scp failed: %s", rec_id, e)
@@ -962,8 +1177,10 @@ def make_far_eval_fn(sdk, image, account, lustre_far_root):
         log.info("[eval_fn] rec=%s: scoring best-val_far checkpoint (epoch %s)",
                  rec_id, best_epoch)
         command = (
-            f"visual_changenet inference -e {lustre_spec} && "
-            f"python3 {lustre_script} {infer_out}/inference.csv {far_json}"
+            f"visual_changenet inference -e {lustre_val_spec} && "
+            f"visual_changenet inference -e {lustre_kpi_spec} && "
+            f"python3 {lustre_script} {val_out}/inference.csv "
+            f"{infer_out}/inference.csv {far_json}"
         )
 
         try:
@@ -1009,11 +1226,15 @@ def make_far_eval_fn(sdk, image, account, lustre_far_root):
             d = _json.loads(raw_result)
             far = d["value"]
             diag = d.get("diagnostics", {})
-            log.info("[eval_fn] rec=%s: FAR@100%%R = %.2f%% (best_epoch=%s, "
-                     "val_far=%.2f%%, curve=%s)",
-                     rec_id, far, diag.get("best_epoch"),
-                     diag.get("val_far_selected", float("nan")),
-                     diag.get("val_far_curve"))
+            log.info(
+                "[eval_fn] rec=%s: calibrated FAR = %.2f%% "
+                "(threshold=%.8f, KPI recall=%.2f%%, best_epoch=%s)",
+                rec_id,
+                far,
+                d.get("threshold", float("nan")),
+                d.get("constraints", {}).get("recall_pct", float("nan")),
+                best_epoch,
+            )
             return far
         except Exception as e:
             log.warning("[eval_fn] rec=%s: cannot read FAR result: %s", rec_id, e)
@@ -1066,7 +1287,7 @@ def launch_llm_narrowed(algo_name, cfg, log_dir, warmup_recs=12):
             automl_settings=settings,
             automl_hyperparameters=hp_list, custom_param_ranges=ranges,
             workspace_path=ws, eval_fn=eval_fn, on_recommendation=_clamp,
-            account=ACCOUNT or None, num_nodes=1,
+            account=ACCOUNT or None, gpu_count=8, num_nodes=1,
             env_vars={"PYTHONPATH": f"{LUSTRE_AOI_ROOT}/patches/valfar"},
         )
         return res, ws
@@ -1164,8 +1385,14 @@ def launch_fixed_train(tag, pinned_values, spec_extra=None, num_epochs=10,
     if train_csv:
         spec["dataset"]["classify"]["train_dataset"] = {
             "csv_path": train_csv, "images_dir": images_dir or LUSTRE_IMAGES_DIR}
-    for k, v in (spec_extra or {}).items():
-        spec[k] = v
+    def _deep_merge(dst, src):
+        for key, value in src.items():
+            if isinstance(value, dict) and isinstance(dst.get(key), dict):
+                _deep_merge(dst[key], value)
+            else:
+                dst[key] = value
+
+    _deep_merge(spec, spec_extra or {})
 
     # Epsilon-width ranges (not zero-width): the value generator's boundary
     # clamp rewrites values sitting exactly on valid_min/valid_max (x1.1/x0.9),
@@ -1193,7 +1420,7 @@ def launch_fixed_train(tag, pinned_values, spec_extra=None, num_epochs=10,
         image=IMAGE, spec_overrides=spec, automl_settings=settings,
         automl_hyperparameters=list(pinned_values), custom_param_ranges=ranges,
         workspace_path=ws, eval_fn=eval_fn, on_recommendation=_clamp,
-        account=ACCOUNT or None, num_nodes=1,
+        account=ACCOUNT or None, gpu_count=8, num_nodes=1,
         env_vars={"PYTHONPATH": f"{LUSTRE_AOI_ROOT}/patches/valfar"},
     )
     import glob as _glob, json as _json
@@ -1224,7 +1451,8 @@ DEFT2_BASELINE_PINS = {
 
 def launch_deft_iter_automl(iter_label, train_csv_lustre, images_dir_lustre,
                             prev_ckpt_lustre, num_recs=6, num_epochs=10,
-                            log_dir=None, search_params=None, search_ranges=None):
+                            log_dir=None, search_params=None, search_ranges=None,
+                            incumbent=None, max_regression=0.0):
     """One DEFT iteration's retrain implemented as a small BFBO search.
 
     Each recommendation trains num_epochs from prev_ckpt (pretrained_model_path
@@ -1270,7 +1498,7 @@ def launch_deft_iter_automl(iter_label, train_csv_lustre, images_dir_lustre,
         automl_hyperparameters=search_params or AUTOML_HPS,
         custom_param_ranges=search_ranges or DEFT_ITER_RANGES,
         workspace_path=ws, eval_fn=eval_fn, on_recommendation=_clamp,
-        account=ACCOUNT or None, num_nodes=1,
+        account=ACCOUNT or None, gpu_count=8, num_nodes=1,
         env_vars={"PYTHONPATH": f"{LUSTRE_AOI_ROOT}/patches/valfar"},
     )
     best = (result or {}).get("best", {})
@@ -1286,6 +1514,18 @@ def launch_deft_iter_automl(iter_label, train_csv_lustre, images_dir_lustre,
     if cands:
         w = min(cands, key=lambda r: r["result"])
         out.update(job_id=w["job_id"], far=w["result"], specs=w["specs"])
+    if incumbent:
+        out["promotion"] = select_incumbent_or_challenger(
+            incumbent,
+            {
+                "metric_value": out["far"],
+                "job_id": out["job_id"],
+                "specs": out["specs"],
+                "workspace": out["workspace"],
+            },
+            direction="minimize",
+            max_regression=max_regression,
+        )
     log.info("[%s] iteration winner: FAR=%.4f%% job=%s", algo_name,
              out["far"], out["job_id"])
     return out

--- a/far_eval_calibrated.py
+++ b/far_eval_calibrated.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Calibrate FAR threshold on validation and apply it unchanged to KPI data.
+
+The classification rule and candidate thresholds exactly match
+``analyze_kpi.py``: ``score > threshold`` predicts a defect, and candidates are
+``nextafter(min_score, -inf)`` plus every observed calibration score. The
+highest candidate below the minimum defect score gives 100% calibration recall
+while minimizing validation FAR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+
+
+def _load(path: Path) -> tuple[list[float], list[bool]]:
+    scores: list[float] = []
+    is_pass: list[bool] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        fields = set(reader.fieldnames or [])
+        missing = {"label", "siamese_score"} - fields
+        if missing:
+            raise ValueError(f"{path}: missing columns {sorted(missing)}")
+        for line, row in enumerate(reader, start=2):
+            raw_score = (row.get("siamese_score") or "").strip()
+            if not raw_score:
+                raise ValueError(f"{path}: empty siamese_score at line {line}")
+            score = float(raw_score)
+            if not math.isfinite(score):
+                raise ValueError(f"{path}: non-finite siamese_score at line {line}")
+            scores.append(score)
+            is_pass.append((row.get("label") or "").strip().upper() == "PASS")
+    if not scores:
+        raise ValueError(f"{path}: no rows")
+    return scores, is_pass
+
+
+def calibrate_threshold(scores: list[float], is_pass: list[bool]) -> float:
+    defects = [score for score, passed in zip(scores, is_pass) if not passed]
+    passed = [score for score, is_ok in zip(scores, is_pass) if is_ok]
+    if not defects or not passed:
+        raise ValueError("calibration data requires both PASS and defect rows")
+    candidates = [math.nextafter(min(scores), -math.inf), *sorted(set(scores))]
+    eligible = [threshold for threshold in candidates if threshold < min(defects)]
+    if not eligible:  # Defensive; nextafter(min(scores), -inf) is always eligible.
+        raise ValueError("no threshold achieves 100% calibration recall")
+    return max(eligible)
+
+
+def evaluate_at_threshold(
+    scores: list[float],
+    is_pass: list[bool],
+    threshold: float,
+) -> dict[str, float | int]:
+    tp = fp = tn = fn = 0
+    for score, passed in zip(scores, is_pass):
+        predicted_defect = score > threshold
+        if not passed and predicted_defect:
+            tp += 1
+        elif passed and predicted_defect:
+            fp += 1
+        elif passed:
+            tn += 1
+        else:
+            fn += 1
+    recall = tp / (tp + fn) if tp + fn else math.nan
+    far = fp / (fp + tn) if fp + tn else math.nan
+    precision = tp / (tp + fp) if tp + fp else math.nan
+    return {
+        "far_pct": far * 100.0,
+        "recall_pct": recall * 100.0,
+        "precision": precision,
+        "tp": tp,
+        "fp": fp,
+        "tn": tn,
+        "fn": fn,
+        "n_pass": fp + tn,
+        "n_defect": tp + fn,
+    }
+
+
+def calibrated_far(validation_csv: Path, kpi_csv: Path) -> dict:
+    val_scores, val_is_pass = _load(validation_csv)
+    kpi_scores, kpi_is_pass = _load(kpi_csv)
+    threshold = calibrate_threshold(val_scores, val_is_pass)
+    validation = evaluate_at_threshold(val_scores, val_is_pass, threshold)
+    kpi = evaluate_at_threshold(kpi_scores, kpi_is_pass, threshold)
+    return {
+        "name": "far_pct",
+        "value": kpi["far_pct"],
+        "unit": "%",
+        "threshold": threshold,
+        "constraints": {"recall_pct": kpi["recall_pct"]},
+        "diagnostics": {
+            "protocol": "validation_threshold_applied_to_kpi",
+            "validation": validation,
+            "kpi": kpi,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("validation_csv", type=Path)
+    parser.add_argument("kpi_csv", type=Path)
+    parser.add_argument("output_json", type=Path)
+    args = parser.parse_args(argv)
+
+    result = calibrated_far(args.validation_csv, args.kpi_csv)
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(result, indent=2) + "\n")
+    print(
+        f"FAR@validation-threshold={result['value']:.4f}% "
+        f"threshold={result['threshold']:.8f} "
+        f"recall={result['constraints']['recall_pct']:.2f}%"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prepare_post_deft_data.py
+++ b/prepare_post_deft_data.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build deterministic, duplicate-free post-DEFT mixture CSVs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+FIELDS = ["input_path", "golden_path", "label", "object_name"]
+
+
+def _normalize_path(value: str) -> str:
+    normalized = value.strip().rstrip("/")
+    if normalized.startswith("kpi/images/"):
+        normalized = normalized[len("kpi/images/") :]
+    return normalized
+
+
+def _identity(row: dict[str, str]) -> tuple[str, str, str]:
+    return (
+        _normalize_path(row["input_path"]),
+        _normalize_path(row["golden_path"]),
+        row["object_name"].strip(),
+    )
+
+
+def stable_deduplicate(
+    rows: list[dict[str, str]],
+) -> tuple[list[dict[str, str]], int]:
+    seen: dict[tuple[str, str, str], str] = {}
+    unique: list[dict[str, str]] = []
+    rejected = 0
+    for row in rows:
+        identity = _identity(row)
+        label = row["label"].strip()
+        prior_label = seen.get(identity)
+        if prior_label is None:
+            seen[identity] = label
+            unique.append(row)
+        elif prior_label != label:
+            raise ValueError(
+                f"conflicting labels for {identity}: {prior_label!r} vs {label!r}"
+            )
+        else:
+            rejected += 1
+    return unique, rejected
+
+
+def _label_counts(rows: list[dict[str, str]]) -> dict[str, int]:
+    return dict(sorted(Counter(row["label"] for row in rows).items()))
+
+
+def build_mixtures(
+    source: Path,
+    output_dir: Path,
+    ratios: tuple[float, ...],
+    seed: int,
+) -> dict:
+    with source.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames != FIELDS:
+            raise ValueError(
+                f"unexpected combined-CSV schema: {reader.fieldnames}; expected {FIELDS}"
+            )
+        input_rows = list(reader)
+
+    rows, duplicate_rejected = stable_deduplicate(input_rows)
+    base = [row for row in rows if row["input_path"].startswith("kpi/images/")]
+    extra = [row for row in rows if not row["input_path"].startswith("kpi/images/")]
+    if not base or not extra:
+        raise ValueError(f"expected base and DEFT rows; got base={len(base)} extra={len(extra)}")
+
+    by_label: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for row in extra:
+        by_label[row["label"]].append(row)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "source": str(source.resolve()),
+        "seed": seed,
+        "input_rows": len(input_rows),
+        "unique_rows": len(rows),
+        "duplicate_rows_rejected": duplicate_rejected,
+        "base_rows": len(base),
+        "base_labels": _label_counts(base),
+        "unique_deft_rows": len(extra),
+        "unique_deft_labels": _label_counts(extra),
+        "mixtures": {},
+    }
+
+    for ratio in ratios:
+        if not 0 < ratio <= 1:
+            raise ValueError(f"ratio must be in (0, 1], got {ratio}")
+        selected: list[dict[str, str]] = []
+        for label, candidates in sorted(by_label.items()):
+            shuffled = list(candidates)
+            random.Random(f"{seed}:{ratio}:{label}").shuffle(shuffled)
+            selected.extend(shuffled[: math.ceil(len(shuffled) * ratio)])
+        random.Random(f"{seed}:{ratio}:merge").shuffle(selected)
+        output_rows = base + selected
+        suffix = round(ratio * 100)
+        output = output_dir / f"train_unique_mix_{suffix:03d}.csv"
+        with output.open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=FIELDS)
+            writer.writeheader()
+            writer.writerows(output_rows)
+        manifest["mixtures"][f"mix_{suffix:03d}"] = {
+            "path": str(output.resolve()),
+            "ratio": ratio,
+            "rows": len(output_rows),
+            "labels": _label_counts(output_rows),
+        }
+
+    manifest_path = output_dir / "post_deft_data_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--ratios", default="0.25,0.50,0.75,1.00")
+    parser.add_argument("--seed", type=int, default=20260814)
+    args = parser.parse_args(argv)
+    ratios = tuple(float(value) for value in args.ratios.split(","))
+    manifest = build_mixtures(args.source, args.output_dir, ratios, args.seed)
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_aoi_incumbent_promotion.py
+++ b/scripts/tests/test_aoi_incumbent_promotion.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "automl_vcn_slurm_v2.py"
+SPEC = importlib.util.spec_from_file_location("automl_vcn_slurm_v2", MODULE_PATH)
+assert SPEC and SPEC.loader
+runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runner)
+
+
+def test_regressing_challenger_rolls_back_to_incumbent():
+    incumbent = {"metric_value": 15.1, "checkpoint": "deft.pth"}
+    challenger = {"metric_value": 25.0, "checkpoint": "automl.pth"}
+
+    result = runner.select_incumbent_or_challenger(incumbent, challenger)
+
+    assert result["selected"] == "incumbent"
+    assert result["selected_artifact"]["checkpoint"] == "deft.pth"
+
+
+def test_improving_challenger_is_promoted():
+    incumbent = {"metric_value": 15.1, "checkpoint": "deft.pth"}
+    challenger = {"metric_value": 11.0, "checkpoint": "automl.pth"}
+
+    result = runner.select_incumbent_or_challenger(incumbent, challenger)
+
+    assert result["selected"] == "challenger"
+    assert result["selected_artifact"]["checkpoint"] == "automl.pth"
+
+
+def test_missing_challenger_metric_rolls_back_to_incumbent():
+    incumbent = {"metric_value": 15.1, "checkpoint": "deft.pth"}
+
+    result = runner.select_incumbent_or_challenger(
+        incumbent,
+        {"metric_value": None, "checkpoint": "automl.pth"},
+    )
+
+    assert result["selected"] == "incumbent"

--- a/scripts/tests/test_aoi_post_deft_campaign.py
+++ b/scripts/tests/test_aoi_post_deft_campaign.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "aoi_post_deft_campaign.py"
+SPEC = importlib.util.spec_from_file_location("aoi_post_deft_campaign", MODULE_PATH)
+assert SPEC and SPEC.loader
+campaign = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(campaign)
+
+
+def test_dry_run_materializes_all_guarded_branches(tmp_path):
+    result = campaign.main(
+        [
+            "--campaign-dir",
+            str(tmp_path),
+            "--mix50-csv",
+            "/remote/mix50.csv",
+            "--mix100-csv",
+            "/remote/mix100.csv",
+            "--images-dir",
+            "/remote/images",
+            "--incumbent-checkpoint",
+            "/remote/deft.pth",
+            "--incumbent-far",
+            "16.096636665087637",
+            "--dry-run",
+        ]
+    )
+
+    manifest = json.loads((tmp_path / "campaign_manifest.json").read_text())
+    tasks = {task["tag"]: task for task in manifest["tasks"]}
+
+    assert result == 0
+    assert set(tasks) == {
+        "postdeft_warm_full_mix050",
+        "postdeft_warm_head_mix050",
+        "postdeft_scratch_mix050",
+        "postdeft_scratch_mix100",
+    }
+    assert manifest["gpus_per_trial"] == 8
+    assert tasks["postdeft_warm_full_mix050"]["recommendations"] == 8
+    assert tasks["postdeft_scratch_mix050"]["recommendations"] == 16
+    assert tasks["postdeft_scratch_mix050"]["max_regression"] == 0.0
+    assert tasks["postdeft_scratch_mix100"]["initial"] == campaign.SCRATCH100_INITIAL

--- a/scripts/tests/test_deft_aoi_training_csv.py
+++ b/scripts/tests/test_deft_aoi_training_csv.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for DEFT AOI assembled-training CSV validation."""
+
+import csv
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = (
+    REPO_ROOT
+    / "skills"
+    / "applications"
+    / "tao-run-deft-aoi"
+    / "scripts"
+    / "validate_training_csv.py"
+)
+SPEC = importlib.util.spec_from_file_location("deft_aoi_validate_csv", MODULE_PATH)
+assert SPEC and SPEC.loader
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+FIELDS = ["input_path", "golden_path", "label", "object_name"]
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _stage_pair(workspace: Path, input_dir: str, golden_dir: str, obj: str) -> None:
+    for directory in (input_dir, golden_dir):
+        target = workspace / directory / f"{obj}_SolderLight.jpg"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"image")
+
+
+def test_duplicate_sample_identity_is_rejected(tmp_path):
+    _stage_pair(tmp_path, "kpi/images/sample", "kpi/images/golden", "C1@1")
+    row = {
+        "input_path": "kpi/images/sample",
+        "golden_path": "kpi/images/golden",
+        "label": "PASS",
+        "object_name": "C1@1",
+    }
+    train_csv = tmp_path / "train.csv"
+    _write_csv(train_csv, [row, dict(row)])
+
+    errors = validator.validate(train_csv, tmp_path)
+
+    assert any("duplicate sample row" in error for error in errors)
+
+
+def test_leakage_normalizes_base_and_workspace_path_coordinates(tmp_path):
+    _stage_pair(tmp_path, "kpi/images/sample", "kpi/images/golden", "C1@1")
+    train_csv = tmp_path / "train.csv"
+    validation_csv = tmp_path / "validation.csv"
+    _write_csv(
+        train_csv,
+        [{
+            "input_path": "kpi/images/sample",
+            "golden_path": "kpi/images/golden",
+            "label": "PASS",
+            "object_name": "C1@1",
+        }],
+    )
+    _write_csv(
+        validation_csv,
+        [{
+            "input_path": "sample",
+            "golden_path": "golden",
+            "label": "PASS",
+            "object_name": "C1@1",
+        }],
+    )
+
+    errors = validator.validate(train_csv, tmp_path, validation_csv)
+
+    assert any("train/val leak" in error for error in errors)

--- a/scripts/tests/test_far_eval_calibrated.py
+++ b/scripts/tests/test_far_eval_calibrated.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+import importlib.util
+import math
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "far_eval_calibrated.py"
+SPEC = importlib.util.spec_from_file_location("far_eval_calibrated", MODULE_PATH)
+assert SPEC and SPEC.loader
+metric = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(metric)
+
+
+def _write(path: Path, rows: list[tuple[str, float]]) -> None:
+    with path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["label", "siamese_score"])
+        writer.writerows(rows)
+
+
+def test_calibration_threshold_is_frozen_for_kpi(tmp_path):
+    validation = tmp_path / "validation.csv"
+    kpi = tmp_path / "kpi.csv"
+    _write(validation, [("PASS", 0.1), ("PASS", 0.6), ("missing", 0.5)])
+    _write(
+        kpi,
+        [("PASS", 0.1), ("PASS", 0.4), ("PASS", 0.55), ("missing", 0.5)],
+    )
+
+    result = metric.calibrated_far(validation, kpi)
+
+    assert result["diagnostics"]["validation"]["far_pct"] == 50.0
+    assert math.isclose(result["value"], 200.0 / 3.0)
+    assert result["constraints"]["recall_pct"] == 100.0
+    assert result["diagnostics"]["protocol"] == "validation_threshold_applied_to_kpi"

--- a/scripts/tests/test_prepare_post_deft_data.py
+++ b/scripts/tests/test_prepare_post_deft_data.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "prepare_post_deft_data.py"
+SPEC = importlib.util.spec_from_file_location("prepare_post_deft_data", MODULE_PATH)
+assert SPEC and SPEC.loader
+builder = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(builder)
+
+
+def test_build_mixtures_rejects_repeated_mined_rows(tmp_path):
+    source = tmp_path / "combined.csv"
+    rows = [
+        {
+            "input_path": "kpi/images/base",
+            "golden_path": "kpi/images/golden",
+            "label": "PASS",
+            "object_name": "C1@1",
+        },
+        {
+            "input_path": "augmentation/mining_pool/images",
+            "golden_path": "augmentation/mining_pool/images",
+            "label": "PASS",
+            "object_name": "C2@1",
+        },
+        {
+            "input_path": "augmentation/mining_pool/images/",
+            "golden_path": "augmentation/mining_pool/images/",
+            "label": "PASS",
+            "object_name": "C2@1",
+        },
+        {
+            "input_path": "results/synthetic_ng",
+            "golden_path": "results/synthetic_ok",
+            "label": "missing",
+            "object_name": "C3@1",
+        },
+    ]
+    with source.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=builder.FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    manifest = builder.build_mixtures(source, tmp_path / "out", (1.0,), 7)
+
+    assert manifest["input_rows"] == 4
+    assert manifest["unique_rows"] == 3
+    assert manifest["duplicate_rows_rejected"] == 1
+    assert manifest["mixtures"]["mix_100"]["rows"] == 3

--- a/skills/applications/tao-run-deft-aoi/references/pipeline-and-state.md
+++ b/skills/applications/tao-run-deft-aoi/references/pipeline-and-state.md
@@ -58,15 +58,23 @@ iteration executes:
      before committing so every iteration grows monotonically.
    - **`images_dir` for the iteration training spec** must be set to the workspace root (e.g. `/data/workspace/`), not the real-image directory. SDG rows already carry workspace-root-relative paths. Resolve `state.config.images_dir` relative to the workspace (`images/` for the canonical layout; `kpi/images/` only for a legacy layout), then prepend that relative prefix exactly once to every iter1 base row's relative `input_path` and `golden_path`; do not merely change the spec. For iter N>1, the previous combined CSV is already in workspace coordinates and must not be prefixed again. If validation shows base files exist only after adding the resolved image-root prefix, fix the CSV and rerun validation; never bypass the FATAL.
    - **Normalize `label` case on every source before concatenation — base_train, previous_iter_train, SDG rows, and mined rows.** Preserve `PASS` uppercase and lowercase+strip everything else; write the normalized combined CSV before running `validate_training_csv.py`. See `references/visual-changenet.md` for the dataloader rule and the failure mode if you violate it.
+   - **Stable-deduplicate before writing the combined CSV.** The logical sample
+     identity is `(input_path, golden_path, object_name)` after normalizing the
+     base `kpi/images/` prefix and trailing slashes. Preserve the earliest row,
+     reject any later row with a conflicting label, and exclude a mined or SDG
+     row that already exists in the previous combined CSV. Never express class
+     weighting by repeating CSV rows; use `fpratio_sampling` or loss weights.
+     Record the input row count, unique output row count, and rejected duplicate
+     count in provenance so every iteration demonstrates actual data novelty.
 
 6. **[INLINE] Pre-train CSV validation** — run **both** checks below; hard stop on either failure. Both must pass before launching the training container; an invalid CSV burns a full GPU run before the container surfaces the root cause.
 
-   a. **Existence check.** Run `scripts/validate_training_csv.py --csv ${RESULTS_DIR}/iter${ITER}/dataset/train_combined_iter${ITER}.csv --workspace-root <workspace> --validation-csv <workspace>/train/base/validation_set.csv --report-json ${RESULTS_DIR}/iter${ITER}/dataset/merge_validation.json`. It hard-stops if any `input_path` / `golden_path` refers to a file missing on disk or if a required column is missing.
+   a. **Existence and uniqueness check.** Run `scripts/validate_training_csv.py --csv ${RESULTS_DIR}/iter${ITER}/dataset/train_combined_iter${ITER}.csv --workspace-root <workspace> --validation-csv <workspace>/train/base/validation_set.csv --report-json ${RESULTS_DIR}/iter${ITER}/dataset/merge_validation.json`. It hard-stops if any `input_path` / `golden_path` refers to a file missing on disk, if a required column is missing, or if a normalized sample identity is duplicated or carries conflicting labels.
 
    b. **Train/validation leakage check.** `scripts/validate_training_csv.py` accepts `--validation-csv`; pass `train/base/validation_set.csv` so the diff on `(input_path, golden_path, label, object_name, boardname)` runs as part of the single validation pass. Hard stop on any validation row appearing in training. (Step 4 already runs the mid-iteration variant on `mining_filter/mining_pool.csv`; this check is the defence-in-depth backstop against leakage introduced by base-CSV reassembly.)
 
    The same successful invocation must write `dataset/merge_validation.json`
-   with `rows_checked`, `missing_file_count=0`, and
+   with `rows_checked`, `missing_file_count=0`, `duplicate_row_count=0`, and
    `train_val_leakage_overlap_count=0`; this artifact is mandatory proof of the
    merge checks, not a summary string substitute.
 

--- a/skills/applications/tao-run-deft-aoi/scripts/validate_training_csv.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/validate_training_csv.py
@@ -21,9 +21,15 @@ This script:
    case-sensitive equality against the literal string "PASS" to detect
    class 0; any deviation produces silent class-collapse failures at
    training start.
-3. Optionally diffs the training CSV against a validation CSV (when
+3. Rejects duplicate sample identities. Repeating rows to change class weight
+   is not allowed: weighting must be expressed by the sampler/loss config so
+   accumulated DEFT snapshots do not silently overweight repeatedly mined
+   samples.
+4. Optionally diffs the training CSV against a validation CSV (when
    `--validation-csv` is supplied) on `(input_path, golden_path, label,
-   object_name, boardname)` where present. Any validation row appearing
+   object_name, boardname)` where present. Paths are normalized across the
+   base-CSV and assembled-workspace coordinate systems before comparison. Any
+   validation row appearing
    in training is a hard-stop train/val leak — running this BEFORE CSV
    assembly is finalized lets the orchestrator avoid a wasted GPU run.
 
@@ -54,6 +60,11 @@ _LEAK_KEY_CANDIDATES = (
     "object_name",
     "boardname",
 )
+_IDENTITY_KEY_CANDIDATES = (
+    "input_path",
+    "golden_path",
+    "object_name",
+)
 
 
 def _resolve(p: str, workspace_root: pathlib.Path) -> pathlib.Path:
@@ -68,6 +79,79 @@ def normalize_label(label: str) -> str:
     if label == "PASS":
         return label
     return label.lower().strip()
+
+
+def _normalize_identity_path(value: str, workspace_root: pathlib.Path) -> str:
+    """Return one logical path across base and assembled CSV coordinates."""
+    raw = (value or "").strip()
+    if not raw:
+        return raw
+    path = pathlib.Path(raw)
+    if path.is_absolute():
+        try:
+            path = path.resolve().relative_to(workspace_root.resolve())
+        except ValueError:
+            path = path.resolve()
+    normalized = path.as_posix().lstrip("./").rstrip("/")
+    if normalized.startswith("kpi/images/"):
+        normalized = normalized[len("kpi/images/") :]
+    return normalized
+
+
+def _identity_key(row: dict, workspace_root: pathlib.Path) -> tuple[str, str, str]:
+    return (
+        _normalize_identity_path(row.get("input_path") or "", workspace_root),
+        _normalize_identity_path(row.get("golden_path") or "", workspace_root),
+        (row.get("object_name") or "").strip(),
+    )
+
+
+def _check_duplicates(
+    rows: list[dict],
+    columns: list[str],
+    workspace_root: pathlib.Path,
+) -> list[str]:
+    missing = [key for key in _IDENTITY_KEY_CANDIDATES if key not in columns]
+    if missing:
+        return []  # Required-column validation reports the schema error.
+
+    first_seen: dict[tuple[str, str, str], tuple[int, str]] = {}
+    duplicates: list[tuple[int, int, tuple[str, str, str]]] = []
+    conflicts: list[tuple[int, int, tuple[str, str, str], str, str]] = []
+    for index, row in enumerate(rows):
+        identity = _identity_key(row, workspace_root)
+        label = normalize_label(row.get("label") or "")
+        prior = first_seen.get(identity)
+        if prior is None:
+            first_seen[identity] = (index, label)
+            continue
+        prior_index, prior_label = prior
+        if label != prior_label:
+            conflicts.append((index, prior_index, identity, label, prior_label))
+        else:
+            duplicates.append((index, prior_index, identity))
+
+    errors: list[str] = []
+    if duplicates:
+        sample = ", ".join(
+            f"row {index} duplicates row {prior}: {identity}"
+            for index, prior, identity in duplicates[:5]
+        )
+        errors.append(
+            f"{len(duplicates)} duplicate sample row(s) on keys "
+            f"{list(_IDENTITY_KEY_CANDIDATES)}; first: {sample}"
+        )
+    if conflicts:
+        sample = ", ".join(
+            f"row {index} conflicts with row {prior}: {identity} "
+            f"labels={prior_label!r}/{label!r}"
+            for index, prior, identity, label, prior_label in conflicts[:5]
+        )
+        errors.append(
+            f"{len(conflicts)} conflicting-label sample row(s) on keys "
+            f"{list(_IDENTITY_KEY_CANDIDATES)}; first: {sample}"
+        )
+    return errors
 
 
 def _check_label_case(rows: list[dict]) -> list[str]:
@@ -99,6 +183,7 @@ def _check_leakage(
     train_rows: list[dict],
     train_cols: list[str],
     validation_csv: pathlib.Path,
+    workspace_root: pathlib.Path,
 ) -> list[str]:
     if not validation_csv.is_file():
         return [f"--validation-csv not found: {validation_csv}"]
@@ -115,7 +200,16 @@ def _check_leakage(
         ]
 
     def _key(row: dict) -> tuple:
-        return tuple((row.get(k) or "").strip() for k in join_keys)
+        values = []
+        for key in join_keys:
+            value = row.get(key) or ""
+            if key in _PATH_COLUMNS:
+                values.append(_normalize_identity_path(value, workspace_root))
+            elif key == "label":
+                values.append(normalize_label(value))
+            else:
+                values.append(value.strip())
+        return tuple(values)
 
     val_keys = {_key(r) for r in val_rows}
     leaks: list[tuple[int, tuple]] = [
@@ -234,8 +328,17 @@ def validate(
     if "label" in columns:
         errors.extend(_check_label_case(rows))
 
+    errors.extend(_check_duplicates(rows, list(columns), workspace_root))
+
     if validation_csv is not None:
-        errors.extend(_check_leakage(rows, list(columns), validation_csv))
+        errors.extend(
+            _check_leakage(
+                rows,
+                list(columns),
+                validation_csv,
+                workspace_root,
+            )
+        )
 
     return errors
 
@@ -295,7 +398,8 @@ def _build_parser() -> argparse.ArgumentParser:
         type=pathlib.Path,
         help=(
             "Write a machine-verifiable success report containing rows_checked, "
-            "missing_file_count, and train_val_leakage_overlap_count."
+            "missing_file_count, duplicate_row_count, and "
+            "train_val_leakage_overlap_count."
         ),
     )
     return parser
@@ -316,6 +420,7 @@ def _write_success_report(args: argparse.Namespace) -> None:
         ),
         "rows_checked": rows_checked,
         "missing_file_count": 0,
+        "duplicate_row_count": 0,
         "train_val_leakage_overlap_count": (
             0 if args.validation_csv is not None else None
         ),


### PR DESCRIPTION
## Summary

- add an incumbent-versus-challenger promotion gate that rolls back missing,
  non-finite, or regressing post-DEFT AutoML results
- keep AutoML selection on global validation FAR, calibrate the 100%-recall
  threshold on validation, and apply it unchanged during final KPI inference
- reject partial-rank validation FAR by requiring the global DDP provenance
  markers emitted by the Visual ChangeNet metric implementation
- build deterministic, duplicate-free DEFT mixtures and hard-stop duplicate or
  conflicting samples in the DEFT training CSV validator
- add a path-parameterized four-arm campaign launcher for warm-full,
  warm-head, scratch-mix50, and scratch-mix100 reproduction on eight-GPU SLURM
  nodes
- preserve durable resume state and normalize old/new AutoML result shapes in
  campaign summaries

## Why

Post-DEFT fine-tuning can legitimately damage a converged checkpoint when a
from-scratch learning-rate regime is reused. Earlier AOI runs were also exposed
to misleading partial-rank validation FAR and accidental deployment of a worse
Phase-3 result. The guarded path allows bad challengers to finish for diagnosis
without replacing the incumbent, while also making scratch training on the
DEFT-curated mixture a reproducible alternative.

## Reproduction

`README_AOI_AUTOML.md` documents mixture generation and a `--dry-run` campaign
command. The dry run writes the complete resolved manifest without launching;
removing `--dry-run` after the normal TAO preflight launches the four branches.
All site paths, credentials, and checkpoints remain external inputs.

## Validation

- `python -m pytest -q scripts/tests/test_aoi_incumbent_promotion.py scripts/tests/test_aoi_post_deft_campaign.py scripts/tests/test_deft_aoi_training_csv.py scripts/tests/test_far_eval_calibrated.py scripts/tests/test_prepare_post_deft_data.py` — 8 passed
- `VALIDATE_BASE_REF=github/main ./scripts/validate-skills.sh --quick` — passed
- `python -m py_compile` on the changed Python entrypoints — passed
