### PR TITLE
[TAO-000][Docs] Point install instructions at the latest release build  (7.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NVIDIA [TAO Skill Bank](https://github.com/NVIDIA-TAO/tao-skills-bank)
+# NVIDIA [TAO Skill Bank](https://github.com/NVIDIA-TAO/tao-skill-bank)
 
 Portable agent skills for training, evaluating, and running inference on NVIDIA TAO models. Works with Claude Code, Codex, Gemini CLI, or any coding agent that speaks the [Agent Skills open standard](https://agentskills.io). Most local Docker model/data actions need only Docker plus NVIDIA Container Toolkit; application workflows may declare small host-Python requirements for deterministic state and analysis adapters. Advanced features—job tracking, multi-node, S3 I/O—are built in, not bolted on: platform skills implement a four-verb execution contract over their native CLI with no `nvidia-tao-sdk`. See [Execution: no SDK required](#execution-no-sdk-required).
 
@@ -6,12 +6,19 @@ Portable agent skills for training, evaluating, and running inference on NVIDIA 
 
 The skill bank works with both Claude Code and Codex. Pick the runtime you use.
 
+**The commands below install the latest release build, `7.1.0`.** Every install
+path pins the marketplace to that tag, so a fresh install gets the same
+validated build every time instead of whatever `main` happens to hold. Newer
+tags appear on the [Releases page](https://github.com/NVIDIA-TAO/tao-skill-bank/releases);
+substitute the tag you want, or use `@main` if you specifically need unreleased
+work.
+
 ### Claude Code
 
-In a Claude Code session, add the marketplace and install the plugin:
+In a Claude Code session, add the marketplace at the release tag and install the plugin:
 
 ```
-/plugin marketplace add git@github.com:NVIDIA-TAO/tao-skills-bank.git
+/plugin marketplace add NVIDIA-TAO/tao-skill-bank@7.1.0
 /plugin install tao-skills@tao-skill-bank
 ```
 
@@ -24,16 +31,23 @@ Codex setup has **two independent pieces** — the plugin (which surfaces the sk
 #### One command (recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NVIDIA-TAO/tao-skills-bank/main/scripts/install-codex-agents.sh | bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA-TAO/tao-skill-bank/main/scripts/install-codex-agents.sh | bash
 ```
+
+The installer is fetched from `main` on purpose — it is the copy that knows
+which tag is current, and it registers the marketplace at that release tag. A
+copy fetched from a release tag only knows about refs that existed when the tag
+was cut.
 
 …or, if you've already cloned or extracted the repo from a zip, run
 `scripts/install-codex-agents.sh` from that directory. The script registers the
-marketplace, installs the TAO Skill Bank plugin, and copies `AGENTS.md` to
-`~/.codex/AGENTS.md` so the TAO identity loads in every Codex session. It's
-idempotent and backs up any existing `~/.codex/AGENTS.md` before overwriting.
-Override the source with `TAO_SKILL_BANK_MARKETPLACE=…` and
-`TAO_SKILL_BANK_REF=…` to use a fork, pinned ref, or local absolute path:
+marketplace **at the latest release tag** (`7.1.0`), installs the TAO Skill Bank
+plugin, and copies `AGENTS.md` to `~/.codex/AGENTS.md` so the TAO identity loads
+in every Codex session. It's idempotent and backs up any existing
+`~/.codex/AGENTS.md` before overwriting. Override the source with
+`TAO_SKILL_BANK_MARKETPLACE=…` and `TAO_SKILL_BANK_REF=…` to use a fork, a
+different tag or branch (`TAO_SKILL_BANK_REF=main` for unreleased work), or a
+local absolute path:
 
 ```bash
 cd /absolute/path/to/tao-skills-external
@@ -48,7 +62,7 @@ If you'd rather drive each step yourself:
 **1. Install the plugin.** Either use the VS Code Codex extension's plugin UI (select **TAO Skill Bank**), or from the CLI:
 
 ```bash
-codex plugin marketplace add git@github.com:NVIDIA-TAO/tao-skills-bank.git
+codex plugin marketplace add NVIDIA-TAO/tao-skill-bank@7.1.0
 codex plugin add tao-skill-bank@tao-local-plugins
 ```
 
@@ -110,7 +124,28 @@ special SDK exception: its Preflight lazily installs the
 
 ### Updating
 
-**Claude Code:**
+Because the install pins a release tag, `update` / `upgrade` re-fetch **that same
+tag** — they do not move you to a newer release. To move to a new release, check
+the [Releases page](https://github.com/NVIDIA-TAO/tao-skill-bank/releases) and
+re-add the marketplace at the new tag; the existing entry is replaced in place.
+
+**Claude Code:** re-point the marketplace, then update the plugin — `/plugin
+install` is a no-op on an already-installed plugin, so it will leave you on the
+old build even after the marketplace moves.
+
+```
+/plugin marketplace add NVIDIA-TAO/tao-skill-bank@<new-tag>
+```
+
+Then update the installed plugin, either from `/plugin manage` in-session or
+from a shell:
+
+```bash
+claude plugin update tao-skills@tao-skill-bank
+```
+
+Restart, or run `/reload-plugins`, to apply. To re-fetch the currently pinned
+tag (e.g. after a cache wipe):
 
 ```
 /plugin marketplace update tao-skill-bank
@@ -128,8 +163,19 @@ then re-run `/plugin install`.
 **Codex:**
 
 ```bash
-codex plugin marketplace upgrade tao-skill-bank
+# Move to a new release. Codex refuses to re-add a marketplace that is already
+# registered at a different ref, so drop the old registration first.
+codex plugin marketplace remove tao-local-plugins
+codex plugin marketplace add NVIDIA-TAO/tao-skill-bank@<new-tag>
+codex plugin add tao-skill-bank@tao-local-plugins
+
+# Or, to re-fetch the tag you are already pinned to:
+codex plugin marketplace upgrade tao-local-plugins
 ```
+
+Note the marketplace is named `tao-local-plugins` (the `name` field in
+`.agents/plugins/marketplace.json`); `tao-skill-bank` is the plugin name.
+Re-running `scripts/install-codex-agents.sh` does all three steps for you.
 
 If you copied `AGENTS.md` to `~/.codex/AGENTS.md`, re-copy from the upgraded plugin cache to pick up identity changes.
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -8,6 +8,7 @@
 - Bumping the AutoML wheel
 - Adding a new image
 - When to use absolute paths instead of keys
+- Bumping the documented release pin
 - Related: Python wheel install matrix
 
 
@@ -110,6 +111,33 @@ Promote to a key (`versions.yaml` entry) when:
 - The image is shared by **two or more skills**.
 - The image will be **bumped on a release cadence**.
 - You want to track it in changelogs / RC notes.
+
+## Bumping the documented release pin
+
+The install instructions point users at the **latest release build**, not at
+`main`, so every install path carries a release tag that has to be bumped when a
+new release is published. After tagging release `X.Y.Z` on GitHub, update:
+
+| File | What to change |
+|---|---|
+| [`README.md`](../README.md) | the tag in the Install section prose, the Claude Code `/plugin marketplace add NVIDIA-TAO/tao-skill-bank@X.Y.Z` block, and the manual `codex plugin marketplace add` block |
+| [`scripts/install-codex-agents.sh`](../scripts/install-codex-agents.sh) | `DEFAULT_MARKETPLACE_REF="X.Y.Z"` |
+
+Leave the curl one-liner pointing at `main`. It fetches the installer, and only
+the copy on `main` knows the current release tag — a copy served from tag
+`X.Y.Z` pins whatever was current when that tag was cut (or nothing at all, for
+tags cut before this pin existed).
+
+```bash
+grep -rn "7\.1\.0" README.md scripts/install-codex-agents.sh   # find every pin to bump
+```
+
+Verify against the published tag before merging — a pin to a tag that does not
+exist yet fails at `marketplace add` time, not in CI:
+
+```bash
+git ls-remote --tags https://github.com/NVIDIA-TAO/tao-skill-bank.git "refs/tags/X.Y.Z"
+```
 
 ## Related: the AutoML wheel
 

--- a/scripts/install-codex-agents.sh
+++ b/scripts/install-codex-agents.sh
@@ -13,17 +13,28 @@
 #      plugin-bundled SessionStart hooks do not yet install identity globally;
 #      see https://github.com/openai/codex/issues/16430.)
 #
-# Override the source via env var if you need a fork or a pinned ref:
+# By default it installs the latest release build (DEFAULT_MARKETPLACE_REF
+# below) rather than whatever `main` holds. Override the source or the ref via
+# env var if you need a fork, a different release, or unreleased work:
 #   TAO_SKILL_BANK_MARKETPLACE=ssh://git@host/path/repo.git \
-#   TAO_SKILL_BANK_REF=release/7.0.0 \
+#   TAO_SKILL_BANK_REF=main \
 #       scripts/install-codex-agents.sh
+# `TAO_SKILL_BANK_REF=` (empty) uses the source's default branch.
 
 set -euo pipefail
 
+# Latest release tag — keep in sync with the pins in README.md on every release.
+DEFAULT_MARKETPLACE_REF="7.1.0"
+
 MARKETPLACE_SOURCE="${TAO_SKILL_BANK_MARKETPLACE:-https://github.com/NVIDIA-TAO/tao-skill-bank.git}"
-MARKETPLACE_REF="${TAO_SKILL_BANK_REF:-}"
+MARKETPLACE_REF="${TAO_SKILL_BANK_REF-$DEFAULT_MARKETPLACE_REF}"
 MARKETPLACE_NAME="tao-local-plugins"   # `name` in .agents/plugins/marketplace.json
 PLUGIN_NAME="tao-skill-bank"
+
+# A local path marketplace (clone or unzipped release) has no ref to check out.
+if [[ -d "$MARKETPLACE_SOURCE" ]]; then
+  MARKETPLACE_REF=""
+fi
 
 log() { printf '[install-codex-agents] %s\n' "$*"; }
 die() { printf '[install-codex-agents] ERROR: %s\n' "$*" >&2; exit 1; }
@@ -33,36 +44,47 @@ command -v codex >/dev/null 2>&1 \
   || die "'codex' CLI not found. Install it first: https://developers.openai.com/codex"
 
 # 1. Marketplace
+# `codex plugin marketplace add` refuses to overwrite a registration that points
+# at a different source or ref, and `upgrade` only re-fetches the ref already
+# recorded — so an existing registration is dropped and re-added. That is what
+# moves a previously unpinned (or older-release) install onto this ref.
 if codex plugin marketplace list 2>/dev/null | grep -qw "$MARKETPLACE_NAME"; then
-  log "Marketplace '$MARKETPLACE_NAME' already registered — refreshing."
-  codex plugin marketplace upgrade "$MARKETPLACE_NAME"
+  log "Marketplace '$MARKETPLACE_NAME' already registered — re-pointing it."
+  codex plugin marketplace remove "$MARKETPLACE_NAME"
+fi
+
+log "Adding marketplace from ${MARKETPLACE_SOURCE}${MARKETPLACE_REF:+ (ref: ${MARKETPLACE_REF})}"
+if [[ -n "$MARKETPLACE_REF" ]]; then
+  codex plugin marketplace add "$MARKETPLACE_SOURCE" --ref "$MARKETPLACE_REF"
 else
-  log "Adding marketplace from $MARKETPLACE_SOURCE"
-  if [[ -n "$MARKETPLACE_REF" ]]; then
-    codex plugin marketplace add "$MARKETPLACE_SOURCE" --ref "$MARKETPLACE_REF"
-  else
-    codex plugin marketplace add "$MARKETPLACE_SOURCE"
-  fi
+  codex plugin marketplace add "$MARKETPLACE_SOURCE"
 fi
 
 # 2. Plugin
-if codex plugin list 2>/dev/null | grep -qw "$PLUGIN_NAME"; then
-  log "Plugin '$PLUGIN_NAME' already installed."
-else
-  log "Installing plugin ${PLUGIN_NAME}@${MARKETPLACE_NAME}"
-  codex plugin add "${PLUGIN_NAME}@${MARKETPLACE_NAME}"
-fi
+# `codex plugin add` is idempotent and re-resolves the version from the
+# marketplace snapshot, so it is run unconditionally — an already-installed
+# plugin from an older ref is replaced by the one this ref ships.
+log "Installing plugin ${PLUGIN_NAME}@${MARKETPLACE_NAME}"
+codex plugin add "${PLUGIN_NAME}@${MARKETPLACE_NAME}"
 
 # 3. Global AGENTS.md identity
-# Prefer the freshly-installed plugin cache so the identity matches the
-# installed plugin version. Fall back to the repo root when running from a
-# clone before the plugin cache exists.
+# Prefer the marketplace snapshot: it is checked out at exactly the ref that was
+# just installed, so the identity matches the release the plugin came from. The
+# plugin cache keeps every version ever installed, so picking its highest
+# version number would hand back a newer identity than a pinned older release
+# ships. Fall back to the cache, then to the repo root when running from a clone.
+CODEX_ROOT="${CODEX_HOME:-${HOME}/.codex}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_AGENTS="${SCRIPT_DIR}/../AGENTS.md"
-CACHE_ROOT="${HOME}/.codex/plugins/cache/${MARKETPLACE_NAME}/${PLUGIN_NAME}"
+CACHE_ROOT="${CODEX_ROOT}/plugins/cache/${MARKETPLACE_NAME}/${PLUGIN_NAME}"
 
 SRC_AGENTS=""
-if [[ -d "$CACHE_ROOT" ]]; then
+MARKETPLACE_ROOT="$(codex plugin marketplace list 2>/dev/null \
+  | awk -v name="$MARKETPLACE_NAME" '$1 == name { print $2; exit }')"
+if [[ -n "$MARKETPLACE_ROOT" && -f "${MARKETPLACE_ROOT}/AGENTS.md" ]]; then
+  SRC_AGENTS="${MARKETPLACE_ROOT}/AGENTS.md"
+fi
+if [[ -z "$SRC_AGENTS" && -d "$CACHE_ROOT" ]]; then
   LATEST_VERSION="$(ls -1 "$CACHE_ROOT" 2>/dev/null | sort -V | tail -n1 || true)"
   if [[ -n "$LATEST_VERSION" && -f "${CACHE_ROOT}/${LATEST_VERSION}/AGENTS.md" ]]; then
     SRC_AGENTS="${CACHE_ROOT}/${LATEST_VERSION}/AGENTS.md"
@@ -77,8 +99,8 @@ if [[ -z "$SRC_AGENTS" ]]; then
   exit 0
 fi
 
-DEST_AGENTS="${HOME}/.codex/AGENTS.md"
-mkdir -p "${HOME}/.codex"
+DEST_AGENTS="${CODEX_ROOT}/AGENTS.md"
+mkdir -p "$CODEX_ROOT"
 if [[ -f "$DEST_AGENTS" ]] && ! cmp -s "$SRC_AGENTS" "$DEST_AGENTS"; then
   BACKUP="${DEST_AGENTS}.bak.$(date +%Y%m%d%H%M%S)"
   log "Backing up existing $DEST_AGENTS -> $BACKUP"

--- a/scripts/install-codex-agents.sh
+++ b/scripts/install-codex-agents.sh
@@ -80,7 +80,7 @@ CACHE_ROOT="${CODEX_ROOT}/plugins/cache/${MARKETPLACE_NAME}/${PLUGIN_NAME}"
 
 SRC_AGENTS=""
 MARKETPLACE_ROOT="$(codex plugin marketplace list 2>/dev/null \
-  | awk -v name="$MARKETPLACE_NAME" '$1 == name { print $2; exit }')"
+  | awk -v name="$MARKETPLACE_NAME" '$1 == name { print $2; exit }' || true)"
 if [[ -n "$MARKETPLACE_ROOT" && -f "${MARKETPLACE_ROOT}/AGENTS.md" ]]; then
   SRC_AGENTS="${MARKETPLACE_ROOT}/AGENTS.md"
 fi

--- a/scripts/tests/test_install_codex_agents.py
+++ b/scripts/tests/test_install_codex_agents.py
@@ -4,6 +4,7 @@
 """Regression tests for the one-shot Codex installer."""
 
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
@@ -14,7 +15,17 @@ INSTALLER = REPO_ROOT / "scripts" / "install-codex-agents.sh"
 SKILL_INSTALLER = (
     REPO_ROOT / "skills" / "core" / "tao-setup" / "scripts" / "install-codex-agents.sh"
 )
+README = REPO_ROOT / "README.md"
 PUBLIC_MARKETPLACE = "https://github.com/NVIDIA-TAO/tao-skill-bank.git"
+
+
+def _pinned_ref() -> str:
+    """The release tag the installer registers the marketplace at by default."""
+    match = re.search(
+        r'^DEFAULT_MARKETPLACE_REF="([^"]+)"', INSTALLER.read_text(), re.MULTILINE
+    )
+    assert match, "the installer must pin a default marketplace ref"
+    return match.group(1)
 
 
 def _write_fake_codex(path: Path) -> None:
@@ -52,9 +63,41 @@ def test_installer_defaults_to_public_https_without_github_credentials(tmp_path)
     )
 
     calls = call_log.read_text().splitlines()
-    assert f"plugin marketplace add {PUBLIC_MARKETPLACE}" in calls
+    assert (
+        f"plugin marketplace add {PUBLIC_MARKETPLACE} --ref {_pinned_ref()}" in calls
+    )
     assert all("git@github.com" not in call for call in calls)
     assert PUBLIC_MARKETPLACE in result.stdout
+
+
+def test_installer_ref_can_be_cleared_to_track_the_default_branch(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_codex(fake_bin / "codex")
+    call_log = tmp_path / "codex-calls.log"
+
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CODEX_CALL_LOG": str(call_log),
+        "TAO_SKILL_BANK_REF": "",
+    }
+    subprocess.run(
+        ["bash", str(INSTALLER)],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    calls = call_log.read_text().splitlines()
+    assert f"plugin marketplace add {PUBLIC_MARKETPLACE}" in calls
+    assert all("--ref" not in call for call in calls)
+
+
+def test_installer_pin_matches_the_readme_install_instructions():
+    """The install docs and the installer must name the same release tag."""
+    assert f"NVIDIA-TAO/tao-skill-bank@{_pinned_ref()}" in README.read_text()
 
 
 def test_packaged_installer_matches_top_level_installer():

--- a/skills/core/tao-setup/scripts/install-codex-agents.sh
+++ b/skills/core/tao-setup/scripts/install-codex-agents.sh
@@ -13,17 +13,28 @@
 #      plugin-bundled SessionStart hooks do not yet install identity globally;
 #      see https://github.com/openai/codex/issues/16430.)
 #
-# Override the source via env var if you need a fork or a pinned ref:
+# By default it installs the latest release build (DEFAULT_MARKETPLACE_REF
+# below) rather than whatever `main` holds. Override the source or the ref via
+# env var if you need a fork, a different release, or unreleased work:
 #   TAO_SKILL_BANK_MARKETPLACE=ssh://git@host/path/repo.git \
-#   TAO_SKILL_BANK_REF=release/7.0.0 \
+#   TAO_SKILL_BANK_REF=main \
 #       scripts/install-codex-agents.sh
+# `TAO_SKILL_BANK_REF=` (empty) uses the source's default branch.
 
 set -euo pipefail
 
+# Latest release tag — keep in sync with the pins in README.md on every release.
+DEFAULT_MARKETPLACE_REF="7.1.0"
+
 MARKETPLACE_SOURCE="${TAO_SKILL_BANK_MARKETPLACE:-https://github.com/NVIDIA-TAO/tao-skill-bank.git}"
-MARKETPLACE_REF="${TAO_SKILL_BANK_REF:-}"
+MARKETPLACE_REF="${TAO_SKILL_BANK_REF-$DEFAULT_MARKETPLACE_REF}"
 MARKETPLACE_NAME="tao-local-plugins"   # `name` in .agents/plugins/marketplace.json
 PLUGIN_NAME="tao-skill-bank"
+
+# A local path marketplace (clone or unzipped release) has no ref to check out.
+if [[ -d "$MARKETPLACE_SOURCE" ]]; then
+  MARKETPLACE_REF=""
+fi
 
 log() { printf '[install-codex-agents] %s\n' "$*"; }
 die() { printf '[install-codex-agents] ERROR: %s\n' "$*" >&2; exit 1; }
@@ -33,36 +44,47 @@ command -v codex >/dev/null 2>&1 \
   || die "'codex' CLI not found. Install it first: https://developers.openai.com/codex"
 
 # 1. Marketplace
+# `codex plugin marketplace add` refuses to overwrite a registration that points
+# at a different source or ref, and `upgrade` only re-fetches the ref already
+# recorded — so an existing registration is dropped and re-added. That is what
+# moves a previously unpinned (or older-release) install onto this ref.
 if codex plugin marketplace list 2>/dev/null | grep -qw "$MARKETPLACE_NAME"; then
-  log "Marketplace '$MARKETPLACE_NAME' already registered — refreshing."
-  codex plugin marketplace upgrade "$MARKETPLACE_NAME"
+  log "Marketplace '$MARKETPLACE_NAME' already registered — re-pointing it."
+  codex plugin marketplace remove "$MARKETPLACE_NAME"
+fi
+
+log "Adding marketplace from ${MARKETPLACE_SOURCE}${MARKETPLACE_REF:+ (ref: ${MARKETPLACE_REF})}"
+if [[ -n "$MARKETPLACE_REF" ]]; then
+  codex plugin marketplace add "$MARKETPLACE_SOURCE" --ref "$MARKETPLACE_REF"
 else
-  log "Adding marketplace from $MARKETPLACE_SOURCE"
-  if [[ -n "$MARKETPLACE_REF" ]]; then
-    codex plugin marketplace add "$MARKETPLACE_SOURCE" --ref "$MARKETPLACE_REF"
-  else
-    codex plugin marketplace add "$MARKETPLACE_SOURCE"
-  fi
+  codex plugin marketplace add "$MARKETPLACE_SOURCE"
 fi
 
 # 2. Plugin
-if codex plugin list 2>/dev/null | grep -qw "$PLUGIN_NAME"; then
-  log "Plugin '$PLUGIN_NAME' already installed."
-else
-  log "Installing plugin ${PLUGIN_NAME}@${MARKETPLACE_NAME}"
-  codex plugin add "${PLUGIN_NAME}@${MARKETPLACE_NAME}"
-fi
+# `codex plugin add` is idempotent and re-resolves the version from the
+# marketplace snapshot, so it is run unconditionally — an already-installed
+# plugin from an older ref is replaced by the one this ref ships.
+log "Installing plugin ${PLUGIN_NAME}@${MARKETPLACE_NAME}"
+codex plugin add "${PLUGIN_NAME}@${MARKETPLACE_NAME}"
 
 # 3. Global AGENTS.md identity
-# Prefer the freshly-installed plugin cache so the identity matches the
-# installed plugin version. Fall back to the repo root when running from a
-# clone before the plugin cache exists.
+# Prefer the marketplace snapshot: it is checked out at exactly the ref that was
+# just installed, so the identity matches the release the plugin came from. The
+# plugin cache keeps every version ever installed, so picking its highest
+# version number would hand back a newer identity than a pinned older release
+# ships. Fall back to the cache, then to the repo root when running from a clone.
+CODEX_ROOT="${CODEX_HOME:-${HOME}/.codex}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_AGENTS="${SCRIPT_DIR}/../AGENTS.md"
-CACHE_ROOT="${HOME}/.codex/plugins/cache/${MARKETPLACE_NAME}/${PLUGIN_NAME}"
+CACHE_ROOT="${CODEX_ROOT}/plugins/cache/${MARKETPLACE_NAME}/${PLUGIN_NAME}"
 
 SRC_AGENTS=""
-if [[ -d "$CACHE_ROOT" ]]; then
+MARKETPLACE_ROOT="$(codex plugin marketplace list 2>/dev/null \
+  | awk -v name="$MARKETPLACE_NAME" '$1 == name { print $2; exit }' || true)"
+if [[ -n "$MARKETPLACE_ROOT" && -f "${MARKETPLACE_ROOT}/AGENTS.md" ]]; then
+  SRC_AGENTS="${MARKETPLACE_ROOT}/AGENTS.md"
+fi
+if [[ -z "$SRC_AGENTS" && -d "$CACHE_ROOT" ]]; then
   LATEST_VERSION="$(ls -1 "$CACHE_ROOT" 2>/dev/null | sort -V | tail -n1 || true)"
   if [[ -n "$LATEST_VERSION" && -f "${CACHE_ROOT}/${LATEST_VERSION}/AGENTS.md" ]]; then
     SRC_AGENTS="${CACHE_ROOT}/${LATEST_VERSION}/AGENTS.md"
@@ -77,8 +99,8 @@ if [[ -z "$SRC_AGENTS" ]]; then
   exit 0
 fi
 
-DEST_AGENTS="${HOME}/.codex/AGENTS.md"
-mkdir -p "${HOME}/.codex"
+DEST_AGENTS="${CODEX_ROOT}/AGENTS.md"
+mkdir -p "$CODEX_ROOT"
 if [[ -f "$DEST_AGENTS" ]] && ! cmp -s "$SRC_AGENTS" "$DEST_AGENTS"; then
   BACKUP="${DEST_AGENTS}.bak.$(date +%Y%m%d%H%M%S)"
   log "Backing up existing $DEST_AGENTS -> $BACKUP"


### PR DESCRIPTION
The Claude Code and Codex install commands pulled the marketplace from the default branch, so a fresh install picked up whatever `main` held at that moment rather than the published release build. Pin every install path to the latest release tag (7.1.0)