### PR TITLE
[TAO-2230][Bugfix] deft-od: mount the detection files, and admit arbitrary paths

### DIFF
--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -234,6 +234,12 @@ Echo it and read the result. A command substitution that fails leaves `EXTRA_MOU
 empty and every later launch still runs, mounting nothing extra — the same silent
 failure this block exists to prevent.
 
+`init_deft_state.py` derives this list from the run's own inputs — the checkpoints, the
+KPI images and labels, the class mapping, the encoder repo, the pool, and both COCO
+detection files. A path that none of those name is invisible to it: pass
+`--extra-mount PATH` (repeatable) at init and it joins the list. Files are mounted by
+their parent directory.
+
 Every `docker run` in this skill is written as
 `-v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE"`. With inputs inside the
 workspace it expands to nothing and the command is unchanged; with KPI data or

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -321,6 +321,40 @@ produces them. Supplying neither the artifacts nor prep's inputs is still an err
 nothing would create them.
 
 
+Three groups of flags apply only to some runs. Build them first so the command below
+stays one shape:
+
+```bash
+# class_stratified only. Both are mandatory under that policy — init refuses without
+# them, so a run that omits them here fails at `mine`, several stages later.
+STRATIFIED_FLAGS=""
+if [ "$ALLOCATION_POLICY" = class_stratified ]; then
+  STRATIFIED_FLAGS="--source-detection-file $SOURCE_DETECTION_FILE"
+  STRATIFIED_FLAGS="$STRATIFIED_FLAGS --target-detection-file $TARGET_DETECTION_FILE"
+fi
+
+# Prep runs only: the pool does not exist yet and these are what builds it.
+PREP_FLAGS=""
+if [ -n "${POOL_IMAGES:-}" ]; then
+  PREP_FLAGS="--pool-images $POOL_IMAGES --codetr-checkpoint $CODETR_CHECKPOINT"
+  PREP_FLAGS="$PREP_FLAGS --codetr-classmap $CODETR_CLASSMAP"
+fi
+
+# A pool that already exists must declare what it holds. Under class_stratified both
+# of these are then mandatory: prep is what would otherwise produce the report and
+# derive the rare classes from it, and a prep that is not going to run cannot.
+EXISTING_POOL_FLAGS=""
+if [ -z "${POOL_IMAGES:-}" ] && [ "$ALLOCATION_POLICY" = class_stratified ]; then
+  EXISTING_POOL_FLAGS="--pool-report $POOL_REPORT --rare-class-list $RARE_CLASS_LIST"
+fi
+
+# Any path the run's own inputs do not name. Repeatable; omit when there are none.
+EXTRA_MOUNT_FLAGS=""
+for path in ${EXTRA_MOUNTS_IN:-}; do
+  EXTRA_MOUNT_FLAGS="$EXTRA_MOUNT_FLAGS --extra-mount $path"
+done
+```
+
 ```bash
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/init_deft_state.py \
   --workspace "$WORKSPACE" \
@@ -340,7 +374,10 @@ nothing would create them.
   --class-mapping "$CLASS_MAPPING" \
   --ap50-thresholds-json "$AP50_THRESHOLDS_JSON" \
   --multiplier "$MULTIPLIER" \
-  --allocation-policy "$ALLOCATION_POLICY"
+  --allocation-policy "$ALLOCATION_POLICY" \
+  --target-classes "$TARGET_CLASSES" \
+  --kpi-conf-threshold "$KPI_CONF_THRESHOLD" \
+  $STRATIFIED_FLAGS $PREP_FLAGS $EXISTING_POOL_FLAGS $EXTRA_MOUNT_FLAGS
 
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/audit_deft_run.py \
   --results-dir "$RESULTS_DIR"

--- a/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/init_deft_state.py
@@ -188,6 +188,13 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--iou-threshold", type=float, default=0.5)
     parser.add_argument("--kpi-conf-threshold", type=float, default=0.3)
 
+    parser.add_argument("--extra-mount", action="append", default=None, metavar="PATH",
+                        help="Extra host path a container must read, repeatable. The mount "
+                             "list is otherwise derived from the run's own inputs, so this is "
+                             "the way to admit anything they do not name -- a spec, an "
+                             "auxiliary dataset, a checkpoint a template points at. Files are "
+                             "mounted by their parent directory.")
+
     parser.add_argument("--force", action="store_true",
                         help="Reinitialize over an existing run. The current state and a non-empty "
                              "log are archived as *.bak.<UTC stamp> first.")
@@ -494,6 +501,12 @@ def main() -> int:
             warnings.append(
                 "--rare-class-list is set but --allocation-policy is global; rare classes are ignored")
 
+        # A mount may be either a file or a directory, so this is existence only --
+        # check_artifact would reject a directory as "not a file".
+        for extra in (args.extra_mount or []):
+            if not _abs(extra).exists():
+                errors.append(f"--extra-mount: does not exist: {_abs(extra)}")
+
         resolved_detection: dict[str, str | None] = {}
         for flag, raw in detection_files.items():
             if not raw:
@@ -558,6 +571,18 @@ def main() -> int:
         for extra in (args.pool_images, args.codetr_checkpoint, args.codetr_classmap):
             if extra:
                 mounted.append(_abs(extra))
+        # `tmm unique_neighbor_matching` opens both COCO detection files from inside the
+        # container under class_stratified allocation. The target file is the KPI
+        # detections, which live with the read-only dataset rather than in the per-run
+        # workspace, so without this the stage fails on a path the spec itself named.
+        for detection in resolved_detection.values():
+            if detection:
+                mounted.append(Path(detection))
+        # Whatever the derivation cannot know about. A run may legitimately reference a
+        # path none of its own config keys name, and without this the only remedy is
+        # editing the skill.
+        for extra in (args.extra_mount or []):
+            mounted.append(_abs(extra))
         # Anything outside the workspace needs its own -v or the container cannot read
         # it. Deriving the mounts here means the stages get a list to use rather than a
         # warning to act on, which is what left earlier runs to work it out mid-flight.

--- a/skills/applications/tao-run-deft-object-detection/scripts/tests/test_state_machine.sh
+++ b/skills/applications/tao-run-deft-object-detection/scripts/tests/test_state_machine.sh
@@ -2405,6 +2405,79 @@ case "$RUN_OUT" in
 esac
 
 # ═══════════════════════════════════════════════════════════════════════════
+# G26 — every path a container opens is mounted, including the ones it is handed
+#
+# The detection files are read by `tmm unique_neighbor_matching` from inside the
+# container. The target file is the KPI detections, which live with the read-only
+# dataset rather than in the per-run workspace. --extra-mount covers whatever the
+# derivation cannot know about.
+# ═══════════════════════════════════════════════════════════════════════════
+CURRENT_SECTION="G26 detection files and arbitrary mounts"
+
+G26_WS=$(new_workspace g26); make_pool "$G26_WS"
+G26_OUT="$WORK/g26_dataset"
+make_file "$G26_OUT/kpi/images/000001.png" "png"
+make_file "$G26_OUT/kpi/labels/000001.txt" "car 0.0 0 0.0 10 10 100 100 0 0 0 0 0 0 0"
+make_file "$G26_OUT/hl_coco_its_kpi.json" '{"images": [], "annotations": []}'
+make_file "$G26_WS/source_pool/coco.json" '{"images": [], "annotations": []}'
+make_file "$G26_WS/source_pool/pool_report.json" '{"annotations_by_class": {"car": 10}}'
+make_file "$WORK/g26_aux/notes.txt" "an input no config key names"
+G26_RUN="$G26_WS/results/run_g26"
+
+mounts_contain() {  # mounts_contain RESULTS_DIR NEEDLE
+  "$PY" -c 'import json,sys
+mounts = json.load(open(sys.argv[1]))["config"]["extra_container_mounts"]
+print(1 if any(sys.argv[2] in m for m in mounts) else 0)' "$1" "$2"
+}
+
+run "$PY" "$INIT" \
+  --results-dir "$G26_RUN" --workspace "$G26_WS" --max-iterations 1 \
+  --num-epochs 1 --learning-rate 0.0001 \
+  --zero-shot-checkpoint "$G26_WS/ckpt/gdino_zero_shot.pth" \
+  --train-spec-template "$G26_WS/specs/train_grounding_dino.yaml" \
+  --source-pool-embeddings "$G26_WS/source_pool/source_embeddings.parquet" \
+  --source-pool-annotations "$G26_WS/source_pool/odvg" \
+  --embedding-model-path "$G26_WS/encoder/siglip" \
+  --kpi-images-dir "$G26_OUT/kpi/images" \
+  --ground-truth-labels-dir "$G26_OUT/kpi/labels" \
+  --class-mapping "$G26_WS/classes/classes_its.yaml" \
+  --ap50-thresholds-json '{"car": 0.9}' \
+  --allocation-policy class_stratified --rare-class-list car \
+  --pool-report "$G26_WS/source_pool/pool_report.json" \
+  --source-detection-file "$G26_WS/source_pool/coco.json" \
+  --target-detection-file "$G26_OUT/hl_coco_its_kpi.json" \
+  --extra-mount "$WORK/g26_aux"
+assert_rc 0 "[G26] class_stratified init succeeds with detection files outside the workspace"
+assert_eq 1 "$(mounts_contain "$G26_RUN/deft_state.json" "$G26_OUT")" \
+  "[G26] the target detection file's directory is mounted"
+assert_eq 1 "$(mounts_contain "$G26_RUN/deft_state.json" "$WORK/g26_aux")" \
+  "[G26] --extra-mount admits a path no config key names"
+
+# A source detection file inside the workspace needs no mount of its own.
+assert_eq 0 "$(mounts_contain "$G26_RUN/deft_state.json" "$G26_WS/source_pool")" \
+  "[G26] a detection file inside the workspace adds no mount"
+
+# An --extra-mount that is not on disk is a configuration error, not a silent skip.
+run "$PY" "$INIT" \
+  --results-dir "$G26_RUN" --workspace "$G26_WS" --max-iterations 1 --force \
+  --num-epochs 1 --learning-rate 0.0001 \
+  --zero-shot-checkpoint "$G26_WS/ckpt/gdino_zero_shot.pth" \
+  --train-spec-template "$G26_WS/specs/train_grounding_dino.yaml" \
+  --source-pool-embeddings "$G26_WS/source_pool/source_embeddings.parquet" \
+  --source-pool-annotations "$G26_WS/source_pool/odvg" \
+  --embedding-model-path "$G26_WS/encoder/siglip" \
+  --kpi-images-dir "$G26_OUT/kpi/images" \
+  --ground-truth-labels-dir "$G26_OUT/kpi/labels" \
+  --class-mapping "$G26_WS/classes/classes_its.yaml" \
+  --ap50-thresholds-json '{"car": 0.9}' \
+  --extra-mount "$WORK/g26_absent"
+assert_rc 1 "[G26] an --extra-mount that is not on disk is refused"
+case "$RUN_OUT" in
+  *"--extra-mount"*) ok "[G26] the refusal names the flag" ;;
+  *) notok "[G26] the refusal names the flag" "output: $RUN_OUT" ;;
+esac
+
+# ═══════════════════════════════════════════════════════════════════════════
 
 printf '\n'
 if [ "$FAILURES" -eq 0 ]; then


### PR DESCRIPTION
Fixes NVBug 6635689.

## The defect

`tmm unique_neighbor_matching` opens both COCO detection files from inside the container under `class_stratified` allocation. `init_deft_state.py` recorded them in config and left them out of the derived mount list, so the stage failed on a path its own spec had named:

```
FileNotFoundError: [Errno 2] No such file or directory: ".../hl_coco_its_kpi.json"
  File ".../nvidia_tao_ds/core/utils/dataset_loading.py", line 144, in _load_coco
```

That file is the `target_detection_file` — the KPI detections, which live with the read-only dataset rather than in the per-run workspace. So this fires on the normal layout, not an unusual one.

The reporter also cites four overlays that mount only the workspace. Those were fixed in #124, which added `$EXTRA_MOUNTS` to every documented launch — but #124 did not add these two paths to the list that variable is built from, so the stage still failed.

## Audit

Every path-valued config key, against the derived mount list:

| | mounted |
|---|---|
| `zero_shot_checkpoint`, `train_spec_template` | yes |
| `source_pool_embeddings`, `source_pool_annotations`, `pool_images` | yes |
| `codetr_checkpoint`, `codetr_classmap` | yes |
| `embedding_model_path` (as repo root when local) | yes |
| `kpi_images_dir`, `ground_truth_labels_dir`, `class_mapping` | yes |
| `source_detection_file`, `target_detection_file` | **no** |

These two were the only gap.

## `--extra-mount`

The derivation can only cover paths the run's own inputs name. A run referencing anything else — a spec that points at an auxiliary checkpoint, a second dataset — had no remedy but editing the skill. `--extra-mount PATH` is repeatable, validated at init like any other input, and mounted by parent directory when it is a file.

Existence-only validation, deliberately: a mount may be a file or a directory, and `check_artifact` would reject a directory as "not a file".

## Verification

833/833 state-machine assertions (up from 827). New G26 covers: a target detection file outside the workspace is mounted; `--extra-mount` admits a path no config key names; a detection file inside the workspace adds no mount; a non-existent `--extra-mount` is refused and the message names the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)