### PR TITLE
[TAO-0][Bugfix] NVBug 6605507: Bind derived IAA specs to producer evidence

### DIFF
--- a/scripts/tests/test_iaa_derived_spec_integrity.py
+++ b/scripts/tests/test_iaa_derived_spec_integrity.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for content-bound IAA derived TAO specs."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+IAA_SCRIPTS = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "applications"
+    / "tao-run-deft-iaa"
+    / "scripts"
+)
+sys.path.insert(0, str(IAA_SCRIPTS))
+
+import audit_deft_run as audit  # noqa: E402
+import init_deft_state as state  # noqa: E402
+import prepare_deft_config as prepare  # noqa: E402
+import run_deft_container as container  # noqa: E402
+import run_iaa_stage as stage  # noqa: E402
+
+
+def _initialized_run(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    results = workspace / "results" / "run"
+    dataset = workspace / "data" / "iaa"
+    images_archive = tmp_path / "images_raw.tar"
+    metadata_archive = tmp_path / "meta.tar.gz"
+    images_archive.write_bytes(b"images")
+    metadata_archive.write_bytes(b"metadata")
+    common = [
+        "--workspace",
+        str(workspace),
+        "--results-dir",
+        str(results),
+        "--dataset-root",
+        str(dataset),
+        "--images-archive",
+        str(images_archive),
+        "--metadata-archive",
+        str(metadata_archive),
+        "--max-iterations",
+        "1",
+    ]
+    assert prepare.main(common) == 0
+    assert state.main(
+        [
+            *common,
+            "--platform",
+            "docker",
+            "--pyt-image",
+            prepare.PINNED_PYT_IMAGE,
+            "--ds-image",
+            prepare.PINNED_DS_IMAGE,
+            "--deft-config",
+            str(results / "config" / "deft_config.yaml"),
+            "--tao-spec",
+            str(results / "config" / "tao_spec.yaml"),
+        ]
+    ) == 0
+    assert stage.main(
+        [
+            "eval-config",
+            "--results-dir",
+            str(results),
+            "--deft-config",
+            str(results / "config" / "deft_config.yaml"),
+            "--iter-label",
+            "baseline",
+        ]
+    ) == 0
+    assert stage.main(
+        [
+            "train-config",
+            "--results-dir",
+            str(results),
+            "--deft-config",
+            str(results / "config" / "deft_config.yaml"),
+            "--iter-num",
+            "1",
+        ]
+    ) == 0
+    return results
+
+
+def test_generated_eval_spec_is_bound_before_launch_and_during_audit(tmp_path):
+    results = _initialized_run(tmp_path)
+    spec = results / "zs" / "specs" / "eval_config.yaml"
+    status = results / "zs" / "specs" / "eval-config.host.status.json"
+    evidence = json.loads(status.read_text())
+
+    assert evidence["fresh_output_sha256"][str(spec)]
+    assert container._validate_derived_spec_input(  # noqa: SLF001
+        "evaluate", "baseline", results
+    ) == evidence["fresh_output_sha256"]
+    assert audit.audit(results)["status"] == "IN_PROGRESS"
+
+    payload = yaml.safe_load(spec.read_text())
+    payload["evaluate"]["batch_size"] += 1
+    spec.write_text(yaml.safe_dump(payload, sort_keys=False))
+
+    with pytest.raises(ValueError, match="content hash mismatch"):
+        container._validate_derived_spec_input(  # noqa: SLF001
+            "evaluate", "baseline", results
+        )
+    report = audit.audit(results)
+    assert report["status"] == "INVALID"
+    assert any("content hash mismatch" in error for error in report["errors"])
+
+
+def test_generated_spec_requires_successful_producer_evidence(tmp_path):
+    results = _initialized_run(tmp_path)
+    status = results / "zs" / "specs" / "eval-config.host.status.json"
+    payload = json.loads(status.read_text())
+    payload["status"] = "running"
+    payload["exit_code"] = None
+    status.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="successful content-bound eval-config"):
+        container._validate_derived_spec_input(  # noqa: SLF001
+            "evaluate", "baseline", results
+        )
+
+
+def test_generated_train_spec_uses_the_same_content_binding(tmp_path):
+    results = _initialized_run(tmp_path)
+    spec = results / "iter_1" / "specs" / "train_config.yaml"
+    status = results / "iter_1" / "specs" / "train-config.host.status.json"
+    evidence = json.loads(status.read_text())
+
+    assert container._validate_derived_spec_input(  # noqa: SLF001
+        "train", "iter1", results
+    ) == evidence["fresh_output_sha256"]
+
+    spec.write_text(spec.read_text() + "\n# unapproved edit\n")
+    with pytest.raises(ValueError, match="content hash mismatch"):
+        container._validate_derived_spec_input(  # noqa: SLF001
+            "train", "iter1", results
+        )

--- a/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
+++ b/skills/applications/tao-run-deft-iaa/references/clip-train-eval.md
@@ -25,6 +25,10 @@ Iteration N uses its freshly published best checkpoint and `iter_N/`.
        --iter-label "$LABEL"
    ```
 
+   The adjacent `eval-config.host.status.json` content-binds this generated
+   YAML. The container wrapper verifies that digest before launch and the
+   commit/audit paths verify it again; do not hand-edit the spec.
+
 2. Set `PHASE_DIR="$RESULTS_DIR/zs"` and `CONTAINER_PHASE=zs` for `baseline`;
    otherwise set `PHASE_DIR="$RESULTS_DIR/iter_$N"` and
    `CONTAINER_PHASE="iter_$N"`. Launch evaluation with both canonical outputs
@@ -101,6 +105,10 @@ another label/path even when its numeric value is plausible.
        --results-dir "$RESULTS_DIR" \
        --deft-config "$RESULTS_DIR/config/deft_config.yaml" --iter-num "$N"
    ```
+
+   The adjacent `train-config.host.status.json` content-binds this generated
+   YAML. Any post-generation edit is an integrity failure, not a supported
+   override; revise approval and start a new immutable run instead.
 
    In the default continual-dataset/non-continual-model mode, the accumulated
    mined datasets are included but training starts from the configured base

--- a/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-iaa/references/scripts-and-agents.md
@@ -51,6 +51,13 @@ consume only variables inherited from the launching process; no wrapper opens
 or sources a credentials file, and no value is written to argv, status, state,
 or logs.
 
+Host adapters record SHA256 digests for their regular-file outputs. For the
+derived `eval_config.yaml` and `train_config.yaml` that TAO containers consume,
+this digest is a mandatory launch and audit boundary: the container wrapper,
+stage commit, and run audit all re-hash the exact file against its successful
+producer status. Never edit a derived spec. Regenerate it through the named
+adapter; a byte change after generation blocks launch and invalidates audit.
+
 ## Stage ownership
 
 | State stage | Producer | Adapter or launch | Read first |

--- a/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
@@ -37,6 +37,7 @@ from command_contract import (
     expected_container_command,
     expected_hf_forwarding,
     expected_image_kind,
+    validate_content_bound_outputs,
 )
 from metric_contract import (
     compare,
@@ -710,6 +711,65 @@ def _validate_command_status(
     return payload
 
 
+def _validate_derived_specs_on_disk(
+    results_dir: pathlib.Path, max_iterations: int, errors: list[str]
+) -> None:
+    candidates = [
+        (
+            results_dir / "zs" / "specs" / "eval_config.yaml",
+            results_dir / "zs" / "specs" / "eval-config.host.status.json",
+            "eval-config",
+            results_dir / "zs",
+        )
+    ]
+    for number in range(1, max_iterations + 1):
+        phase = results_dir / f"iter_{number}"
+        candidates.extend(
+            [
+                (
+                    phase / "specs" / "train_config.yaml",
+                    phase / "specs" / "train-config.host.status.json",
+                    "train-config",
+                    phase,
+                ),
+                (
+                    phase / "specs" / "eval_config.yaml",
+                    phase / "specs" / "eval-config.host.status.json",
+                    "eval-config",
+                    phase,
+                ),
+            ]
+        )
+    for spec_path, status_path, producer, scope in candidates:
+        if not spec_path.exists() and not status_path.exists():
+            continue
+        if not status_path.is_file():
+            errors.append(f"derived spec lacks producer evidence: {spec_path}")
+            continue
+        try:
+            raw_payload = json.loads(status_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            raw_payload = None
+        # A failed/running producer is retry evidence, not a trusted spec. The
+        # container gate rejects it; audit content-checks only successful output.
+        if not isinstance(raw_payload, dict) or raw_payload.get("status") != "ok":
+            continue
+        payload = _validate_command_status(
+            status_path,
+            f"derived {producer} status",
+            errors,
+            scope,
+            required_name=producer,
+        )
+        if payload is not None:
+            try:
+                validate_content_bound_outputs(
+                    payload, [spec_path], f"derived {producer} status"
+                )
+            except (OSError, ValueError) as exc:
+                errors.append(str(exc))
+
+
 def _history_iteration_numbers(
     payload: dict[str, Any], errors: list[str]
 ) -> list[int]:
@@ -878,6 +938,8 @@ def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str
         errors.append("state.current_iteration must be >= 0")
     if valid_max and valid_current and current_iteration > max_iterations:
         errors.append("state.current_iteration must not exceed max_iterations")
+    if valid_max and max_iterations >= 1:
+        _validate_derived_specs_on_disk(results_dir, max_iterations, errors)
 
     gate = _gate_from_state(state, errors)
     gate_met = state.get("gate_met")

--- a/skills/applications/tao-run-deft-iaa/scripts/command_contract.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/command_contract.py
@@ -31,6 +31,77 @@ def command_sha256(command: list[str]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def file_sha256(path: pathlib.Path) -> str:
+    """Hash one regular, non-symlink file without trusting path aliases."""
+    absolute = pathlib.Path(path).expanduser()
+    if (
+        not absolute.is_absolute()
+        or not absolute.is_file()
+        or absolute.is_symlink()
+        or absolute.resolve() != absolute
+    ):
+        raise ValueError(f"content-bound input is missing or unsafe: {absolute}")
+    digest = hashlib.sha256()
+    with absolute.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def fresh_output_sha256(paths: list[str]) -> dict[str, str]:
+    """Bind the byte content of every regular file produced by an adapter."""
+    hashes: dict[str, str] = {}
+    for raw in paths:
+        path = pathlib.Path(raw)
+        if path.is_file() and not path.is_symlink():
+            hashes[str(path)] = file_sha256(path)
+    return hashes
+
+
+def validate_content_bound_outputs(
+    payload: dict[str, Any], required_outputs: list[pathlib.Path], evidence_name: str
+) -> dict[str, str]:
+    """Verify that required outputs still have their producer-recorded bytes."""
+    hashes = payload.get("fresh_output_sha256")
+    if not isinstance(hashes, dict):
+        raise ValueError(f"{evidence_name}.fresh_output_sha256 must be an object")
+    verified: dict[str, str] = {}
+    for path in required_outputs:
+        absolute = pathlib.Path(path).expanduser()
+        key = str(absolute)
+        expected = hashes.get(key)
+        if not isinstance(expected, str) or not re.fullmatch(r"[0-9a-f]{64}", expected):
+            raise ValueError(
+                f"{evidence_name} does not bind a SHA256 digest for {absolute}"
+            )
+        actual = file_sha256(absolute)
+        if actual != expected:
+            raise ValueError(
+                f"content hash mismatch for {absolute}: expected {expected}, got {actual}"
+            )
+        verified[key] = actual
+    return verified
+
+
+def derived_spec_evidence(
+    name: str, label: str, results_dir: pathlib.Path
+) -> tuple[pathlib.Path, pathlib.Path, str] | None:
+    """Return the exact generated spec and producer status consumed by an action."""
+    if name == "evaluate":
+        phase = "zs" if label == "baseline" else f"iter_{_iteration_number(label)}"
+        spec_name = "eval_config.yaml"
+        producer = "eval-config"
+    elif name == "train":
+        phase = f"iter_{_iteration_number(label)}"
+        spec_name = "train_config.yaml"
+        producer = "train-config"
+    else:
+        return None
+    spec = results_dir / phase / "specs" / spec_name
+    status = results_dir / phase / "specs" / f"{producer}.host.status.json"
+    return spec, status, producer
+
+
 def _iteration_number(label: str) -> int:
     match = re.fullmatch(r"iter([1-9][0-9]*)", label)
     if not match:

--- a/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/commit_stage.py
@@ -36,6 +36,7 @@ from command_contract import (
     expected_container_command,
     expected_hf_forwarding,
     expected_image_kind,
+    validate_content_bound_outputs,
 )
 from log_stage import append_stage, next_seq
 
@@ -321,6 +322,8 @@ def _required_command_status(
                 raise ValueError(
                     f"{output} is older than the command recorded by {name}"
                 )
+        if required_name in {"eval-config", "train-config"}:
+            validate_content_bound_outputs(payload, outputs, name)
     return str(resolved)
 
 

--- a/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_deft_container.py
@@ -27,11 +27,13 @@ from typing import Any
 
 from command_contract import (
     command_sha256,
+    derived_spec_evidence,
     expected_container_command,
     expected_hf_forwarding,
     expected_fresh_outputs,
     expected_image_kind,
     expected_stage_directory,
+    validate_content_bound_outputs,
 )
 
 
@@ -281,6 +283,30 @@ def _load_existing_status(path: pathlib.Path) -> dict[str, Any] | None:
     return payload
 
 
+def _validate_derived_spec_input(
+    name: str, label: str, results_dir: pathlib.Path
+) -> dict[str, str]:
+    evidence = derived_spec_evidence(name, label, results_dir)
+    if evidence is None:
+        return {}
+    spec_path, status_path, producer = evidence
+    payload = _load_existing_status(status_path)
+    if (
+        payload is None
+        or payload.get("schema_version") != "1"
+        or payload.get("workflow") != "tao-run-deft-iaa"
+        or payload.get("kind") != "host"
+        or payload.get("name") != producer
+        or payload.get("status") != "ok"
+        or payload.get("exit_code") != 0
+        or str(spec_path) not in payload.get("fresh_outputs", [])
+    ):
+        raise ValueError(
+            f"{name} requires successful content-bound {producer} evidence: {status_path}"
+        )
+    return validate_content_bound_outputs(payload, [spec_path], str(status_path))
+
+
 def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
     results_dir = args.results_dir.expanduser().resolve()
     state = _load_state(results_dir)
@@ -336,6 +362,9 @@ def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
         raise ValueError(
             f"--pass-hf-token for {args.name} must be {required_hf} per immutable approval"
         )
+    input_sha256 = _validate_derived_spec_input(
+        args.name, label, results_dir
+    )
     stage_dir.mkdir(parents=True, exist_ok=True)
     log_path = stage_dir / f"{args.name}.log"
     status_path = stage_dir / f"{args.name}.status.json"
@@ -475,6 +504,7 @@ def run(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path, int]:
             "exit_code": None,
             "log_path": str(log_path),
             "fresh_outputs": fresh_outputs,
+            "input_sha256": input_sha256,
         }
         _atomic_json(status_path, running_payload)
         for raw in fresh_outputs:

--- a/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/run_iaa_stage.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from checkpoint_contract import METADATA_RELPATH, validate_best_checkpoint
 from command_contract import (
+    fresh_output_sha256,
     command_sha256,
     expected_container_command,
     expected_hf_forwarding,
@@ -893,6 +894,7 @@ def _execute_stage(
             print(f"run_iaa_stage[{args.stage}]: {exc}", file=sys.stderr)
             return 2
         fresh_outputs = _result_paths(report, results, args.stage)
+        output_hashes = fresh_output_sha256(fresh_outputs)
         finished_at = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
         _atomic_json(
             status_path,
@@ -902,6 +904,7 @@ def _execute_stage(
                 "status": "ok",
                 "exit_code": 0,
                 "fresh_outputs": fresh_outputs,
+                "fresh_output_sha256": output_hashes,
             },
         )
         report = dict(report)


### PR DESCRIPTION
## Reported issue

NVBug 6605507: generated `eval_config.yaml` and `train_config.yaml` files were consumed by TAO containers without the content binding applied to the approved run configuration. A post-generation edit could therefore change the bytes TAO executed while the run still appeared valid.

## Original reproduction

On `origin/main`:

1. Prepare and initialize a fresh IAA run from the real `images_raw.tar` and `meta.tar.gz` exports.
2. Generate the baseline evaluation spec through `run_iaa_stage.py eval-config`.
3. Change `zs/specs/eval_config.yaml` after generation (the reproduction changed `evaluate.batch_size` from 32 to 33).
4. Run `audit_deft_run.py` and attempt the evaluation launch.

Observed before the fix: the audit remained `IN_PROGRESS` with exit 0, and no launch-time integrity check tied the edited YAML to its producer evidence.

Expected: every derived TAO spec must be byte-bound to the successful host adapter that generated it; later mutation must block launch and invalidate the run.

## Root cause

Host adapter status recorded only output paths and timestamps. The launch, commit, and audit paths consequently proved that the expected file existed and was fresh, but not that its current bytes were the bytes emitted by the trusted producer.

This is a root-cause fix because content identity is now part of the shared command-evidence contract and is revalidated at every trust boundary. It does not special-case `batch_size`, compare parsed YAML fields selectively, or mask the reproduction with a one-off audit condition.

## Implementation

- Record SHA-256 digests for regular-file host-adapter outputs.
- Resolve the exact producer status for baseline/iteration evaluation specs and iteration training specs.
- Require successful producer evidence and verify the current file digest before any train/evaluate container launch.
- Revalidate the same binding during stage commit and full run audit, including uncommitted generated specs already on disk.
- Reject missing, unsafe, symlinked, unbound, or byte-modified files.
- Document that derived specs are regenerated by their named adapter rather than hand-edited.

Shortcut approaches intentionally avoided:

- no YAML-key allowlist or symptom-specific `batch_size` check;
- no reliance on modification time as content identity;
- no launch-only check that would leave commit/audit accepting corrupted evidence;
- no automatic digest refresh after a user edit.

## Regression coverage

Added `scripts/tests/test_iaa_derived_spec_integrity.py`, covering:

- successful baseline evaluation-spec binding;
- launch and audit rejection after a byte-level mutation;
- rejection of non-successful producer evidence;
- the equivalent training-spec path.

## Verification

- `python3 -m pytest -q scripts/tests/test_iaa_derived_spec_integrity.py` — **3 passed**
- `python3 -m pytest -q scripts/tests` — **261 passed, 2 skipped**
- `scripts/validate-skills.sh` — **passed**
- `git diff --check` — **passed**

Refreshed user-facing reproduction with the real IAA archives:

- Fresh, unmodified generated spec: audit reported `IN_PROGRESS`; launch gate accepted the producer digest.
- After changing `evaluate.batch_size` from 32 to 33: launch failed with `content hash mismatch`; audit reported `INVALID` and exited 1 with the same expected/actual SHA-256 mismatch.

## Residual risks / limitations

The integrity boundary intentionally trusts wrapper-owned command-status evidence, as the existing workflow contract does. This change binds the derived content to that evidence; it is not intended to provide an external signature against an attacker who can rewrite every artifact and every status record in the results directory.
