### PR TITLE
[TAO-0][Bugfix] NVBug 6608848: Honor CUDA-visible GPU allocation in preflight

### DIFF
--- a/scripts/check_tao_launch_preflight.py
+++ b/scripts/check_tao_launch_preflight.py
@@ -499,42 +499,21 @@ def run(
 
 
 def detect_local_gpu_arches() -> list[str]:
-    if not shutil.which("nvidia-smi"):
+    ok, gpus = query_host_gpus(print_result=False)
+    if not ok:
         return []
-    result = run(
-        ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
-        timeout=20,
-    )
-    if result.returncode != 0:
-        return []
-    arches = []
-    for line in result.stdout.splitlines():
-        value = line.strip()
-        if not value:
-            continue
-        arches.append(normalize_gpu_arch(value))
-    return arches
+    return [gpu["sm"] for gpu in gpus if gpu.get("sm")]
 
 
 def detect_local_gpu_memory_gb() -> list[float]:
-    if not shutil.which("nvidia-smi"):
+    ok, gpus = query_host_gpus(print_result=False)
+    if not ok:
         return []
-    result = run(
-        ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
-        timeout=20,
-    )
-    if result.returncode != 0:
-        return []
-    memory_gb = []
-    for line in result.stdout.splitlines():
-        value = line.strip()
-        if not value:
-            continue
-        try:
-            memory_gb.append(float(value) / 1024.0)
-        except ValueError:
-            continue
-    return memory_gb
+    return [
+        float(gpu["memory_mib"]) / 1024.0
+        for gpu in gpus
+        if gpu.get("memory_mib") is not None
+    ]
 
 
 def check_gpu_arch_allowlists(
@@ -1104,27 +1083,107 @@ def docker_runtimes() -> tuple[bool, set[str]]:
     return True, runtimes
 
 
-def parse_gpu_query_output(stdout: str, has_compute_cap: bool) -> list[dict[str, Any]]:
+def parse_gpu_query_output(
+    stdout: str, has_compute_cap: bool, *, has_uuid: bool = False
+) -> list[dict[str, Any]]:
     gpus: list[dict[str, Any]] = []
     for row in csv.reader(stdout.splitlines()):
-        if len(row) < 4:
+        minimum_columns = 5 if has_uuid else 4
+        if len(row) < minimum_columns:
             continue
+        offset = 1 if has_uuid else 0
         memory_mib = None
         try:
-            memory_mib = float(row[3].strip())
+            memory_mib = float(row[3 + offset].strip())
         except ValueError:
             pass
-        compute_cap = row[4].strip() if has_compute_cap and len(row) > 4 else ""
+        compute_cap_index = 4 + offset
+        compute_cap = (
+            row[compute_cap_index].strip()
+            if has_compute_cap and len(row) > compute_cap_index
+            else ""
+        )
         gpus.append(
             {
                 "index": row[0].strip(),
-                "name": row[1].strip(),
-                "driver_version": row[2].strip(),
+                "uuid": row[1].strip() if has_uuid else "",
+                "name": row[1 + offset].strip(),
+                "driver_version": row[2 + offset].strip(),
                 "memory_mib": memory_mib,
                 "sm": sm_from_compute_cap(compute_cap) if compute_cap else "",
             }
         )
     return gpus
+
+
+def filter_cuda_visible_gpus(
+    gpus: list[dict[str, Any]], raw_visibility: str | None
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Apply the launcher process's CUDA visibility contract to host inventory.
+
+    ``nvidia-smi`` intentionally reports physical inventory. CUDA workloads see
+    only ``CUDA_VISIBLE_DEVICES`` and renumber the selected devices densely, so
+    preflight must preserve both namespaces instead of treating inventory as
+    availability.
+    """
+    physical_count = len(gpus)
+    if raw_visibility is None:
+        visible = [dict(gpu, visible_index=str(index)) for index, gpu in enumerate(gpus)]
+        print(
+            "CUDA-visible GPU comparison: "
+            f"physical={physical_count}, visible={len(visible)}, "
+            "source=unrestricted"
+        )
+        return True, visible
+
+    raw = raw_visibility.strip()
+    if not raw or raw == "-1":
+        print(
+            "CUDA-visible GPU comparison: "
+            f"physical={physical_count}, visible=0, source=CUDA_VISIBLE_DEVICES"
+        )
+        return False, []
+
+    tokens = [token.strip() for token in raw.split(",")]
+    if any(not token for token in tokens):
+        print("CUDA_VISIBLE_DEVICES is invalid: empty device token")
+        return False, []
+
+    by_index = {str(gpu.get("index")): gpu for gpu in gpus}
+    selected: list[dict[str, Any]] = []
+    selected_host_ids: set[str] = set()
+    for token in tokens:
+        match = by_index.get(token) if token.isdigit() else None
+        if match is None and token.upper().startswith("GPU-"):
+            candidates = [
+                gpu
+                for gpu in gpus
+                if str(gpu.get("uuid", "")).upper().startswith(token.upper())
+            ]
+            if len(candidates) == 1:
+                match = candidates[0]
+        if match is None:
+            print(
+                "CUDA_VISIBLE_DEVICES cannot be resolved against host inventory: "
+                f"token={token!r}"
+            )
+            return False, []
+        host_id = str(match.get("index"))
+        if host_id in selected_host_ids:
+            print(
+                "CUDA_VISIBLE_DEVICES selects the same host GPU more than once: "
+                f"index={host_id}"
+            )
+            return False, []
+        selected_host_ids.add(host_id)
+        selected.append(dict(match, visible_index=str(len(selected))))
+
+    print(
+        "CUDA-visible GPU comparison: "
+        f"physical={physical_count}, visible={len(selected)}, "
+        "source=CUDA_VISIBLE_DEVICES"
+    )
+    return True, selected
 
 
 def print_gpus(gpus: list[dict[str, Any]], prefix: str = "Host GPU OK") -> None:
@@ -1139,14 +1198,14 @@ def print_gpus(gpus: list[dict[str, Any]], prefix: str = "Host GPU OK") -> None:
         )
 
 
-def query_host_gpus() -> tuple[bool, list[dict[str, Any]]]:
+def query_host_gpus(*, print_result: bool = True) -> tuple[bool, list[dict[str, Any]]]:
     if not shutil.which("nvidia-smi"):
         print("nvidia-smi not found on host PATH")
         return False, []
 
     command = [
         "nvidia-smi",
-        "--query-gpu=index,name,driver_version,memory.total,compute_cap",
+        "--query-gpu=index,uuid,name,driver_version,memory.total,compute_cap",
         "--format=csv,noheader,nounits",
     ]
     result = run(command, timeout=20)
@@ -1154,7 +1213,7 @@ def query_host_gpus() -> tuple[bool, list[dict[str, Any]]]:
     if not has_compute_cap:
         command = [
             "nvidia-smi",
-            "--query-gpu=index,name,driver_version,memory.total",
+            "--query-gpu=index,uuid,name,driver_version,memory.total",
             "--format=csv,noheader,nounits",
         ]
         result = run(command, timeout=20)
@@ -1162,12 +1221,16 @@ def query_host_gpus() -> tuple[bool, list[dict[str, Any]]]:
         print(f"nvidia-smi GPU query failed: {command_detail(result)}")
         return False, []
 
-    gpus = parse_gpu_query_output(result.stdout, has_compute_cap)
+    gpus = parse_gpu_query_output(result.stdout, has_compute_cap, has_uuid=True)
     if not gpus:
         print("nvidia-smi did not report any GPUs")
         return False, []
-    print_gpus(gpus)
-    return True, gpus
+    visibility_ok, visible_gpus = filter_cuda_visible_gpus(
+        gpus, os.environ.get("CUDA_VISIBLE_DEVICES")
+    )
+    if print_result and visibility_ok:
+        print_gpus(visible_gpus)
+    return visibility_ok, visible_gpus
 
 
 def query_docker_gpus(
@@ -1640,6 +1703,7 @@ def check_local_docker(
     target_gpu_indices: list[str],
 ) -> bool:
     ok = True
+    effective_target_gpu_indices = list(target_gpu_indices)
     docker_host = os.environ.get("DOCKER_HOST")
     remote_docker = docker_host_is_remote(docker_host)
     if require_remote_docker and not remote_docker:
@@ -1681,6 +1745,8 @@ def check_local_docker(
                 gpu_ok, gpus = query_host_gpus()
                 selection_ok, gpus = filter_target_gpus(gpus, target_gpu_indices)
                 gpu_ok = gpu_ok and selection_ok
+                if gpu_ok and not effective_target_gpu_indices:
+                    effective_target_gpu_indices = [str(gpu["index"]) for gpu in gpus]
             ok = gpu_ok and ok
             if gpu_ok:
                 ok = (
@@ -1699,15 +1765,20 @@ def check_local_docker(
                     )
                     and ok
                 )
-            ok = (
-                check_docker_gpu_smoke(
-                    container_image,
-                    gpu_smoke_image,
-                    pull_smoke_image,
-                    target_gpu_indices,
+            if gpu_ok:
+                ok = (
+                    check_docker_gpu_smoke(
+                        container_image,
+                        gpu_smoke_image,
+                        pull_smoke_image,
+                        effective_target_gpu_indices,
+                    )
+                    and ok
                 )
-                and ok
-            )
+            else:
+                print(
+                    "Docker GPU smoke skipped: effective GPU allocation failed validation"
+                )
 
     for label, raw_path in paths:
         path = normalize_local_path(raw_path)

--- a/scripts/tests/test_launch_preflight.py
+++ b/scripts/tests/test_launch_preflight.py
@@ -76,6 +76,59 @@ def test_target_gpu_selection_rejects_missing_index(capsys):
     assert "missing index(es)=2" in capsys.readouterr().out
 
 
+def _host_gpus():
+    return [
+        {
+            "index": str(index),
+            "uuid": f"GPU-0000000{index}",
+            "name": "A100",
+            "driver_version": "600.0",
+            "memory_mib": 81920.0,
+            "sm": "sm_80",
+        }
+        for index in range(4)
+    ]
+
+
+def test_cuda_visible_devices_filters_and_renumbers_host_inventory(capsys):
+    ok, visible = preflight.filter_cuda_visible_gpus(_host_gpus(), "2,0")
+    assert ok
+    assert [gpu["index"] for gpu in visible] == ["2", "0"]
+    assert [gpu["visible_index"] for gpu in visible] == ["0", "1"]
+    assert "physical=4, visible=2" in capsys.readouterr().out
+
+
+def test_cuda_visible_devices_accepts_unique_gpu_uuid_prefix():
+    ok, visible = preflight.filter_cuda_visible_gpus(_host_gpus(), "GPU-00000002")
+    assert ok
+    assert [gpu["index"] for gpu in visible] == ["2"]
+
+
+@pytest.mark.parametrize("visibility", ["", "-1"])
+def test_cuda_visible_devices_rejects_empty_allocation(visibility):
+    ok, visible = preflight.filter_cuda_visible_gpus(_host_gpus(), visibility)
+    assert not ok
+    assert visible == []
+
+
+@pytest.mark.parametrize("visibility", ["0,,1", "7", "GPU-unknown", "0,0"])
+def test_cuda_visible_devices_fails_closed_on_invalid_selection(visibility):
+    ok, visible = preflight.filter_cuda_visible_gpus(_host_gpus(), visibility)
+    assert not ok
+    assert visible == []
+
+
+def test_gpu_resource_count_uses_cuda_visible_inventory(monkeypatch, capsys):
+    monkeypatch.setattr(
+        preflight,
+        "query_host_gpus",
+        lambda **_kwargs: (True, _host_gpus()[:2]),
+    )
+    assert not preflight.check_gpu_resources(4, None, None, None, [], False)
+    output = capsys.readouterr().out
+    assert "qualifying_gpus=2 < required=4" in output
+
+
 def test_multi_device_docker_gpu_request_preserves_csv_quotes():
     assert preflight.docker_gpu_request(["0", "1", "2", "4"]) == '"device=0,1,2,4"'
     assert preflight.docker_gpu_request([]) == "all"

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -146,7 +146,15 @@ Run this section only after required intake is resolved.
    docker version --format '{{.Server.Version}}'
    docker image inspect nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt >/dev/null 2>&1  # versions-key: images.tao_toolkit.pyt
    docker image inspect nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services >/dev/null 2>&1  # versions-key: images.tao_toolkit.data_services
-   nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader
+   TARGET_GPU_ARGS=()
+   IFS=, read -r -a GPU_ID_LIST <<< "$GPU_IDS"
+   for GPU_ID in "${GPU_ID_LIST[@]}"; do
+     TARGET_GPU_ARGS+=(--target-gpu-index "$GPU_ID")
+   done
+   "${TAO_SKILL_BANK_PATH:?}/scripts/check_tao_launch_preflight.py" \
+     --skill-bank "$TAO_SKILL_BANK_PATH" --platform docker \
+     --container-image nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt \
+     --gpu-min-count "$NUM_GPUS" "${TARGET_GPU_ARGS[@]}"
    ```
 
    Missing local images are planned pulls. Do not run a CUDA container probe
@@ -160,7 +168,12 @@ Run this section only after required intake is resolved.
    If the user explicitly asks for a permissions check, `stat` only that named
    file, warn about group/other readability, and still require credentials to
    be exported in the launching environment.
-6. Resolve the approved GPU shape. SigLIP2-so400m training commonly needs
+6. Resolve the approved GPU shape. The shared preflight intersects physical
+   `nvidia-smi` inventory with `CUDA_VISIBLE_DEVICES`, then compares the
+   process-visible count with `num_gpus` and verifies every requested host
+   index is visible. Its summary must show `physical`, `visible`, and
+   `requested`; a request larger than the visible set is blocking. Keep using
+   `nvidia-smi` for utilization and memory on the selected devices. SigLIP2-so400m training commonly needs
    roughly 30–45 GB free per selected GPU at the bundled batch size. Treat this
    as a planning estimate, not a capability guarantee. Surface occupied GPUs;
    do not silently reshape `gpu_ids`.
@@ -257,7 +270,8 @@ Inputs
                  (source=versions.yaml; status=<local | pull after approval>)
   data-services image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
                        (source=versions.yaml; status=<local | pull after approval>)
-  GPUs: <selected IDs> (source=<user | default>);
+  GPUs: <selected host IDs> (source=<user | default>);
+        physical=<count>; visible=<CUDA-visible count>; requested=<num_gpus>;
         memory=<free/total discovery result>
 
 Planned writes/actions


### PR DESCRIPTION
## Reported issue

NVBug 6608848: IAA GPU preflight counted physical devices through `nvidia-smi`, so a process restricted by `CUDA_VISIBLE_DEVICES` could pass a GPU-count check for devices it could not use.

## Original reproduction

On an eight-A100 host using `origin/main`:

1. Set `CUDA_VISIBLE_DEVICES=0,1`.
2. Run the shared preflight GPU inventory and request four GPUs.

Observed before the fix: `query_host_gpus()` returned all eight physical GPUs and `check_gpu_resources(4, ...)` returned true.

Expected: preflight must compare physical inventory, process-visible allocation, and the requested host device set, then fail when the visible allocation cannot satisfy the request.

## Root cause

The shared preflight used `nvidia-smi` physical inventory directly as launch capacity. It did not model CUDA visibility or preserve the distinction between host IDs and the dense visible-device namespace.

This is a root-cause fix because all shared local GPU architecture, memory, count, target-selection, and Docker-smoke decisions now consume one visibility-aware inventory. It does not hard-code the reported `0,1` example, subtract a count heuristically, or let a Docker smoke test run after allocation validation has already failed.

## Implementation

- Query physical index, UUID, model, driver, memory, and compute capability once.
- Intersect that inventory with `CUDA_VISIBLE_DEVICES`, supporting numeric host indices and unique GPU UUID prefixes.
- Preserve host identity while assigning dense `visible_index` values.
- Fail closed for empty/`-1`, unresolved, ambiguous, empty-token, and duplicate selections.
- Route shared architecture and memory/count checks through the visible inventory.
- Validate explicitly requested Docker host GPU IDs against that allocation.
- Skip Docker GPU smoke when effective allocation validation fails.
- Update the IAA user-facing preflight to call the packaged shared helper with the exact requested host IDs and selected image.

Shortcut approaches intentionally avoided:

- no raw `len(CUDA_VISIBLE_DEVICES.split(','))` counting;
- no assumption that visibility tokens are always small dense ordinals;
- no silent fallback to physical inventory when visibility is malformed;
- no smoke launch with `--gpus all` after a restricted allocation fails.

## Regression coverage

Expanded `scripts/tests/test_launch_preflight.py` for reordered numeric selections, dense renumbering, UUID prefixes, empty and disabled allocations, invalid/missing/duplicate IDs, and resource-count enforcement against only visible devices.

## Verification

- `python3 -m pytest -q scripts/tests/test_launch_preflight.py` — **27 passed**
- `python3 -m pytest -q scripts/tests` — **267 passed, 2 skipped**
- `scripts/validate-skills.sh` — **passed**
- `git diff --check` — **passed**

Refreshed user-facing reproduction on the eight-A100 host:

- `CUDA_VISIBLE_DEVICES=0,1` produced `physical=8, visible=2`.
- A four-GPU IAA preflight rejected requested host IDs 2 and 3, skipped the Docker smoke because allocation validation failed, and exited 2.

## Residual risks / limitations

GPU UUIDs and numeric host indices are supported. MIG UUID allocation is deliberately fail-closed rather than guessed; adding MIG-aware inventory requires an explicit supported TAO/MIG contract.
