### PR TITLE
[TAO-0][Bugfix] NVBug 6610028: Separate host and container GPU ordinals

### DIFF
--- a/scripts/tests/test_iaa_deft_container.py
+++ b/scripts/tests/test_iaa_deft_container.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Focused tests for IAA DEFT Docker GPU scoping."""
+"""Focused tests for IAA DEFT host/container GPU scoping."""
 
+import json
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 IAA_SCRIPTS = (
     Path(__file__).resolve().parents[2]
@@ -17,12 +19,93 @@ IAA_SCRIPTS = (
 )
 sys.path.insert(0, str(IAA_SCRIPTS))
 import run_deft_container as container  # noqa: E402
+import init_deft_state as state  # noqa: E402
+import prepare_deft_config as prepare  # noqa: E402
 
 
 def test_docker_gpu_args_use_exact_approved_devices():
     assert container._docker_gpu_args(  # noqa: SLF001
         {"gpu_ids": [0, 2], "num_gpus": 2}
     ) == ["--gpus", '"device=0,2"']
+
+
+def test_nonzero_host_devices_become_dense_container_ordinals(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    results = workspace / "results" / "run"
+    dataset = workspace / "data" / "iaa"
+    images_archive = tmp_path / "images_raw.tar"
+    metadata_archive = tmp_path / "meta.tar.gz"
+    images_archive.write_bytes(b"images")
+    metadata_archive.write_bytes(b"metadata")
+
+    assert prepare.main(
+        [
+            "--workspace",
+            str(workspace),
+            "--results-dir",
+            str(results),
+            "--dataset-root",
+            str(dataset),
+            "--images-archive",
+            str(images_archive),
+            "--metadata-archive",
+            str(metadata_archive),
+            "--max-iterations",
+            "1",
+            "--num-gpus",
+            "2",
+            "--gpu-ids",
+            "1,3",
+        ]
+    ) == 0
+
+    tao_spec = yaml.safe_load((results / "config" / "tao_spec.yaml").read_text())
+    approval = json.loads((results / "config" / "approval.json").read_text())
+    assert tao_spec["train"]["gpu_ids"] == [0, 1]
+    assert tao_spec["evaluate"]["gpu_ids"] == [0, 1]
+    assert approval["host_gpu_ids"] == [1, 3]
+    assert approval["container_gpu_ids"] == [0, 1]
+
+    assert state.main(
+        [
+            "--workspace",
+            str(workspace),
+            "--results-dir",
+            str(results),
+            "--dataset-root",
+            str(dataset),
+            "--images-archive",
+            str(images_archive),
+            "--metadata-archive",
+            str(metadata_archive),
+            "--max-iterations",
+            "1",
+            "--platform",
+            "docker",
+            "--pyt-image",
+            prepare.PINNED_PYT_IMAGE,
+            "--ds-image",
+            prepare.PINNED_DS_IMAGE,
+            "--deft-config",
+            str(results / "config" / "deft_config.yaml"),
+            "--tao-spec",
+            str(results / "config" / "tao_spec.yaml"),
+        ]
+    ) == 0
+    persisted = json.loads((results / "deft_state.json").read_text())
+    assert persisted["config"]["gpu_ids"] == [1, 3]
+    assert persisted["config"]["container_gpu_ids"] == [0, 1]
+    assert container._docker_gpu_args(persisted["config"]) == [  # noqa: SLF001
+        "--gpus",
+        '"device=1,3"',
+    ]
+
+
+@pytest.mark.parametrize("value", [None, "0,1", [], [True], [0, 0], [-1]])
+def test_approval_gpu_namespaces_reject_malformed_values(value):
+    with pytest.raises(ValueError):
+        state._approval_gpu_ids(value, "host_gpu_ids")  # noqa: SLF001
 
 
 @pytest.mark.parametrize(

--- a/skills/applications/tao-run-deft-iaa/references/preflight.md
+++ b/skills/applications/tao-run-deft-iaa/references/preflight.md
@@ -163,7 +163,10 @@ Run this section only after required intake is resolved.
 6. Resolve the approved GPU shape. SigLIP2-so400m training commonly needs
    roughly 30–45 GB free per selected GPU at the bundled batch size. Treat this
    as a planning estimate, not a capability guarantee. Surface occupied GPUs;
-   do not silently reshape `gpu_ids`.
+   do not silently reshape the selected host `gpu_ids`. These are launcher
+   device selectors. The immutable preparation step separately derives TAO's
+   in-container ordinals as `0..num_gpus-1`, because Docker renumbers every
+   exposed allocation into a dense container-local CUDA namespace.
 7. Resolve all run values and their sources. Validate the metric contract
    vocabulary against `references/metric-contract.md`. Do not create a config
    to discover defaults; read the bundled templates.
@@ -305,7 +308,9 @@ For a new run, perform the following in order.
      nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt python3 -c 'import torch; torch.zeros(1).cuda()'  # versions-key: images.tao_toolkit.pyt
    ```
 
-   `GPU_IDS` is the exact approved `gpu_ids` list (for example `0` or `0,2`).
+   `GPU_IDS` is the exact approved host `gpu_ids` list (for example `0` or
+   `0,2`). The Docker selector remains `device=0,2`, while the TAO spec uses
+   container-local `gpu_ids: [0, 1]` for that two-device allocation.
    CUDA initialization or unsupported-architecture failure is a hard stop.
 3. Reuse a complete workspace venv if the runtime probe passes. Otherwise
    create it and install only the bundled runtime's third-party dependencies:

--- a/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/audit_deft_run.py
@@ -1085,7 +1085,7 @@ def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str
                     errors.append(f"approval manifest is invalid JSON: {exc}")
                 else:
                     expected_approval = {
-                        "schema_version": "2",
+                        "schema_version": "3",
                         "workflow": WORKFLOW,
                         "workspace": str(pathlib.Path(str(config.get("workspace", ""))).resolve()),
                         "results_dir": str(results_dir.resolve()),
@@ -1100,6 +1100,8 @@ def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str
                         ),
                         "requires_hf_token": config.get("requires_hf_token"),
                         "max_iterations": max_iterations,
+                        "host_gpu_ids": config.get("gpu_ids"),
+                        "container_gpu_ids": config.get("container_gpu_ids"),
                         "metric_contract": gate,
                         "pyt_image": config.get("pyt_image"),
                         "ds_image": config.get("ds_image"),
@@ -1151,7 +1153,7 @@ def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str
                         derived = {
                             "training_epochs": tao_train.get("num_epochs"),
                             "num_gpus": tao_train.get("num_gpus"),
-                            "gpu_ids": tao_train.get("gpu_ids"),
+                            "container_gpu_ids": tao_train.get("gpu_ids"),
                             "history_aware": history.get("enabled"),
                             "replay_fraction": history.get("replay_fraction"),
                             "mining_topn": mining.get("topn"),
@@ -1229,6 +1231,23 @@ def audit(results_dir: pathlib.Path, require_complete: bool = False) -> dict[str
         gpu_ids = config.get("gpu_ids")
         if not isinstance(gpu_ids, list) or len(gpu_ids) != config.get("num_gpus"):
             errors.append("state.config.gpu_ids must match state.config.num_gpus")
+        container_gpu_ids = config.get("container_gpu_ids")
+        num_gpus = config.get("num_gpus")
+        expected_container_gpu_ids = (
+            list(range(num_gpus))
+            if isinstance(num_gpus, int)
+            and not isinstance(num_gpus, bool)
+            and num_gpus >= 1
+            else None
+        )
+        if (
+            expected_container_gpu_ids is None
+            or container_gpu_ids != expected_container_gpu_ids
+        ):
+            errors.append(
+                "state.config.container_gpu_ids must be a dense zero-based list "
+                "matching state.config.num_gpus"
+            )
         for field in (
             "history_aware",
             "continual_dataset",

--- a/skills/applications/tao-run-deft-iaa/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/init_deft_state.py
@@ -98,6 +98,17 @@ def _parse_gpu_ids(raw: str, num_gpus: int) -> list[int]:
     return gpu_ids
 
 
+def _approval_gpu_ids(value: object, field: str) -> list[int]:
+    """Parse one approval GPU namespace without coercing malformed JSON types."""
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, int) or isinstance(item, bool) for item in value)
+    ):
+        raise ValueError(f"approval.json {field} must be a non-empty integer list")
+    return _parse_gpu_ids(",".join(str(item) for item in value), len(value))
+
+
 def _resolve_dataset_root(root: pathlib.Path) -> pathlib.Path:
     """Resolve the intended dataset root before dataset_setup materializes it."""
     resolved = root.expanduser().resolve()
@@ -228,8 +239,23 @@ def _load_run_config(args: argparse.Namespace) -> dict:
         spec_sha256[name] = _sha256(spec_path)
     approval_path = config_dir / "approval.json"
     approval = json.loads(approval_path.read_text())
+    approved_host_gpu_ids = _approval_gpu_ids(
+        approval.get("host_gpu_ids"), "host_gpu_ids"
+    )
+    approved_container_gpu_ids = _approval_gpu_ids(
+        approval.get("container_gpu_ids"), "container_gpu_ids"
+    )
+    if len(approved_container_gpu_ids) != len(approved_host_gpu_ids):
+        raise ValueError(
+            "approval.json host_gpu_ids and container_gpu_ids must have equal length"
+        )
+    if approved_container_gpu_ids != list(range(len(approved_host_gpu_ids))):
+        raise ValueError(
+            "approval.json container_gpu_ids must be the dense zero-based "
+            "namespace for the approved host GPU allocation"
+        )
     expected_approval = {
-        "schema_version": "2",
+        "schema_version": "3",
         "workflow": WORKFLOW,
         "workspace": str(args.workspace.resolve()),
         "results_dir": str(args.results_dir.resolve()),
@@ -244,6 +270,8 @@ def _load_run_config(args: argparse.Namespace) -> dict:
         ),
         "requires_hf_token": args.requires_hf_token,
         "max_iterations": args.max_iterations,
+        "host_gpu_ids": approved_host_gpu_ids,
+        "container_gpu_ids": approved_container_gpu_ids,
         "metric_contract": args.metric_contract,
         "pyt_image": args.pyt_image,
         "ds_image": args.ds_image,
@@ -280,6 +308,14 @@ def _load_run_config(args: argparse.Namespace) -> dict:
     if not isinstance(gpu_ids, list):
         raise ValueError("prepared tao_spec train.gpu_ids must be a list")
     parsed_gpu_ids = _parse_gpu_ids(",".join(str(item) for item in gpu_ids), num_gpus)
+    if parsed_gpu_ids != approved_container_gpu_ids:
+        raise ValueError(
+            "prepared TAO gpu_ids must match approval.json container_gpu_ids"
+        )
+    if num_gpus != len(approved_host_gpu_ids):
+        raise ValueError(
+            "prepared TAO num_gpus must match the approved host GPU allocation"
+        )
     if evaluate.get("num_gpus") != num_gpus or evaluate.get("gpu_ids") != gpu_ids:
         raise ValueError("prepared TAO train/evaluate GPU shapes must match")
     training_epochs = train.get("num_epochs")
@@ -326,7 +362,8 @@ def _load_run_config(args: argparse.Namespace) -> dict:
         "tao_spec_sha256": _sha256(args.tao_spec),
         "training_epochs": training_epochs,
         "num_gpus": num_gpus,
-        "gpu_ids": parsed_gpu_ids,
+        "gpu_ids": approved_host_gpu_ids,
+        "container_gpu_ids": parsed_gpu_ids,
         "history_aware": history.get("enabled"),
         "replay_fraction": replay,
         "mining_topn": int(mining.get("topn")),

--- a/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
+++ b/skills/applications/tao-run-deft-iaa/scripts/prepare_deft_config.py
@@ -204,7 +204,11 @@ def materialize(args: argparse.Namespace) -> dict[str, Any]:
         raise ValueError("--replay-fraction must be in [0, 1]")
     if args.knn_metric not in {"cosine", "euclidean"}:
         raise ValueError("--knn-metric must be cosine or euclidean")
-    gpu_ids = _gpu_ids(args.gpu_ids, args.num_gpus)
+    # ``gpu_ids`` is an allocation in the launcher/host namespace. Container
+    # runtimes expose that allocation as a dense zero-based CUDA namespace, so
+    # TAO must never receive the host ordinals directly.
+    host_gpu_ids = _gpu_ids(args.gpu_ids, args.num_gpus)
+    container_gpu_ids = list(range(args.num_gpus))
     metric_contract = validate_contract(
         {
             "metric_name": args.metric_name,
@@ -265,10 +269,12 @@ def materialize(args: argparse.Namespace) -> dict[str, Any]:
         {
             "num_epochs": args.training_epochs,
             "num_gpus": args.num_gpus,
-            "gpu_ids": gpu_ids,
+            "gpu_ids": container_gpu_ids,
         }
     )
-    tao["evaluate"].update({"num_gpus": args.num_gpus, "gpu_ids": gpu_ids})
+    tao["evaluate"].update(
+        {"num_gpus": args.num_gpus, "gpu_ids": container_gpu_ids}
+    )
 
     _atomic_yaml(config_dir / "deft_config.yaml", deft)
     _atomic_yaml(config_dir / "tao_spec.yaml", tao)
@@ -277,7 +283,7 @@ def materialize(args: argparse.Namespace) -> dict[str, Any]:
     _atomic_json(
         config_dir / "approval.json",
         {
-            "schema_version": "2",
+            "schema_version": "3",
             "workflow": "tao-run-deft-iaa",
             "workspace": str(workspace),
             "results_dir": str(results_dir),
@@ -288,6 +294,8 @@ def materialize(args: argparse.Namespace) -> dict[str, Any]:
             "checksums_file": str(checksums_file) if checksums_file else None,
             "requires_hf_token": args.requires_hf_token,
             "max_iterations": args.max_iterations,
+            "host_gpu_ids": host_gpu_ids,
+            "container_gpu_ids": container_gpu_ids,
             "metric_contract": metric_contract,
             "pyt_image": PINNED_PYT_IMAGE,
             "ds_image": PINNED_DS_IMAGE,
@@ -301,7 +309,8 @@ def materialize(args: argparse.Namespace) -> dict[str, Any]:
         "max_iterations": args.max_iterations,
         "training_epochs": args.training_epochs,
         "num_gpus": args.num_gpus,
-        "gpu_ids": gpu_ids,
+        "gpu_ids": host_gpu_ids,
+        "container_gpu_ids": container_gpu_ids,
         "requires_hf_token": args.requires_hf_token,
         "iaa_deft_bundle_sha256": runtime_sha256,
         "approval_manifest": str(config_dir / "approval.json"),


### PR DESCRIPTION
## Reported issue

NVBug 6610028: IAA used `gpu_ids` both as host/Docker selectors and as TAO container-local CUDA ordinals. Any allocation not starting at host GPU 0 therefore generated invalid TAO specs inside the container.

## Original reproduction

On `origin/main`:

1. Prepare an IAA run with `--num-gpus 1 --gpu-ids 1`.
2. Inspect the generated Docker selector and TAO train/evaluate specs.

Observed before the fix: Docker correctly selected physical device 1, but the TAO specs also contained `gpu_ids: [1]`. Inside a one-device container, that allocation is exposed as `cuda:0`; ordinal 1 does not exist.

Expected: retain host GPU IDs for launcher allocation while giving TAO dense container-local ordinals `0..num_gpus-1`.

## Root cause

One field represented two different namespaces. Configuration preparation copied the host allocation directly into TAO specs, and approval/state/audit did not preserve or validate the distinction.

This is a root-cause fix because the namespace separation is explicit and immutable from preparation through approval, initialization, state, audit, and launch. It does not special-case host GPU 1 or remap only at the final Docker command.

## Implementation

- Treat the requested `gpu_ids` as immutable host/launcher selectors.
- Derive TAO train/evaluate `container_gpu_ids` as dense zero-based ordinals.
- Record both namespaces in approval schema v3 and canonical state.
- Validate types, uniqueness, equal cardinality, density, and exact TAO-spec agreement during initialization.
- Revalidate both namespaces in the run audit.
- Keep Docker `--gpus device=...` selection on host IDs.
- Document host versus container-local semantics in IAA preflight.

Shortcut approaches intentionally avoided:

- no special case for `[1]` or for a particular GPU count;
- no modulo/subtraction heuristic;
- no mutation of the approved host allocation at launch time;
- no permissive coercion of malformed approval JSON.

## Regression coverage

Expanded `scripts/tests/test_iaa_deft_container.py` to execute real config preparation and state initialization for host devices `[1,3]`, prove TAO receives `[0,1]`, prove Docker retains `device=1,3`, and reject malformed approval namespaces and invalid launcher state.

## Verification

- `python3 -m pytest -q scripts/tests/test_iaa_deft_container.py` — **12 passed**
- `python3 -m pytest -q scripts/tests` — **265 passed, 2 skipped**
- `scripts/validate-skills.sh` — **passed**
- `git diff --check` — **passed**

Refreshed user-facing reproduction with the real IAA archives:

- Host allocation `[1]` remained Docker selector `device=1`.
- Generated TAO evaluation spec contained `[0]`.
- A real TAO 7.1 Docker container restricted to physical GPU 1 reported one CUDA device and successfully allocated on `cuda:0`.
- Initialized run audit reported `IN_PROGRESS` with no namespace error.

## Residual risks / limitations

Approval schema v3 intentionally makes the namespace distinction explicit. An in-progress run frozen to an older skill/runtime hash must resume with that exact old implementation or be recreated under the new approval contract; the workflow already enforces that immutable-runtime rule.
