### PR TITLE
[TAO-0000][CI] stamp: scan scripts/ so duplicated pins can't drift unnoticed

### DIFF
--- a/scripts/stamp_versions.py
+++ b/scripts/stamp_versions.py
@@ -28,6 +28,11 @@ Rules enforced:
     exempt (JSON cannot carry annotations; pins there are recorded artifacts,
     not templates). The 7.1.0 stray backlog is cleared: CI runs
     ``--check --strict-strays``, so a new unannotated pin fails the pipeline.
+  * Scan scope: ``skills/``, ``templates/``, and ``scripts/`` (so pins embedded
+    in CI helpers and test fixtures are covered too — a stale duplicate there is
+    exactly how a marked pin can drift unnoticed). The versions-key tooling
+    itself (``stamp_versions.py``, ``migrate-to-version-keys.py``) is skipped
+    because its docstrings document the marker format with example pins.
 
 versions.yaml is parsed with a minimal indentation-based reader (2-space
 indents, scalar leaves) so this script has no third-party dependencies and can
@@ -58,6 +63,12 @@ STRAY_WHEEL_RE = re.compile(r"nvidia-tao-[a-z-]+(?:\[[A-Za-z0-9_,-]+\])?==[A-Za-
 DOTTED_KEY_VALUE_RE = re.compile(r"^(\s*[A-Za-z_]+:\s*)([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)(\s*#.*)$")
 
 SCAN_EXTENSIONS = {".md", ".yaml", ".yml", ".sh", ".py", ".config", ".json", ".txt"}
+
+# The versions-key tooling documents the marker format with example image URIs
+# and example ``# versions-key:`` comments in its own docstrings. Those examples
+# are not live pins, so scanning them would raise spurious drift/stray reports —
+# skip these files by basename.
+SKIP_BASENAMES = {"stamp_versions.py", "migrate-to-version-keys.py"}
 
 
 def parse_versions(path: str) -> dict[str, str]:
@@ -94,6 +105,8 @@ def iter_skill_files(skills_dir: str):
     for root, dirs, files in os.walk(skills_dir):
         dirs[:] = [d for d in dirs if d != ".git"]
         for fname in files:
+            if fname in SKIP_BASENAMES:
+                continue
             if os.path.splitext(fname)[1] in SCAN_EXTENSIONS:
                 yield os.path.join(root, fname)
 
@@ -120,7 +133,7 @@ def main() -> int:
                     help="unannotated image/wheel pins are errors, not warnings")
     ap.add_argument("--versions-file", default="versions.yaml")
     ap.add_argument("--skills-dir", default="skills",
-                    help="primary tree to scan (templates/ is always scanned too when present)")
+                    help="primary tree to scan (templates/ and scripts/ are scanned too when present)")
     args = ap.parse_args()
 
     versions = parse_versions(args.versions_file)
@@ -132,7 +145,7 @@ def main() -> int:
     strays: list[str] = []
     stamped = 0
 
-    scan_dirs = [args.skills_dir] + (["templates"] if os.path.isdir("templates") else [])
+    scan_dirs = [args.skills_dir] + [d for d in ("templates", "scripts") if os.path.isdir(d)]
     all_files = [p for d in scan_dirs for p in iter_skill_files(d)]
     for path in sorted(all_files):
         try:

--- a/scripts/tests/test_resolve_tao_image.py
+++ b/scripts/tests/test_resolve_tao_image.py
@@ -18,7 +18,7 @@ resolve_tao_image = importlib.import_module("resolve_tao_image")
 resolve_tao_model = importlib.import_module("resolve_tao_model")
 
 
-COSMOS_RL_IMAGE = "nvcr.io/nvstaging/tao/tao-cosmos-rl:main-direct-train-no-cache-20260811-v1"
+COSMOS_RL_IMAGE = "nvcr.io/nvstaging/tao/tao-cosmos-rl:main-direct-train-no-cache-20260811-v1"  # versions-key: images.tao_toolkit.cosmos_rl
 
 
 def test_cosmos_nano_default_train_preserves_rl_image_contract():

--- a/scripts/tests/test_tao_job_record.py
+++ b/scripts/tests/test_tao_job_record.py
@@ -38,7 +38,7 @@ def state_dir(tmp_path, monkeypatch):
 def open_job(capsys, **overrides):
     argv = [
         "open", "--platform", "slurm",
-        "--image", "nvcr.io/nvidia/tao/tao-toolkit:6.26.3-pyt",
+        "--image", "nvcr.io/nvidia/tao/tao-toolkit:6.26.3-pyt",  # unpinned: test fixture
         "--network-arch", "dino", "--action", "train",
         "--storage-tier", "A",
         "--results-root", "/lustre/fsw/users/me/results",
@@ -89,7 +89,7 @@ def test_open_id_is_the_printed_handle_and_matches_pattern(capsys):
 
 
 def test_open_explicit_results_dir_used_verbatim(state_dir, capsys):
-    argv = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",
+    argv = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",  # unpinned: test fixture
             "--network-arch", "dino", "--action", "evaluate",
             "--storage-tier", "C", "--results-dir", "/data/out/run1"]
     assert jr.main(argv) == 0
@@ -98,7 +98,7 @@ def test_open_explicit_results_dir_used_verbatim(state_dir, capsys):
 
 
 def test_open_requires_exactly_one_results_arg(capsys):
-    base = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",
+    base = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",  # unpinned: test fixture
             "--network-arch", "d", "--action", "a", "--storage-tier", "C"]
     with pytest.raises(SystemExit):
         jr.main(base)  # neither
@@ -116,7 +116,7 @@ def test_open_never_overwrites_existing_record(state_dir, capsys, monkeypatch):
 
 
 def test_open_sanitizes_weird_arch_names(state_dir, capsys):
-    argv = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",
+    argv = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",  # unpinned: test fixture
             "--network-arch", "visual changenet!", "--action", "train",
             "--storage-tier", "C", "--results-dir", "/data/out"]
     assert jr.main(argv) == 0
@@ -253,7 +253,7 @@ def test_rt_out_of_pattern_secrets_redacted(state_dir, capsys):
 
 
 def test_rt_url_userinfo_redacted_in_results_dir(state_dir, capsys):
-    argv = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",
+    argv = ["open", "--platform", "docker", "--image", "nvcr.io/x/y:1",  # unpinned: test fixture
             "--network-arch", "dino", "--action", "train", "--storage-tier", "C",
             "--results-dir", "https://user:leakSECRETpw@host/bucket/out"]
     assert jr.main(argv) == 0
@@ -263,7 +263,7 @@ def test_rt_url_userinfo_redacted_in_results_dir(state_dir, capsys):
 
 
 def test_rt_legit_results_dir_with_credword_segment_untouched(state_dir, capsys):
-    argv = ["open", "--platform", "slurm", "--image", "nvcr.io/x/y:1",
+    argv = ["open", "--platform", "slurm", "--image", "nvcr.io/x/y:1",  # unpinned: test fixture
             "--network-arch", "dino", "--action", "train", "--storage-tier", "A",
             "--results-dir", "/lustre/exp/token=v1/keyframes/run"]
     assert jr.main(argv) == 0
@@ -339,7 +339,7 @@ def test_platform_input_is_normalized_not_rejected(capsys, state_dir, raw, canon
     # --platform=<raw> form: a raw value may start with '-' (argparse-safe).
     assert jr.main([
         "open", f"--platform={raw}",
-        "--image", "nvcr.io/nvidia/tao/tao-toolkit:6.26.3-pyt",
+        "--image", "nvcr.io/nvidia/tao/tao-toolkit:6.26.3-pyt",  # unpinned: test fixture
         "--network-arch", "dino", "--action", "train",
         "--storage-tier", "A", "--results-root", "/tmp/results",
     ]) == 0


### PR DESCRIPTION
## Why

`scripts/stamp_versions.py` only scanned `skills/` + `templates/`, so a versions.yaml image/wheel pin **duplicated as an unmarked literal under `scripts/`** was invisible to both the stamp fan-out and the `--check` drift guard. On `release/7.2.0` the build-13 `cosmos_rl` bump drifted exactly such a duplicate in `scripts/tests/test_resolve_tao_image.py`, which broke the three cosmos-rl unit tests and blocked unrelated PRs.

## What

- **Scan `scripts/`** in addition to `skills/` and `templates/`. Skip the versions-key tooling itself (`stamp_versions.py`, `migrate-to-version-keys.py`), whose docstrings document the marker format with example pins.
- **Mark the cosmos-rl test constant** with `# versions-key: images.tao_toolkit.cosmos_rl`, so it's now auto-managed like every other cosmos-rl site — a bump re-stamps it, so this drift can't recur.
- **Annotate deliberate test fixtures** in `test_tao_job_record.py` with `# unpinned: test fixture`.

## Verification

- `scripts/stamp_versions.py --check --strict-strays` → `OK … (0 stray warning(s))` over `skills/` + `templates/` + `scripts/`.
- `stamp` mode finds **no** drift on main (main is internally consistent); files compile; the cosmos-rl invariant holds (resolve == constant == versions.yaml).
- A new unmarked image/wheel pin anywhere in those trees now fails `--check --strict-strays`.

## Cherry-pick to `release/7.2.0`

Labeled `release/7.2.0` for cherry-pick after merge. **Note:** `release/7.2.0` additionally has a genuine latent drift that main does not — `scripts/ci/render_and_validate_templates.py` carries a marked `pyt` pin stuck at `7.1.0-pyt`. Once this lands on release, run `scripts/stamp_versions.py` there to re-stamp it (the broadened scan will otherwise flag it). The cosmos-rl constant was already realigned on `release/7.2.0` directly.