### PR TITLE
[TLT-5942][Bugfix] Align TAO 7.2 skill contracts with runtime

### DIFF
--- a/scripts/tests/test_dinov3_schema_drift.py
+++ b/scripts/tests/test_dinov3_schema_drift.py
@@ -148,25 +148,9 @@ def test_regenerated_contracts_match_committed(tao_core_dinov3_config, tmp_path)
         regenerated = json.loads(
             (scratch_model_dir / "schemas" / f"{action}.schema.json").read_text()
         )
-        committed_backbone = _backbone_properties(_load_committed_schema(action))
-        regenerated_backbone = _backbone_properties(regenerated)
-        for field in ("teacher_type", "student_type"):
-            assert regenerated_backbone[field]["enum"] == committed_backbone[field]["enum"], (
-                f"{action}.schema.json backbone options drifted from tao-core: re-run "
-                "scripts/generate_dataclass_schemas.py for tao-train-dinov3."
-            )
-            assert regenerated_backbone[field]["default"] == committed_backbone[field]["default"]
-
-        committed_model = _model_properties(_load_committed_schema(action))
-        regenerated_model = _model_properties(regenerated)
-        for field in ("lora", "preservation"):
-            assert _normalize_unordered_metadata(
-                regenerated_model[field]
-            ) == _normalize_unordered_metadata(committed_model[field]), (
-                f"{action}.schema.json model.{field} drifted from tao-core"
-            )
-        assert (
-            regenerated["properties"]["train"]["properties"]["log_every_n_steps"]
-            == _load_committed_schema(action)["properties"]["train"]["properties"]
-            ["log_every_n_steps"]
+        assert _normalize_unordered_metadata(
+            regenerated
+        ) == _normalize_unordered_metadata(_load_committed_schema(action)), (
+            f"{action}.schema.json drifted from verbatim tao-core generator output: "
+            "re-run scripts/generate_dataclass_schemas.py for tao-train-dinov3."
         )

--- a/scripts/tests/test_dinov3_schema_drift.py
+++ b/scripts/tests/test_dinov3_schema_drift.py
@@ -7,11 +7,10 @@ The committed ``skills/models/tao-train-dinov3/schemas/*.schema.json`` files are
 generated from the TAO Core dataclass config (``nvidia_tao_core.config.dinov3``)
 by ``scripts/generate_dataclass_schemas.py``. Guarded invariants:
 
-1. The backbone enums in the committed schemas list every backbone TAO's DINOv3
-   supports (always checked, stdlib-only — runs in the validate-skills CI job).
-2. When a tao-core checkout is importable, it must carry the DINOv3 config with
-   the same backbone set, and regenerating the schemas from it must reproduce
-   the committed backbone options (skipped when tao-core is absent).
+1. The committed schemas expose the complete backbone, LoRA, preservation, and
+   logging-cadence contracts (always checked, stdlib-only).
+2. When a tao-core checkout is importable, regenerating from it must reproduce
+   those committed contracts (skipped when tao-core is absent).
 
 Note: a full byte-compare against a fresh regeneration is deliberately NOT done —
 ``dataclass2json_converter`` emits ``automl_disabled_parameters``/``popular`` in
@@ -33,14 +32,49 @@ ACTIONS = ("convert", "export", "inference", "train")
 # Must match SUPPORTED_BACKBONES in nvidia_tao_core.config.dinov3.default_config
 # (mirrored from nvidia_tao_pytorch.config.dinov3.default_config).
 EXPECTED_BACKBONES = ["vit_s", "vit_s_plus", "vit_b", "vit_l", "vit_h_plus", "vit_7b"]
+EXPECTED_LORA_DEFAULTS = {
+    "enable": False,
+    "rank": 8,
+    "alpha": 16.0,
+    "dropout": 0.05,
+    "target_modules": ["qkv", "proj"],
+    "num_last_blocks": 0,
+}
+EXPECTED_PRESERVATION_DEFAULTS = {
+    "enable": False,
+    "cls_mse_weight": 0.05,
+    "cls_cosine_weight": 0.05,
+}
 
 
 def _backbone_properties(schema):
     return schema["properties"]["model"]["properties"]["backbone"]["properties"]
 
 
+def _model_properties(schema):
+    return schema["properties"]["model"]["properties"]
+
+
 def _load_committed_schema(action):
     return json.loads((MODEL_DIR / "schemas" / f"{action}.schema.json").read_text())
+
+
+def _normalize_unordered_metadata(value):
+    """Sort generator metadata whose source is a Python set."""
+    if isinstance(value, dict):
+        return {
+            key: (
+                sorted(item)
+                if key in {"popular", "automl_disabled_parameters"}
+                and isinstance(item, list)
+                and all(isinstance(entry, str) for entry in item)
+                else _normalize_unordered_metadata(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_normalize_unordered_metadata(item) for item in value]
+    return value
 
 
 @pytest.mark.parametrize("action", ACTIONS)
@@ -51,6 +85,23 @@ def test_committed_backbone_enums(action):
     assert backbone["student_type"]["enum"] == EXPECTED_BACKBONES
     assert backbone["teacher_type"]["default"] == "vit_b"
     assert backbone["student_type"]["default"] == "vit_b"
+
+
+@pytest.mark.parametrize("action", ACTIONS)
+def test_committed_adaptation_and_logging_contracts(action):
+    """Every action schema carries the shared DINOv3 model/train contract."""
+    schema = _load_committed_schema(action)
+    model = _model_properties(schema)
+    assert model["lora"]["default"] == EXPECTED_LORA_DEFAULTS
+    assert model["preservation"]["default"] == EXPECTED_PRESERVATION_DEFAULTS
+    assert "disabled" not in model["lora"]["description"].lower()
+    assert schema["properties"]["train"]["properties"]["log_every_n_steps"] == {
+        "default": 1,
+        "description": "Number of training steps between logger updates.",
+        "minimum": 1,
+        "title": "logging interval",
+        "type": "int",
+    }
 
 
 @pytest.fixture(scope="module")
@@ -71,8 +122,8 @@ def test_tao_core_backbones_match(tao_core_dinov3_config):
     assert tao_core_dinov3_config.SUPPORTED_BACKBONES == EXPECTED_BACKBONES
 
 
-def test_regenerated_backbone_enums_match_committed(tao_core_dinov3_config, tmp_path):
-    """Schemas regenerated from tao-core carry the committed backbone options."""
+def test_regenerated_contracts_match_committed(tao_core_dinov3_config, tmp_path):
+    """Bug-critical schema contracts exactly match a tao-core regeneration."""
     sys.path.insert(0, str(SCRIPTS_DIR))
     try:
         generator = importlib.import_module("generate_dataclass_schemas")
@@ -105,3 +156,17 @@ def test_regenerated_backbone_enums_match_committed(tao_core_dinov3_config, tmp_
                 "scripts/generate_dataclass_schemas.py for tao-train-dinov3."
             )
             assert regenerated_backbone[field]["default"] == committed_backbone[field]["default"]
+
+        committed_model = _model_properties(_load_committed_schema(action))
+        regenerated_model = _model_properties(regenerated)
+        for field in ("lora", "preservation"):
+            assert _normalize_unordered_metadata(
+                regenerated_model[field]
+            ) == _normalize_unordered_metadata(committed_model[field]), (
+                f"{action}.schema.json model.{field} drifted from tao-core"
+            )
+        assert (
+            regenerated["properties"]["train"]["properties"]["log_every_n_steps"]
+            == _load_committed_schema(action)["properties"]["train"]["properties"]
+            ["log_every_n_steps"]
+        )

--- a/scripts/tests/test_visual_changenet_release_contracts.py
+++ b/scripts/tests/test_visual_changenet_release_contracts.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Release-contract guards for Visual ChangeNet skill workflows."""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODEL_ROOT = REPO_ROOT / "skills" / "models" / "tao-train-visual-changenet"
+DEFT_ROOT = REPO_ROOT / "skills" / "applications" / "tao-run-deft-aoi"
+DINOV3_VARIANTS = {
+    "vit_small_dinov3",
+    "vit_small_plus_dinov3",
+    "vit_base_dinov3",
+    "vit_large_dinov3",
+    "vit_huge_plus_dinov3",
+    "vit_7b_dinov3",
+}
+
+
+def test_dinov3_workflows_document_every_supported_variant():
+    model_reference = (MODEL_ROOT / "references" / "dinov3-backbones.md").read_text()
+    deft_reference = (DEFT_ROOT / "references" / "visual-changenet.md").read_text()
+
+    for variant in DINOV3_VARIANTS:
+        assert variant in model_reference
+        assert variant in deft_reference
+    for required in ("freeze_backbone: true", "HF_TOKEN", "pretrained_backbone_path"):
+        assert required in model_reference
+        assert required in deft_reference
+
+
+def test_far_checkpoint_recipe_uses_checkpointer_contract():
+    tuning = (MODEL_ROOT / "references" / "tuning-parameters.md").read_text()
+    for required in (
+        "enable_topk: true",
+        "monitor: val_far",
+        "mode: min",
+        "replace_periodic: false",
+        "optim.monitor_name",
+    ):
+        assert required in tuning
+
+
+def test_downstream_checkpoint_defaults_are_explicit_inputs():
+    templates = (
+        MODEL_ROOT / "references" / "spec_template_train.yaml",
+        DEFT_ROOT / "references" / "baseline_spec.yaml",
+    )
+    for template in templates:
+        spec = yaml.safe_load(template.read_text())
+        assert all(spec[action]["checkpoint"] == "" for action in ("evaluate", "inference", "export"))

--- a/scripts/tests/test_visual_changenet_release_contracts.py
+++ b/scripts/tests/test_visual_changenet_release_contracts.py
@@ -52,4 +52,13 @@ def test_downstream_checkpoint_defaults_are_explicit_inputs():
     )
     for template in templates:
         spec = yaml.safe_load(template.read_text())
-        assert all(spec[action]["checkpoint"] == "" for action in ("evaluate", "inference", "export"))
+        assert all(
+            spec[action]["checkpoint"] == ""
+            for action in ("evaluate", "inference", "export")
+        )
+
+    deft_spec = yaml.safe_load(
+        (DEFT_ROOT / "references" / "baseline_spec.yaml").read_text()
+    )
+    assert deft_spec["evaluate"]["trt_engine"] == ""
+    assert deft_spec["inference"]["trt_engine"] == ""

--- a/skills/applications/tao-run-deft-aoi/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi/SKILL.md
@@ -104,7 +104,13 @@ Do not use this skill for a single standalone TAO training run, one-off inferenc
 
 ## Base Model
 
-The loop operates on **NVIDIA TAO Visual ChangeNet** classify with the **NVIDIA C-RADIOv2-B** backbone, fine-tuned end-to-end. The architecture is defined in `specs/baseline_spec.yaml` — that file is the source of truth. Pretrained weights originate from HuggingFace (`HF_TOKEN` required for networked fetches); `NGC_KEY` gates container pulls. ChangeNet backbone resolution and the staged-file/HuggingFace-download fallback for `model.backbone.pretrained_backbone_path` are owned by `references/visual-changenet.md`; the spec itself must always point to a local mounted file, never a URL. SigLIP for k-NN mining is owned by `references/tao-mine-aoi-images.md`. AnomalyGen-side checkpoints (Cosmos-Predict2, T5, NVDINOV2, C-RADIO-V3, DINOv2-large, SAM2, Qwen3-VL — ~22 GB for 2B-only, ~140 GB with 14B + T5-11b) live under `<workspace>/augmentation/anomalygen/base_checkpoints/`. Network-mode rules and staged-asset requirements are in `references/air-gap.md`; model-specific bootstrap details are in `references/paidf-anomalygen.md`.
+The loop uses **NVIDIA TAO Visual ChangeNet** classify with either end-to-end
+C-RADIOv2-B or a frozen DINOv3 backbone. `specs/baseline_spec.yaml` defines the
+architecture. Backbone variants, staging, `HF_TOKEN`, and mount rules are owned
+by `references/visual-changenet.md`; the spec always points to a local mounted
+file. `NGC_KEY` gates container pulls. SigLIP mining is owned by
+`references/tao-mine-aoi-images.md`; AnomalyGen assets and network/air-gap rules
+are owned by `references/paidf-anomalygen.md` and `references/air-gap.md`.
 
 ## Train AutoML Policy
 

--- a/skills/applications/tao-run-deft-aoi/references/baseline_spec.yaml
+++ b/skills/applications/tao-run-deft-aoi/references/baseline_spec.yaml
@@ -113,14 +113,14 @@ dataset:
       augment: True
     num_classes: 2
 evaluate:
-  # The loop discovers a successful train artifact and passes its explicit
-  # container path. Never derive this from the action-local results_dir.
+  # The loop discovers successful artifacts and passes explicit container
+  # paths. Never derive them from the action-local results_dir.
   checkpoint: ''
-  trt_engine: "${results_dir}/gen_trt_engine/changenet-classify.trt"
+  trt_engine: ''
   batch_size: ${dataset.classify.batch_size}
 inference:
   checkpoint: ''
-  trt_engine: "${results_dir}/gen_trt_engine/changenet-classify.trt"
+  trt_engine: ''
   batch_size: ${dataset.classify.batch_size}
 export:
   gpu_id: 0

--- a/skills/applications/tao-run-deft-aoi/references/baseline_spec.yaml
+++ b/skills/applications/tao-run-deft-aoi/references/baseline_spec.yaml
@@ -113,16 +113,18 @@ dataset:
       augment: True
     num_classes: 2
 evaluate:
-  checkpoint: "${results_dir}/train/changenet_classify.pth"
+  # The loop discovers a successful train artifact and passes its explicit
+  # container path. Never derive this from the action-local results_dir.
+  checkpoint: ''
   trt_engine: "${results_dir}/gen_trt_engine/changenet-classify.trt"
   batch_size: ${dataset.classify.batch_size}
 inference:
-  checkpoint: "${results_dir}/train/changenet_model_classify_latest.pth"
+  checkpoint: ''
   trt_engine: "${results_dir}/gen_trt_engine/changenet-classify.trt"
   batch_size: ${dataset.classify.batch_size}
 export:
   gpu_id: 0
-  checkpoint: "${results_dir}/train/changenet_classify.pth"
+  checkpoint: ''
   onnx_file: "${results_dir}/export/changenet-classify.onnx"
   input_width: 224
   input_height: 224

--- a/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
+++ b/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
@@ -68,7 +68,7 @@ spec, then:
 - Setting `inference.checkpoint` to the best checkpoint
 - Setting `model.classify.eval_margin` to the evaluator-selected threshold when one exists; otherwise retaining the training spec value
 - Disabling augmentation (`augmentation_config.augment: false`)
-- Adding a stub `train.classify.loss` (TAO's `load_from_checkpoint` rebuilds the criterion and asserts on the loss/difference_module pairing)
+- Omitting the training-only `train` subtree
 
 The consumer sets four things and runs:
 
@@ -144,10 +144,9 @@ config verbatim, but if you build an inference spec by hand, watch out:
    set to `.png`. Dataloader finds zero rows; predict loop runs over 0 batches;
    no error. Verify `image_ext` matches actual files on disk.
 
-4. **`loss` / `difference_module` pair (assertion).** Contrastive loss requires
-   `difference_module: euclidean`. CE loss works with either. The training spec
-   already paired them correctly — copy both fields together, never one without
-   the other.
+4. **Training-only keys copied into inference.** Do not carry the `train`
+   subtree into a hand-authored inference spec. The model architecture determines
+   the checkpoint-compatible criterion for non-training actions.
 
 ## When to Re-Run
 

--- a/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
+++ b/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
@@ -68,7 +68,10 @@ spec, then:
 - Setting `inference.checkpoint` to the best checkpoint
 - Setting `model.classify.eval_margin` to the evaluator-selected threshold when one exists; otherwise retaining the training spec value
 - Disabling augmentation (`augmentation_config.augment: false`)
-- Omitting the training-only `train` subtree
+- Carrying only `train.classify.loss` as a compatibility stub for the pinned
+  TAO 7.1 image. It must match the checkpoint's training spec. TAO 7.2 images
+  containing NVIDIA-TAO/tao-pytorch#107 derive the non-training criterion from
+  the model architecture and no longer require this stub.
 
 The consumer sets four things and runs:
 
@@ -144,9 +147,11 @@ config verbatim, but if you build an inference spec by hand, watch out:
    set to `.png`. Dataloader finds zero rows; predict loop runs over 0 batches;
    no error. Verify `image_ext` matches actual files on disk.
 
-4. **Training-only keys copied into inference.** Do not carry the `train`
-   subtree into a hand-authored inference spec. The model architecture determines
-   the checkpoint-compatible criterion for non-training actions.
+4. **`loss` / `difference_module` pair (assertion on the pinned TAO 7.1 image).**
+   Contrastive loss requires `difference_module: euclidean`; CE loss works with
+   either. Copy `train.classify.loss` from the training spec until the documented
+   image baseline includes NVIDIA-TAO/tao-pytorch#107. Do not copy other
+   training-only keys.
 
 ## When to Re-Run
 

--- a/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
+++ b/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
@@ -76,9 +76,9 @@ Before every train launch, validate these coupled spec invariants:
   `epoch 1` must also lower `checkpoint_interval`; otherwise TAO aborts before
   the first epoch.
 - Derive inference/evaluate specs from the exact training spec. Preserve the
-  model/loss block, but set `dataset.classify.augmentation_config.augment=false`,
-  then change only task paths/checkpoint/results overrides. A loss/difference-
-  module mismatch can load the checkpoint and then fail at criterion construction.
+  model architecture, set `dataset.classify.augmentation_config.augment=false`,
+  and change only task paths/checkpoint/results overrides. Non-train specs do
+  not need `train.classify.loss`.
 - Use the underlying skill's documented `visual_changenet <task> -e <spec>`
   entrypoint. Do not switch to direct package-module/Hydra commands after an
   error; their config-path semantics differ.
@@ -122,6 +122,14 @@ When deriving `iter${N}_spec.yaml` from `baseline_spec.yaml`, **only `train_data
 A bulk `sed 's|/data/datasets/NV_PCB_Siamese/images|/data/workspace|g'` on the spec catches all four and breaks the latter three. Edit `train_dataset.images_dir` surgically.
 
 ## Two-Checkpoint Compare
+
+The baseline template intentionally leaves all downstream checkpoint fields
+empty. After a successful train, discover the concrete `model_epoch_*_step_*.pth`
+files and the `changenet_model_classify_latest.pth` symlink under that
+iteration's `train/` directory. Pass the selected checkpoint as an explicit
+container path to inference, evaluate, or export. Never use
+`${results_dir}/train/...`: Hydra rebases `${results_dir}` to the current
+action's output directory.
 
 Run inference on both the best-val checkpoint (lowest `val_loss`) and the
 latest checkpoint (highest epoch). `val_loss` and the customer's deployment
@@ -236,6 +244,35 @@ model:
 ```
 
 If `HF_TOKEN` is unset or the workspace already has a staged file, Pre-Flight uses the staged file as-is and skips the download. If neither is available, Pre-Flight **hard stops** — there is no working URL fallback in this TAO version, so silently falling through would just produce the FileNotFoundError above after the container starts.
+
+### Frozen DINOv3 profiles
+
+DEFT supports `vit_small_dinov3`, `vit_small_plus_dinov3`,
+`vit_base_dinov3`, `vit_large_dinov3`, `vit_huge_plus_dinov3`, and
+`vit_7b_dinov3`. The baseline spec must use the same type and set
+`model.backbone.freeze_backbone: true`:
+
+```yaml
+model:
+  backbone:
+    type: vit_large_dinov3
+    freeze_backbone: true
+    pretrained_backbone_path: ''
+```
+
+In network mode, accept the DINOv3 license and export `HF_TOKEN`; Pre-Flight
+then stages the matching `timm/vit_*_patch16_dinov3.lvd1689m` file with:
+
+```bash
+STAGED=$(<skill_root>/scripts/deft_python.sh \
+  <skill_root>/scripts/stage_backbone.py \
+  --workspace <workspace> --backbone-type vit_large_dinov3)
+BACKBONE_CONTAINER_PATH="/data/pretrained_models/$(basename "$STAGED")"
+```
+
+Pre-Flight rewrites `pretrained_backbone_path` to that container path and uses
+the same mount for train, evaluate, and inference. In air-gap mode, pre-stage
+the exact profile file; the helper rejects a missing or mismatched checkpoint.
 
 ## Label case rule (CSV assembly)
 

--- a/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
+++ b/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
@@ -77,8 +77,10 @@ Before every train launch, validate these coupled spec invariants:
   the first epoch.
 - Derive inference/evaluate specs from the exact training spec. Preserve the
   model architecture, set `dataset.classify.augmentation_config.augment=false`,
-  and change only task paths/checkpoint/results overrides. Non-train specs do
-  not need `train.classify.loss`.
+  and change only task paths/checkpoint/results overrides. Keep only the
+  matching `train.classify.loss` compatibility stub while the skill baseline
+  remains TAO 7.1; TAO 7.2 images containing NVIDIA-TAO/tao-pytorch#107 no
+  longer require it.
 - Use the underlying skill's documented `visual_changenet <task> -e <spec>`
   entrypoint. Do not switch to direct package-module/Hydra commands after an
   error; their config-path semantics differ.

--- a/skills/applications/tao-run-deft-aoi/scripts/prepare_inference_spec.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/prepare_inference_spec.py
@@ -86,9 +86,10 @@ def _build_inference_spec(
 
     Strips train/evaluate/export blocks. Keeps model + dataset architecture
     verbatim so backbone, lighting layout, image size, difference module, and
-    concat type all match the checkpoint. Non-training actions derive their
-    checkpoint-compatible criterion from the model architecture, so no
-    ``train`` subtree is carried into the inference handoff.
+    concat type all match the checkpoint. The currently pinned TAO 7.1 runtime
+    still rebuilds its criterion during non-training actions, so carry only the
+    matching ``train.classify.loss`` compatibility stub. TAO 7.2 runtimes that
+    include NVIDIA-TAO/tao-pytorch#107 no longer require it.
 
     The ``inference.checkpoint`` path is the in-container mount point, not the
     host path — consumers mount ``best_model.json["checkpoint"]`` (host) to
@@ -100,6 +101,17 @@ def _build_inference_spec(
         "encryption_key": train_spec.get("encryption_key", "tlt_encode"),
         "task": train_spec.get("task", "classify"),
         "results_dir": "",  # CONSUMER: override with your output dir
+        # Required by the pinned TAO 7.1 runtime. Remove after the documented
+        # baseline includes NVIDIA-TAO/tao-pytorch#107.
+        "train": {
+            "classify": {
+                "loss": (
+                    train_spec.get("train", {})
+                    .get("classify", {})
+                    .get("loss", "ce")
+                ),
+            },
+        },
         "model": deepcopy(train_spec["model"]),
         "dataset": {"classify": deepcopy(train_spec["dataset"]["classify"])},
         "inference": {

--- a/skills/applications/tao-run-deft-aoi/scripts/prepare_inference_spec.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/prepare_inference_spec.py
@@ -86,10 +86,9 @@ def _build_inference_spec(
 
     Strips train/evaluate/export blocks. Keeps model + dataset architecture
     verbatim so backbone, lighting layout, image size, difference module, and
-    concat type all match the checkpoint. Adds a ``train.classify.loss`` stub
-    because TAO's PL classifier rebuilds its criterion on load and asserts the
-    loss/difference_module pairing — without this stub, load_from_checkpoint
-    raises before inference ever starts.
+    concat type all match the checkpoint. Non-training actions derive their
+    checkpoint-compatible criterion from the model architecture, so no
+    ``train`` subtree is carried into the inference handoff.
 
     The ``inference.checkpoint`` path is the in-container mount point, not the
     host path — consumers mount ``best_model.json["checkpoint"]`` (host) to
@@ -101,12 +100,6 @@ def _build_inference_spec(
         "encryption_key": train_spec.get("encryption_key", "tlt_encode"),
         "task": train_spec.get("task", "classify"),
         "results_dir": "",  # CONSUMER: override with your output dir
-        # Stub required by TAO's load_from_checkpoint criterion check.
-        "train": {
-            "classify": {
-                "loss": train_spec.get("train", {}).get("classify", {}).get("loss", "ce"),
-            },
-        },
         "model": deepcopy(train_spec["model"]),
         "dataset": {"classify": deepcopy(train_spec["dataset"]["classify"])},
         "inference": {

--- a/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 from types import SimpleNamespace
 
+import yaml
 
 SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPTS = SKILL_ROOT / "scripts"
@@ -96,6 +97,14 @@ class ReportRenderingTests(unittest.TestCase):
                 "c_radio_v2_vit_base_patch16_224",
             )
             self.assertFalse(handoff["backbone_frozen"])
+            inference_spec = yaml.safe_load(
+                (results / "best_model_inference_spec.yaml").read_text()
+            )
+            self.assertNotIn("train", inference_spec)
+            self.assertEqual(
+                inference_spec["inference"]["checkpoint"],
+                prepare_inference_spec.CHECKPOINT_MOUNT,
+            )
 
     def test_airgap_guard_blocks_install_and_forces_no_pull(self) -> None:
         policy = {"network_mode": "airgap"}

--- a/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_changenet_report_rendering.py
@@ -100,7 +100,7 @@ class ReportRenderingTests(unittest.TestCase):
             inference_spec = yaml.safe_load(
                 (results / "best_model_inference_spec.yaml").read_text()
             )
-            self.assertNotIn("train", inference_spec)
+            self.assertEqual(inference_spec["train"]["classify"]["loss"], "ce")
             self.assertEqual(
                 inference_spec["inference"]["checkpoint"],
                 prepare_inference_spec.CHECKPOINT_MOUNT,

--- a/skills/models/tao-train-dinov3/SKILL.md
+++ b/skills/models/tao-train-dinov3/SKILL.md
@@ -163,6 +163,9 @@ For `convert`, `export`, and `inference`, copy the training-time backbone config
 - `model.backbone.rope_theta` controls the rotary frequency base. It defaults to `100.0` and is tunable; changing it alters positional encoding, so evaluate the resulting checkpoint for the intended task.
 - `model.centering_method` supports `sinkhorn` and `softmax`.
 - `model.gram.*` controls optional Gram anchoring.
+- `model.lora.*` enables parameter-efficient continual pre-training. The default targets the attention `qkv` and `proj` projections; `num_last_blocks: 0` adapts every transformer block.
+- `model.preservation.*` adds CLS-token MSE and cosine losses against the frozen anchor teacher. It is recommended with LoRA when global embedding quality matters.
+- `train.log_every_n_steps` controls step-level loss visibility and defaults to `1`, so short smoke runs emit component and preservation losses.
 - `train.precision` defaults to `16-mixed`; choose precision based on hardware and measured quality.
 - `train.use_custom_attention: false` uses native attention when custom attention is unavailable.
 - Crop and export dimensions need to be divisible by `model.backbone.patch_size`.

--- a/skills/models/tao-train-dinov3/references/dinov3-recipes.md
+++ b/skills/models/tao-train-dinov3/references/dinov3-recipes.md
@@ -27,6 +27,36 @@ Keep evaluation samples separate from the unlabeled training corpus when possibl
 
 Compare the high-resolution result with a relevant base-resolution checkpoint before selecting a model.
 
+## LoRA and representation preservation
+
+LoRA freezes the backbone's base weights and adapts low-rank projections while
+the DINO/iBOT heads remain trainable. Start with the default attention targets:
+
+```yaml
+model:
+  lora:
+    enable: true
+    rank: 8
+    alpha: 16.0
+    dropout: 0.05
+    target_modules: [qkv, proj]
+    num_last_blocks: 0
+  preservation:
+    enable: true
+    cls_mse_weight: 0.05
+    cls_cosine_weight: 0.05
+train:
+  log_every_n_steps: 1
+```
+
+`num_last_blocks: 0` adapts every block; a positive value limits adapters to
+the final N blocks. The preservation terms protect global CLS geometry and are
+complementary to Gram anchoring, which protects patch-token geometry. Compare
+downstream metrics before changing the default loss weights.
+
+Component losses are logged per step. `log_every_n_steps: 1` makes them visible
+even when a smoke run has fewer than 50 optimizer steps.
+
 ## Checkpoint files
 
 | File | Typical use |

--- a/skills/models/tao-train-dinov3/references/spec_template_convert.yaml
+++ b/skills/models/tao-train-dinov3/references/spec_template_convert.yaml
@@ -30,6 +30,17 @@ model:
     teacher_scale: 1.0
   lora:
     enable: false
+    rank: 8
+    alpha: 16.0
+    dropout: 0.05
+    target_modules:
+    - qkv
+    - proj
+    num_last_blocks: 0
+  preservation:
+    enable: false
+    cls_mse_weight: 0.05
+    cls_cosine_weight: 0.05
 dataset:
   train_dataset:
     images_dir: ''
@@ -69,6 +80,7 @@ train:
   precision: 16-mixed
   use_custom_attention: true
   distributed_strategy: auto
+  log_every_n_steps: 1
   schedulers:
     learning_rate:
       val_base: 5.0e-05

--- a/skills/models/tao-train-dinov3/references/spec_template_export.yaml
+++ b/skills/models/tao-train-dinov3/references/spec_template_export.yaml
@@ -30,6 +30,17 @@ model:
     teacher_scale: 1.0
   lora:
     enable: false
+    rank: 8
+    alpha: 16.0
+    dropout: 0.05
+    target_modules:
+    - qkv
+    - proj
+    num_last_blocks: 0
+  preservation:
+    enable: false
+    cls_mse_weight: 0.05
+    cls_cosine_weight: 0.05
 dataset:
   train_dataset:
     images_dir: ''
@@ -71,6 +82,7 @@ train:
   precision: 16-mixed
   use_custom_attention: true
   distributed_strategy: auto
+  log_every_n_steps: 1
   schedulers:
     learning_rate:
       val_base: 5.0e-05

--- a/skills/models/tao-train-dinov3/references/spec_template_inference.yaml
+++ b/skills/models/tao-train-dinov3/references/spec_template_inference.yaml
@@ -29,6 +29,17 @@ model:
     teacher_scale: 1.0
   lora:
     enable: false
+    rank: 8
+    alpha: 16.0
+    dropout: 0.05
+    target_modules:
+    - qkv
+    - proj
+    num_last_blocks: 0
+  preservation:
+    enable: false
+    cls_mse_weight: 0.05
+    cls_cosine_weight: 0.05
 dataset:
   train_dataset:
     images_dir: ''
@@ -70,6 +81,7 @@ train:
   precision: 16-mixed
   use_custom_attention: true
   distributed_strategy: auto
+  log_every_n_steps: 1
   schedulers:
     learning_rate:
       val_base: 5.0e-05

--- a/skills/models/tao-train-dinov3/references/spec_template_train.yaml
+++ b/skills/models/tao-train-dinov3/references/spec_template_train.yaml
@@ -1,7 +1,7 @@
 # DINOv3 continual pre-training example (base resolution; Gram disabled).
 # Mirrors tao-pytorch nvidia_tao_pytorch/ssl/dinov3/experiment_specs/train_dinov3_vitb.yaml.
-# Schema source of truth: schemas/train.schema.json, generated from the tao-pytorch
-# dinov3 dataclasses (nvidia_tao_pytorch/config/dinov3/default_config.py).
+# Schema source of truth: schemas/train.schema.json, generated from the tao-core
+# DINOv3 dataclasses (nvidia_tao_core/config/dinov3/default_config.py).
 encryption_key: ''
 results_dir: ''
 wandb:
@@ -49,6 +49,19 @@ model:
     teacher_scale: 1.0
   lora:
     enable: false
+    rank: 8
+    alpha: 16.0
+    dropout: 0.05
+    target_modules:
+    - qkv
+    - proj
+    # 0 adapts every transformer block; otherwise adapt only the last N blocks.
+    num_last_blocks: 0
+  preservation:
+    # Preserve the frozen anchor teacher's global CLS representation.
+    enable: false
+    cls_mse_weight: 0.05
+    cls_cosine_weight: 0.05
 dataset:
   train_dataset:
     images_dir: ''
@@ -94,6 +107,9 @@ train:
   precision: 16-mixed
   use_custom_attention: true
   distributed_strategy: auto
+  # Component and preservation losses are step-level metrics. Keep this at 1 for
+  # short smoke runs so every loss is visible in TensorBoard.
+  log_every_n_steps: 1
   schedulers:
     # LR auto-scales with global batch: 5e-5 * sqrt(global_batch / 1024).
     # Adjust warm_up_steps and freeze_steps for the planned training length.

--- a/skills/models/tao-train-dinov3/schemas/convert.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/convert.schema.json
@@ -1,43 +1,43 @@
 {
   "automl_default_parameters": [
-    "dataset.batch_size",
-    "dataset.workers"
+    "dataset.workers",
+    "dataset.batch_size"
   ],
   "automl_disabled_parameters": [
-    "gen_trt_engine",
-    "gen_trt_engine.tensorrt",
-    "train.schedulers.momentum",
-    "inference.gpu_ids",
+    "dataset.train_dataset",
+    "wandb.tags",
+    "inference",
+    "train.cudnn",
+    "train.gpu_ids",
+    "train.schedulers",
+    "model",
+    "model.head",
     "model.backbone",
     "dataset",
-    "wandb",
-    "dataset.train_dataset",
-    "train.schedulers",
-    "train.schedulers.weight_decay",
-    "model.gram",
-    "train.schedulers.teacher_temperature",
-    "wandb.tags",
-    "train.schedulers.learning_rate",
-    "convert",
-    "dataset.transform",
-    "train.gpu_ids",
-    "export",
     "train.checkpointer",
-    "train.schedulers.last_layer_learning_rate",
-    "model.lora",
-    "train.cudnn",
-    "model.head",
-    "train",
-    "model.distill",
-    "dataset.test_dataset",
-    "gen_trt_engine.tensorrt.layers_precision",
-    "model",
-    "dataset.transform.local_crops_scale",
     "train.optim",
-    "inference",
-    "dataset.transform.global_crops_scale",
+    "model.gram",
+    "gen_trt_engine",
+    "model.preservation",
+    "train.schedulers.weight_decay",
     "model.lora.target_modules",
-    "model.preservation"
+    "train.schedulers.last_layer_learning_rate",
+    "dataset.transform.global_crops_scale",
+    "train.schedulers.learning_rate",
+    "wandb",
+    "model.distill",
+    "train",
+    "train.schedulers.teacher_temperature",
+    "inference.gpu_ids",
+    "dataset.transform",
+    "train.schedulers.momentum",
+    "gen_trt_engine.tensorrt.layers_precision",
+    "dataset.transform.local_crops_scale",
+    "gen_trt_engine.tensorrt",
+    "convert",
+    "dataset.test_dataset",
+    "model.lora",
+    "export"
   ],
   "default": {
     "convert": {
@@ -126,10 +126,9 @@
       "checkpoint_interval_unit": "epoch",
       "checkpointer": {
         "auto_insert_metric_name": false,
-        "dirpath": "",
         "enable_topk": false,
         "filename": "model_best_{epoch:03d}",
-        "monitor": "",
+        "replace_periodic": false,
         "save_top_k": 1
       },
       "clip_grad_norm": 3.0,
@@ -142,6 +141,7 @@
         0
       ],
       "layerwise_decay": 1.0,
+      "log_every_n_steps": 1,
       "num_epochs": 10,
       "num_gpus": 1,
       "num_nodes": 1,
@@ -150,22 +150,21 @@
         "optim": "adamw"
       },
       "precision": "16-mixed",
-      "pretrained_model_path": "",
       "results_dir": "",
       "resume_training_checkpoint_path": "",
       "schedulers": {
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -193,8 +192,7 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1,
-      "log_every_n_steps": 1
+      "validation_interval": 1
     },
     "wandb": {
       "enable": true,
@@ -311,15 +309,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -371,9 +369,9 @@
       },
       "description": "Configurable parameters to convert an SSL backbone to the backbone_v2 (timm) layout.",
       "popular": [
-        "checkpoint",
         "output_path",
-        "source"
+        "source",
+        "checkpoint"
       ],
       "properties": {
         "checkpoint": {
@@ -465,6 +463,7 @@
           "automl_enabled": true,
           "default": 4,
           "description": "The batch size for training",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -486,7 +485,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -503,7 +502,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -533,11 +532,11 @@
           },
           "description": "Configuration parameters for data transformation",
           "popular": [
-            "local_crops_size",
-            "global_crops_size",
-            "global_crops_scale",
-            "local_crops_scale",
             "n_global_crops",
+            "global_crops_size",
+            "local_crops_scale",
+            "global_crops_scale",
+            "local_crops_size",
             "n_local_crops"
           ],
           "properties": {
@@ -555,6 +554,7 @@
             "global_crops_size": {
               "default": 256,
               "description": "Size of global crops for DINOv3 training.",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Global Crops Size",
@@ -574,6 +574,7 @@
             "local_crops_size": {
               "default": 112,
               "description": "Size of local crops (multiple of patch 16)",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Local Crops Size",
@@ -582,6 +583,7 @@
             "n_global_crops": {
               "default": 2,
               "description": "Number of global crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Global Crops",
@@ -590,6 +592,7 @@
             "n_local_crops": {
               "default": 8,
               "description": "Number of local crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Local Crops",
@@ -603,6 +606,7 @@
           "automl_enabled": true,
           "default": 8,
           "description": "The number of parallel workers processing data",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -676,12 +680,12 @@
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
       "popular": [
         "backbone",
-        "centering_method",
-        "gram",
+        "lora",
         "distill",
         "head",
-        "lora",
-        "preservation"
+        "preservation",
+        "centering_method",
+        "gram"
       ],
       "properties": {
         "backbone": {
@@ -697,11 +701,11 @@
           },
           "description": "Configuration for the DINOv3 backbone",
           "popular": [
+            "patch_size",
+            "rope_theta",
             "img_size",
             "num_register_tokens",
-            "drop_path_rate",
-            "rope_theta",
-            "patch_size"
+            "drop_path_rate"
           ],
           "properties": {
             "drop_path_rate": {
@@ -726,6 +730,7 @@
             "num_register_tokens": {
               "default": 4,
               "description": "Number of register tokens (DINOv3 ViT-B uses 4)",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "num register tokens",
@@ -743,7 +748,7 @@
             },
             "rope_theta": {
               "default": 100.0,
-              "description": "Frequency base for 2D axial RoPE. Defaults to 100.0 and may be tuned; changing it alters rotary position encoding.",
+              "description": "Frequency base for 2D axial RoPE. Must match the timm DINOv3 reference; verified by the step-4 feature-parity smoke test.",
               "popular": true,
               "title": "RoPE theta",
               "type": "float"
@@ -799,8 +804,8 @@
           },
           "description": "Configuration for distillation (reused from nvdinov2)",
           "popular": [
-            "disable_masking",
-            "enable"
+            "enable",
+            "disable_masking"
           ],
           "properties": {
             "disable_masking": {
@@ -837,9 +842,9 @@
           },
           "description": "Configuration for DINOv3 Gram anchoring",
           "popular": [
-            "w_gram",
             "start_step",
-            "enable"
+            "enable",
+            "w_gram"
           ],
           "properties": {
             "enable": {
@@ -852,6 +857,7 @@
             "refresh_interval": {
               "default": 0,
               "description": "Steps between refreshing the Gram teacher from the EMA teacher (only when teacher_source='ema'). 0 = never refresh (frozen snapshot, Phase 0 behavior).",
+              "maximum": Infinity,
               "minimum": 0,
               "title": "gram refresh interval",
               "type": "int"
@@ -859,6 +865,7 @@
             "start_step": {
               "default": 0,
               "description": "Global step at which the Gram term activates",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "gram start step",
@@ -899,14 +906,15 @@
           },
           "description": "Configuration for the DINOv3 head (reused from nvdinov2)",
           "popular": [
-            "hidden_dim",
             "bottleneck_dim",
-            "num_layers"
+            "num_layers",
+            "hidden_dim"
           ],
           "properties": {
             "bottleneck_dim": {
               "default": 384,
               "description": "Dimension of the bottleneck layer in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "bottleneck dimension",
@@ -915,6 +923,7 @@
             "hidden_dim": {
               "default": 2048,
               "description": "Dimension of the hidden layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "hidden dimension",
@@ -923,6 +932,7 @@
             "num_layers": {
               "default": 3,
               "description": "Number of layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "number of Layers",
@@ -949,11 +959,11 @@
           },
           "description": "Configuration for LoRA parameter-efficient continual pre-training",
           "popular": [
+            "rank",
+            "num_last_blocks",
             "alpha",
             "target_modules",
-            "enable",
-            "num_last_blocks",
-            "rank"
+            "enable"
           ],
           "properties": {
             "alpha": {
@@ -1019,8 +1029,8 @@
           },
           "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
           "popular": [
-            "cls_cosine_weight",
             "cls_mse_weight",
+            "cls_cosine_weight",
             "enable"
           ],
           "properties": {
@@ -1081,10 +1091,9 @@
         "checkpoint_interval_unit": "epoch",
         "checkpointer": {
           "auto_insert_metric_name": false,
-          "dirpath": "",
           "enable_topk": false,
           "filename": "model_best_{epoch:03d}",
-          "monitor": "",
+          "replace_periodic": false,
           "save_top_k": 1
         },
         "clip_grad_norm": 3.0,
@@ -1097,6 +1106,7 @@
           0
         ],
         "layerwise_decay": 1.0,
+        "log_every_n_steps": 1,
         "num_epochs": 10,
         "num_gpus": 1,
         "num_nodes": 1,
@@ -1105,22 +1115,21 @@
           "optim": "adamw"
         },
         "precision": "16-mixed",
-        "pretrained_model_path": "",
         "results_dir": "",
         "resume_training_checkpoint_path": "",
         "schedulers": {
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -1148,25 +1157,24 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1,
-        "log_every_n_steps": 1
+        "validation_interval": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
-        "schedulers",
-        "num_prototypes",
-        "checkpoint_interval",
-        "use_custom_attention",
-        "num_gpus",
-        "clip_grad_norm",
-        "validation_interval",
         "layerwise_decay",
+        "checkpoint_interval",
         "optim",
-        "num_nodes",
-        "distributed_strategy",
-        "num_epochs",
         "gpu_ids",
-        "precision"
+        "validation_interval",
+        "num_gpus",
+        "precision",
+        "num_prototypes",
+        "schedulers",
+        "distributed_strategy",
+        "num_nodes",
+        "clip_grad_norm",
+        "num_epochs",
+        "use_custom_attention"
       ],
       "properties": {
         "checkpoint_interval": {
@@ -1191,10 +1199,9 @@
           "automl_enabled": false,
           "default": {
             "auto_insert_metric_name": false,
-            "dirpath": "",
             "enable_topk": false,
             "filename": "model_best_{epoch:03d}",
-            "monitor": "",
+            "replace_periodic": false,
             "save_top_k": 1
           },
           "properties": {
@@ -1203,13 +1210,12 @@
               "type": "bool"
             },
             "dirpath": {
-              "default": "",
               "description": "Directory for best checkpoints. Defaults to results_dir.",
               "type": "string"
             },
             "enable_topk": {
               "default": false,
-              "description": "Save the top-K checkpoints ranked by a monitored metric, in addition to the periodic checkpoints.",
+              "description": "Save checkpoint(s) ranked by a monitored metric. This is additive to periodic checkpoints unless replace_periodic is enabled.",
               "title": "Enable best-checkpoint saving",
               "type": "bool"
             },
@@ -1219,7 +1225,7 @@
               "type": "string"
             },
             "mode": {
-              "description": "Override direction. 'min' for losses, 'max' for accuracy/mAP/mIoU. Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default direction.",
               "enum": [
                 "min",
                 "max"
@@ -1228,14 +1234,18 @@
               "type": "categorical"
             },
             "monitor": {
-              "default": "",
-              "description": "Override the network's default monitored metric (e.g. val_loss, val_acc, val_miou, mAP). Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default metric.",
               "title": "Monitored metric",
               "type": "string"
             },
+            "replace_periodic": {
+              "default": false,
+              "description": "When best-checkpoint saving is enabled, replace periodic history with one metric-best checkpoint and its latest symlink.",
+              "title": "Replace periodic checkpoints",
+              "type": "bool"
+            },
             "save_top_k": {
               "default": 1,
-              "description": "How many best checkpoints to keep (1 = only the single best).",
               "minimum": 1,
               "title": "Number of best checkpoints",
               "type": "int"
@@ -1256,6 +1266,7 @@
             "benchmark": true,
             "deterministic": false
           },
+          "description": "CuDNN settings compatible with DINOv3 custom attention.",
           "properties": {
             "benchmark": {
               "default": true,
@@ -1301,9 +1312,17 @@
           "title": "layerwise decay factor",
           "type": "float"
         },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
+        },
         "num_epochs": {
           "default": 10,
           "description": "Number of epochs to run the training.",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "Number of epochs",
@@ -1392,15 +1411,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1430,9 +1449,9 @@
           "popular": [
             "learning_rate",
             "weight_decay",
-            "last_layer_learning_rate",
             "teacher_temperature",
-            "momentum"
+            "momentum",
+            "last_layer_learning_rate"
           ],
           "properties": {
             "last_layer_learning_rate": {
@@ -1440,8 +1459,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1449,10 +1468,10 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
-                "freeze_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "freeze_steps",
+                "max_decay_steps"
               ],
               "properties": {
                 "freeze_steps": {
@@ -1470,14 +1489,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1504,8 +1523,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1513,9 +1532,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1526,14 +1545,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1569,9 +1588,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1625,9 +1644,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1681,9 +1700,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1730,6 +1749,7 @@
         "seed": {
           "default": 1234,
           "description": "The seed for the initializer in PyTorch. If < 0, disable fixed seed.",
+          "maximum": Infinity,
           "minimum": -1,
           "title": "Seed for randomization",
           "type": "int"
@@ -1747,13 +1767,6 @@
           "minimum": 1,
           "popular": true,
           "title": "Validation interval",
-          "type": "int"
-        },
-        "log_every_n_steps": {
-          "default": 1,
-          "description": "Number of training steps between logger updates.",
-          "minimum": 1,
-          "title": "logging interval",
           "type": "int"
         }
       },

--- a/skills/models/tao-train-dinov3/schemas/convert.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/convert.schema.json
@@ -35,7 +35,9 @@
     "dataset.transform.local_crops_scale",
     "train.optim",
     "inference",
-    "dataset.transform.global_crops_scale"
+    "dataset.transform.global_crops_scale",
+    "model.lora.target_modules",
+    "model.preservation"
   ],
   "default": {
     "convert": {
@@ -102,8 +104,19 @@
       },
       "lora": {
         "alpha": 16.0,
+        "dropout": 0.05,
         "enable": false,
-        "rank": 8
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "model_name": "",
@@ -144,15 +157,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -180,7 +193,8 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1
+      "validation_interval": 1,
+      "log_every_n_steps": 1
     },
     "wandb": {
       "enable": true,
@@ -260,6 +274,21 @@
         "bottleneck_dim": 384,
         "hidden_dim": 2048,
         "num_layers": 3
+      },
+      "lora": {
+        "alpha": 16.0,
+        "enable": false,
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "train": {
@@ -282,15 +311,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -594,7 +623,8 @@
         "model.backbone",
         "model.head",
         "model.gram",
-        "model.lora"
+        "model.lora",
+        "model.preservation"
       ],
       "automl_enabled": false,
       "default": {
@@ -628,8 +658,19 @@
         },
         "lora": {
           "alpha": 16.0,
+          "dropout": 0.05,
           "enable": false,
-          "rank": 8
+          "num_last_blocks": 0,
+          "rank": 8,
+          "target_modules": [
+            "qkv",
+            "proj"
+          ]
+        },
+        "preservation": {
+          "cls_cosine_weight": 0.05,
+          "cls_mse_weight": 0.05,
+          "enable": false
         }
       },
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
@@ -638,7 +679,9 @@
         "centering_method",
         "gram",
         "distill",
-        "head"
+        "head",
+        "lora",
+        "preservation"
       ],
       "properties": {
         "backbone": {
@@ -889,32 +932,122 @@
           "type": "collection"
         },
         "lora": {
+          "automl_disabled_parameters": [
+            "model.lora.target_modules"
+          ],
           "automl_enabled": false,
           "default": {
             "alpha": 16.0,
+            "dropout": 0.05,
             "enable": false,
-            "rank": 8
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
           },
-          "description": "Disabled LoRA stub for forward-compatibility",
+          "description": "Configuration for LoRA parameter-efficient continual pre-training",
+          "popular": [
+            "alpha",
+            "target_modules",
+            "enable",
+            "num_last_blocks",
+            "rank"
+          ],
           "properties": {
             "alpha": {
               "default": 16.0,
-              "description": "LoRA scaling alpha",
+              "description": "LoRA scaling alpha; the applied scale is alpha / rank.",
+              "popular": true,
               "title": "lora alpha",
+              "type": "float"
+            },
+            "dropout": {
+              "default": 0.05,
+              "description": "Dropout applied to the LoRA branch input only (the frozen base path is untouched).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "lora dropout",
               "type": "float"
             },
             "enable": {
               "default": false,
-              "description": "Whether to apply LoRA adapters (disabled in v1)",
+              "description": "Whether to apply LoRA adapters to the backbone (parameter-efficient SSL)",
+              "popular": true,
               "title": "enable lora",
               "type": "bool"
             },
+            "num_last_blocks": {
+              "default": 0,
+              "description": "Adapt only the last N transformer blocks. 0 = all blocks.",
+              "maximum": Infinity,
+              "minimum": 0,
+              "popular": true,
+              "title": "lora num last blocks",
+              "type": "int"
+            },
             "rank": {
               "default": 8,
-              "description": "LoRA rank",
+              "description": "LoRA rank (r). The low-rank update is dW = (alpha/r) * B @ A.",
+              "maximum": Infinity,
               "minimum": 1,
+              "popular": true,
               "title": "lora rank",
               "type": "int"
+            },
+            "target_modules": {
+              "automl_enabled": false,
+              "default": [
+                "qkv",
+                "proj"
+              ],
+              "description": "Projections to adapt inside each targeted ViT block. 'qkv' and 'proj' are the attention projections (the v1 default); 'fc1'/'fc2' additionally adapt the FFN. SwiGLU backbones (ViT-S+/H+/7B) expose a fused fc1 and are deferred in v1.",
+              "popular": true,
+              "title": "lora target modules",
+              "type": "list"
+            }
+          },
+          "type": "collection"
+        },
+        "preservation": {
+          "automl_enabled": false,
+          "default": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
+          },
+          "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
+          "popular": [
+            "cls_cosine_weight",
+            "cls_mse_weight",
+            "enable"
+          ],
+          "properties": {
+            "cls_cosine_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token cosine preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls cosine weight",
+              "type": "float"
+            },
+            "cls_mse_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token MSE preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls mse weight",
+              "type": "float"
+            },
+            "enable": {
+              "default": false,
+              "description": "Whether to add CLS-token preservation losses against the frozen anchor teacher. Recommended alongside LoRA for continual pre-training.",
+              "popular": true,
+              "title": "enable preservation",
+              "type": "bool"
             }
           },
           "type": "collection"
@@ -979,15 +1112,15 @@
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -1015,7 +1148,8 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1
+        "validation_interval": 1,
+        "log_every_n_steps": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
@@ -1258,15 +1392,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1306,8 +1440,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1336,14 +1470,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1370,8 +1504,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1392,14 +1526,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1614,6 +1748,13 @@
           "popular": true,
           "title": "Validation interval",
           "type": "int"
+        },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
         }
       },
       "type": "collection"
@@ -1693,6 +1834,6 @@
     "network_arch": "dinov3",
     "schema_action": "convert",
     "schema_version": 1,
-    "source": "tao-pytorch dataclass config"
+    "source": "tao-core dataclass config"
   }
 }

--- a/skills/models/tao-train-dinov3/schemas/export.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/export.schema.json
@@ -1,43 +1,43 @@
 {
   "automl_default_parameters": [
-    "dataset.batch_size",
-    "dataset.workers"
+    "dataset.workers",
+    "dataset.batch_size"
   ],
   "automl_disabled_parameters": [
-    "gen_trt_engine",
-    "gen_trt_engine.tensorrt",
-    "train.schedulers.momentum",
-    "inference.gpu_ids",
+    "dataset.train_dataset",
+    "wandb.tags",
+    "inference",
+    "train.cudnn",
+    "train.gpu_ids",
+    "train.schedulers",
+    "model",
+    "model.head",
     "model.backbone",
     "dataset",
-    "wandb",
-    "dataset.train_dataset",
-    "train.schedulers",
-    "train.schedulers.weight_decay",
-    "model.gram",
-    "train.schedulers.teacher_temperature",
-    "wandb.tags",
-    "train.schedulers.learning_rate",
-    "convert",
-    "dataset.transform",
-    "train.gpu_ids",
-    "export",
     "train.checkpointer",
-    "train.schedulers.last_layer_learning_rate",
-    "model.lora",
-    "train.cudnn",
-    "model.head",
-    "train",
-    "model.distill",
-    "dataset.test_dataset",
-    "gen_trt_engine.tensorrt.layers_precision",
-    "model",
-    "dataset.transform.local_crops_scale",
     "train.optim",
-    "inference",
-    "dataset.transform.global_crops_scale",
+    "model.gram",
+    "gen_trt_engine",
+    "model.preservation",
+    "train.schedulers.weight_decay",
     "model.lora.target_modules",
-    "model.preservation"
+    "train.schedulers.last_layer_learning_rate",
+    "dataset.transform.global_crops_scale",
+    "train.schedulers.learning_rate",
+    "wandb",
+    "model.distill",
+    "train",
+    "train.schedulers.teacher_temperature",
+    "inference.gpu_ids",
+    "dataset.transform",
+    "train.schedulers.momentum",
+    "gen_trt_engine.tensorrt.layers_precision",
+    "dataset.transform.local_crops_scale",
+    "gen_trt_engine.tensorrt",
+    "convert",
+    "dataset.test_dataset",
+    "model.lora",
+    "export"
   ],
   "default": {
     "dataset": {
@@ -71,8 +71,8 @@
       "checkpoint": "???",
       "gpu_id": 0,
       "input_channel": 3,
-      "input_height": 518,
-      "input_width": 518,
+      "input_height": 256,
+      "input_width": 256,
       "on_cpu": false,
       "onnx_file": "???",
       "opset_version": 12,
@@ -132,10 +132,9 @@
       "checkpoint_interval_unit": "epoch",
       "checkpointer": {
         "auto_insert_metric_name": false,
-        "dirpath": "",
         "enable_topk": false,
         "filename": "model_best_{epoch:03d}",
-        "monitor": "",
+        "replace_periodic": false,
         "save_top_k": 1
       },
       "clip_grad_norm": 3.0,
@@ -148,6 +147,7 @@
         0
       ],
       "layerwise_decay": 1.0,
+      "log_every_n_steps": 1,
       "num_epochs": 10,
       "num_gpus": 1,
       "num_nodes": 1,
@@ -156,22 +156,21 @@
         "optim": "adamw"
       },
       "precision": "16-mixed",
-      "pretrained_model_path": "",
       "results_dir": "",
       "resume_training_checkpoint_path": "",
       "schedulers": {
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -199,8 +198,7 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1,
-      "log_every_n_steps": 1
+      "validation_interval": 1
     },
     "wandb": {
       "enable": true,
@@ -317,15 +315,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -414,6 +412,7 @@
           "automl_enabled": true,
           "default": 4,
           "description": "The batch size for training",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -435,7 +434,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -452,7 +451,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -482,11 +481,11 @@
           },
           "description": "Configuration parameters for data transformation",
           "popular": [
-            "local_crops_size",
-            "global_crops_size",
-            "global_crops_scale",
-            "local_crops_scale",
             "n_global_crops",
+            "global_crops_size",
+            "local_crops_scale",
+            "global_crops_scale",
+            "local_crops_size",
             "n_local_crops"
           ],
           "properties": {
@@ -504,6 +503,7 @@
             "global_crops_size": {
               "default": 256,
               "description": "Size of global crops for DINOv3 training.",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Global Crops Size",
@@ -523,6 +523,7 @@
             "local_crops_size": {
               "default": 112,
               "description": "Size of local crops (multiple of patch 16)",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Local Crops Size",
@@ -531,6 +532,7 @@
             "n_global_crops": {
               "default": 2,
               "description": "Number of global crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Global Crops",
@@ -539,6 +541,7 @@
             "n_local_crops": {
               "default": 8,
               "description": "Number of local crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Local Crops",
@@ -552,6 +555,7 @@
           "automl_enabled": true,
           "default": 8,
           "description": "The number of parallel workers processing data",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -573,8 +577,8 @@
         "checkpoint": "???",
         "gpu_id": 0,
         "input_channel": 3,
-        "input_height": 518,
-        "input_width": 518,
+        "input_height": 256,
+        "input_width": 256,
         "on_cpu": false,
         "onnx_file": "???",
         "opset_version": 12,
@@ -609,14 +613,14 @@
           "type": "int"
         },
         "input_height": {
-          "default": 518,
+          "default": 256,
           "description": "Input height",
           "minimum": 128,
           "title": "Input height",
           "type": "int"
         },
         "input_width": {
-          "default": 518,
+          "default": 256,
           "description": "Input width",
           "minimum": 128,
           "title": "Input width",
@@ -715,12 +719,12 @@
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
       "popular": [
         "backbone",
-        "centering_method",
-        "gram",
+        "lora",
         "distill",
         "head",
-        "lora",
-        "preservation"
+        "preservation",
+        "centering_method",
+        "gram"
       ],
       "properties": {
         "backbone": {
@@ -736,11 +740,11 @@
           },
           "description": "Configuration for the DINOv3 backbone",
           "popular": [
+            "patch_size",
+            "rope_theta",
             "img_size",
             "num_register_tokens",
-            "drop_path_rate",
-            "rope_theta",
-            "patch_size"
+            "drop_path_rate"
           ],
           "properties": {
             "drop_path_rate": {
@@ -765,6 +769,7 @@
             "num_register_tokens": {
               "default": 4,
               "description": "Number of register tokens (DINOv3 ViT-B uses 4)",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "num register tokens",
@@ -782,7 +787,7 @@
             },
             "rope_theta": {
               "default": 100.0,
-              "description": "Frequency base for 2D axial RoPE. Defaults to 100.0 and may be tuned; changing it alters rotary position encoding.",
+              "description": "Frequency base for 2D axial RoPE. Must match the timm DINOv3 reference; verified by the step-4 feature-parity smoke test.",
               "popular": true,
               "title": "RoPE theta",
               "type": "float"
@@ -838,8 +843,8 @@
           },
           "description": "Configuration for distillation (reused from nvdinov2)",
           "popular": [
-            "disable_masking",
-            "enable"
+            "enable",
+            "disable_masking"
           ],
           "properties": {
             "disable_masking": {
@@ -876,9 +881,9 @@
           },
           "description": "Configuration for DINOv3 Gram anchoring",
           "popular": [
-            "w_gram",
             "start_step",
-            "enable"
+            "enable",
+            "w_gram"
           ],
           "properties": {
             "enable": {
@@ -891,6 +896,7 @@
             "refresh_interval": {
               "default": 0,
               "description": "Steps between refreshing the Gram teacher from the EMA teacher (only when teacher_source='ema'). 0 = never refresh (frozen snapshot, Phase 0 behavior).",
+              "maximum": Infinity,
               "minimum": 0,
               "title": "gram refresh interval",
               "type": "int"
@@ -898,6 +904,7 @@
             "start_step": {
               "default": 0,
               "description": "Global step at which the Gram term activates",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "gram start step",
@@ -938,14 +945,15 @@
           },
           "description": "Configuration for the DINOv3 head (reused from nvdinov2)",
           "popular": [
-            "hidden_dim",
             "bottleneck_dim",
-            "num_layers"
+            "num_layers",
+            "hidden_dim"
           ],
           "properties": {
             "bottleneck_dim": {
               "default": 384,
               "description": "Dimension of the bottleneck layer in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "bottleneck dimension",
@@ -954,6 +962,7 @@
             "hidden_dim": {
               "default": 2048,
               "description": "Dimension of the hidden layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "hidden dimension",
@@ -962,6 +971,7 @@
             "num_layers": {
               "default": 3,
               "description": "Number of layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "number of Layers",
@@ -988,11 +998,11 @@
           },
           "description": "Configuration for LoRA parameter-efficient continual pre-training",
           "popular": [
+            "rank",
+            "num_last_blocks",
             "alpha",
             "target_modules",
-            "enable",
-            "num_last_blocks",
-            "rank"
+            "enable"
           ],
           "properties": {
             "alpha": {
@@ -1058,8 +1068,8 @@
           },
           "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
           "popular": [
-            "cls_cosine_weight",
             "cls_mse_weight",
+            "cls_cosine_weight",
             "enable"
           ],
           "properties": {
@@ -1120,10 +1130,9 @@
         "checkpoint_interval_unit": "epoch",
         "checkpointer": {
           "auto_insert_metric_name": false,
-          "dirpath": "",
           "enable_topk": false,
           "filename": "model_best_{epoch:03d}",
-          "monitor": "",
+          "replace_periodic": false,
           "save_top_k": 1
         },
         "clip_grad_norm": 3.0,
@@ -1136,6 +1145,7 @@
           0
         ],
         "layerwise_decay": 1.0,
+        "log_every_n_steps": 1,
         "num_epochs": 10,
         "num_gpus": 1,
         "num_nodes": 1,
@@ -1144,22 +1154,21 @@
           "optim": "adamw"
         },
         "precision": "16-mixed",
-        "pretrained_model_path": "",
         "results_dir": "",
         "resume_training_checkpoint_path": "",
         "schedulers": {
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -1187,25 +1196,24 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1,
-        "log_every_n_steps": 1
+        "validation_interval": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
-        "schedulers",
-        "num_prototypes",
-        "checkpoint_interval",
-        "use_custom_attention",
-        "num_gpus",
-        "clip_grad_norm",
-        "validation_interval",
         "layerwise_decay",
+        "checkpoint_interval",
         "optim",
-        "num_nodes",
-        "distributed_strategy",
-        "num_epochs",
         "gpu_ids",
-        "precision"
+        "validation_interval",
+        "num_gpus",
+        "precision",
+        "num_prototypes",
+        "schedulers",
+        "distributed_strategy",
+        "num_nodes",
+        "clip_grad_norm",
+        "num_epochs",
+        "use_custom_attention"
       ],
       "properties": {
         "checkpoint_interval": {
@@ -1230,10 +1238,9 @@
           "automl_enabled": false,
           "default": {
             "auto_insert_metric_name": false,
-            "dirpath": "",
             "enable_topk": false,
             "filename": "model_best_{epoch:03d}",
-            "monitor": "",
+            "replace_periodic": false,
             "save_top_k": 1
           },
           "properties": {
@@ -1242,13 +1249,12 @@
               "type": "bool"
             },
             "dirpath": {
-              "default": "",
               "description": "Directory for best checkpoints. Defaults to results_dir.",
               "type": "string"
             },
             "enable_topk": {
               "default": false,
-              "description": "Save the top-K checkpoints ranked by a monitored metric, in addition to the periodic checkpoints.",
+              "description": "Save checkpoint(s) ranked by a monitored metric. This is additive to periodic checkpoints unless replace_periodic is enabled.",
               "title": "Enable best-checkpoint saving",
               "type": "bool"
             },
@@ -1258,7 +1264,7 @@
               "type": "string"
             },
             "mode": {
-              "description": "Override direction. 'min' for losses, 'max' for accuracy/mAP/mIoU. Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default direction.",
               "enum": [
                 "min",
                 "max"
@@ -1267,14 +1273,18 @@
               "type": "categorical"
             },
             "monitor": {
-              "default": "",
-              "description": "Override the network's default monitored metric (e.g. val_loss, val_acc, val_miou, mAP). Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default metric.",
               "title": "Monitored metric",
               "type": "string"
             },
+            "replace_periodic": {
+              "default": false,
+              "description": "When best-checkpoint saving is enabled, replace periodic history with one metric-best checkpoint and its latest symlink.",
+              "title": "Replace periodic checkpoints",
+              "type": "bool"
+            },
             "save_top_k": {
               "default": 1,
-              "description": "How many best checkpoints to keep (1 = only the single best).",
               "minimum": 1,
               "title": "Number of best checkpoints",
               "type": "int"
@@ -1295,6 +1305,7 @@
             "benchmark": true,
             "deterministic": false
           },
+          "description": "CuDNN settings compatible with DINOv3 custom attention.",
           "properties": {
             "benchmark": {
               "default": true,
@@ -1340,9 +1351,17 @@
           "title": "layerwise decay factor",
           "type": "float"
         },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
+        },
         "num_epochs": {
           "default": 10,
           "description": "Number of epochs to run the training.",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "Number of epochs",
@@ -1431,15 +1450,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1469,9 +1488,9 @@
           "popular": [
             "learning_rate",
             "weight_decay",
-            "last_layer_learning_rate",
             "teacher_temperature",
-            "momentum"
+            "momentum",
+            "last_layer_learning_rate"
           ],
           "properties": {
             "last_layer_learning_rate": {
@@ -1479,8 +1498,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1488,10 +1507,10 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
-                "freeze_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "freeze_steps",
+                "max_decay_steps"
               ],
               "properties": {
                 "freeze_steps": {
@@ -1509,14 +1528,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1543,8 +1562,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1552,9 +1571,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1565,14 +1584,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1608,9 +1627,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1664,9 +1683,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1720,9 +1739,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1769,6 +1788,7 @@
         "seed": {
           "default": 1234,
           "description": "The seed for the initializer in PyTorch. If < 0, disable fixed seed.",
+          "maximum": Infinity,
           "minimum": -1,
           "title": "Seed for randomization",
           "type": "int"
@@ -1786,13 +1806,6 @@
           "minimum": 1,
           "popular": true,
           "title": "Validation interval",
-          "type": "int"
-        },
-        "log_every_n_steps": {
-          "default": 1,
-          "description": "Number of training steps between logger updates.",
-          "minimum": 1,
-          "title": "logging interval",
           "type": "int"
         }
       },

--- a/skills/models/tao-train-dinov3/schemas/export.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/export.schema.json
@@ -35,7 +35,9 @@
     "dataset.transform.local_crops_scale",
     "train.optim",
     "inference",
-    "dataset.transform.global_crops_scale"
+    "dataset.transform.global_crops_scale",
+    "model.lora.target_modules",
+    "model.preservation"
   ],
   "default": {
     "dataset": {
@@ -108,8 +110,19 @@
       },
       "lora": {
         "alpha": 16.0,
+        "dropout": 0.05,
         "enable": false,
-        "rank": 8
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "model_name": "",
@@ -150,15 +163,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -186,7 +199,8 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1
+      "validation_interval": 1,
+      "log_every_n_steps": 1
     },
     "wandb": {
       "enable": true,
@@ -266,6 +280,21 @@
         "bottleneck_dim": 384,
         "hidden_dim": 2048,
         "num_layers": 3
+      },
+      "lora": {
+        "alpha": 16.0,
+        "enable": false,
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "train": {
@@ -288,15 +317,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -633,7 +662,8 @@
         "model.backbone",
         "model.head",
         "model.gram",
-        "model.lora"
+        "model.lora",
+        "model.preservation"
       ],
       "automl_enabled": false,
       "default": {
@@ -667,8 +697,19 @@
         },
         "lora": {
           "alpha": 16.0,
+          "dropout": 0.05,
           "enable": false,
-          "rank": 8
+          "num_last_blocks": 0,
+          "rank": 8,
+          "target_modules": [
+            "qkv",
+            "proj"
+          ]
+        },
+        "preservation": {
+          "cls_cosine_weight": 0.05,
+          "cls_mse_weight": 0.05,
+          "enable": false
         }
       },
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
@@ -677,7 +718,9 @@
         "centering_method",
         "gram",
         "distill",
-        "head"
+        "head",
+        "lora",
+        "preservation"
       ],
       "properties": {
         "backbone": {
@@ -928,32 +971,122 @@
           "type": "collection"
         },
         "lora": {
+          "automl_disabled_parameters": [
+            "model.lora.target_modules"
+          ],
           "automl_enabled": false,
           "default": {
             "alpha": 16.0,
+            "dropout": 0.05,
             "enable": false,
-            "rank": 8
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
           },
-          "description": "Disabled LoRA stub for forward-compatibility",
+          "description": "Configuration for LoRA parameter-efficient continual pre-training",
+          "popular": [
+            "alpha",
+            "target_modules",
+            "enable",
+            "num_last_blocks",
+            "rank"
+          ],
           "properties": {
             "alpha": {
               "default": 16.0,
-              "description": "LoRA scaling alpha",
+              "description": "LoRA scaling alpha; the applied scale is alpha / rank.",
+              "popular": true,
               "title": "lora alpha",
+              "type": "float"
+            },
+            "dropout": {
+              "default": 0.05,
+              "description": "Dropout applied to the LoRA branch input only (the frozen base path is untouched).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "lora dropout",
               "type": "float"
             },
             "enable": {
               "default": false,
-              "description": "Whether to apply LoRA adapters (disabled in v1)",
+              "description": "Whether to apply LoRA adapters to the backbone (parameter-efficient SSL)",
+              "popular": true,
               "title": "enable lora",
               "type": "bool"
             },
+            "num_last_blocks": {
+              "default": 0,
+              "description": "Adapt only the last N transformer blocks. 0 = all blocks.",
+              "maximum": Infinity,
+              "minimum": 0,
+              "popular": true,
+              "title": "lora num last blocks",
+              "type": "int"
+            },
             "rank": {
               "default": 8,
-              "description": "LoRA rank",
+              "description": "LoRA rank (r). The low-rank update is dW = (alpha/r) * B @ A.",
+              "maximum": Infinity,
               "minimum": 1,
+              "popular": true,
               "title": "lora rank",
               "type": "int"
+            },
+            "target_modules": {
+              "automl_enabled": false,
+              "default": [
+                "qkv",
+                "proj"
+              ],
+              "description": "Projections to adapt inside each targeted ViT block. 'qkv' and 'proj' are the attention projections (the v1 default); 'fc1'/'fc2' additionally adapt the FFN. SwiGLU backbones (ViT-S+/H+/7B) expose a fused fc1 and are deferred in v1.",
+              "popular": true,
+              "title": "lora target modules",
+              "type": "list"
+            }
+          },
+          "type": "collection"
+        },
+        "preservation": {
+          "automl_enabled": false,
+          "default": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
+          },
+          "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
+          "popular": [
+            "cls_cosine_weight",
+            "cls_mse_weight",
+            "enable"
+          ],
+          "properties": {
+            "cls_cosine_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token cosine preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls cosine weight",
+              "type": "float"
+            },
+            "cls_mse_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token MSE preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls mse weight",
+              "type": "float"
+            },
+            "enable": {
+              "default": false,
+              "description": "Whether to add CLS-token preservation losses against the frozen anchor teacher. Recommended alongside LoRA for continual pre-training.",
+              "popular": true,
+              "title": "enable preservation",
+              "type": "bool"
             }
           },
           "type": "collection"
@@ -1018,15 +1151,15 @@
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -1054,7 +1187,8 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1
+        "validation_interval": 1,
+        "log_every_n_steps": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
@@ -1297,15 +1431,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1345,8 +1479,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1375,14 +1509,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1409,8 +1543,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1431,14 +1565,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1653,6 +1787,13 @@
           "popular": true,
           "title": "Validation interval",
           "type": "int"
+        },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
         }
       },
       "type": "collection"
@@ -1732,6 +1873,6 @@
     "network_arch": "dinov3",
     "schema_action": "export",
     "schema_version": 1,
-    "source": "tao-pytorch dataclass config"
+    "source": "tao-core dataclass config"
   }
 }

--- a/skills/models/tao-train-dinov3/schemas/inference.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/inference.schema.json
@@ -1,43 +1,43 @@
 {
   "automl_default_parameters": [
-    "dataset.batch_size",
-    "dataset.workers"
+    "dataset.workers",
+    "dataset.batch_size"
   ],
   "automl_disabled_parameters": [
-    "gen_trt_engine",
-    "gen_trt_engine.tensorrt",
-    "train.schedulers.momentum",
-    "inference.gpu_ids",
+    "dataset.train_dataset",
+    "wandb.tags",
+    "inference",
+    "train.cudnn",
+    "train.gpu_ids",
+    "train.schedulers",
+    "model",
+    "model.head",
     "model.backbone",
     "dataset",
-    "wandb",
-    "dataset.train_dataset",
-    "train.schedulers",
-    "train.schedulers.weight_decay",
-    "model.gram",
-    "train.schedulers.teacher_temperature",
-    "wandb.tags",
-    "train.schedulers.learning_rate",
-    "convert",
-    "dataset.transform",
-    "train.gpu_ids",
-    "export",
     "train.checkpointer",
-    "train.schedulers.last_layer_learning_rate",
-    "model.lora",
-    "train.cudnn",
-    "model.head",
-    "train",
-    "model.distill",
-    "dataset.test_dataset",
-    "gen_trt_engine.tensorrt.layers_precision",
-    "model",
-    "dataset.transform.local_crops_scale",
     "train.optim",
-    "inference",
-    "dataset.transform.global_crops_scale",
+    "model.gram",
+    "gen_trt_engine",
+    "model.preservation",
+    "train.schedulers.weight_decay",
     "model.lora.target_modules",
-    "model.preservation"
+    "train.schedulers.last_layer_learning_rate",
+    "dataset.transform.global_crops_scale",
+    "train.schedulers.learning_rate",
+    "wandb",
+    "model.distill",
+    "train",
+    "train.schedulers.teacher_temperature",
+    "inference.gpu_ids",
+    "dataset.transform",
+    "train.schedulers.momentum",
+    "gen_trt_engine.tensorrt.layers_precision",
+    "dataset.transform.local_crops_scale",
+    "gen_trt_engine.tensorrt",
+    "convert",
+    "dataset.test_dataset",
+    "model.lora",
+    "export"
   ],
   "default": {
     "dataset": {
@@ -131,10 +131,9 @@
       "checkpoint_interval_unit": "epoch",
       "checkpointer": {
         "auto_insert_metric_name": false,
-        "dirpath": "",
         "enable_topk": false,
         "filename": "model_best_{epoch:03d}",
-        "monitor": "",
+        "replace_periodic": false,
         "save_top_k": 1
       },
       "clip_grad_norm": 3.0,
@@ -147,6 +146,7 @@
         0
       ],
       "layerwise_decay": 1.0,
+      "log_every_n_steps": 1,
       "num_epochs": 10,
       "num_gpus": 1,
       "num_nodes": 1,
@@ -155,22 +155,21 @@
         "optim": "adamw"
       },
       "precision": "16-mixed",
-      "pretrained_model_path": "",
       "results_dir": "",
       "resume_training_checkpoint_path": "",
       "schedulers": {
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -198,8 +197,7 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1,
-      "log_every_n_steps": 1
+      "validation_interval": 1
     },
     "wandb": {
       "enable": true,
@@ -316,15 +314,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -413,6 +411,7 @@
           "automl_enabled": true,
           "default": 4,
           "description": "The batch size for training",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -434,7 +433,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -451,7 +450,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -481,11 +480,11 @@
           },
           "description": "Configuration parameters for data transformation",
           "popular": [
-            "local_crops_size",
-            "global_crops_size",
-            "global_crops_scale",
-            "local_crops_scale",
             "n_global_crops",
+            "global_crops_size",
+            "local_crops_scale",
+            "global_crops_scale",
+            "local_crops_size",
             "n_local_crops"
           ],
           "properties": {
@@ -503,6 +502,7 @@
             "global_crops_size": {
               "default": 256,
               "description": "Size of global crops for DINOv3 training.",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Global Crops Size",
@@ -522,6 +522,7 @@
             "local_crops_size": {
               "default": 112,
               "description": "Size of local crops (multiple of patch 16)",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Local Crops Size",
@@ -530,6 +531,7 @@
             "n_global_crops": {
               "default": 2,
               "description": "Number of global crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Global Crops",
@@ -538,6 +540,7 @@
             "n_local_crops": {
               "default": 8,
               "description": "Number of local crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Local Crops",
@@ -551,6 +554,7 @@
           "automl_enabled": true,
           "default": 8,
           "description": "The number of parallel workers processing data",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -584,14 +588,15 @@
       },
       "description": "Configurable parameters to construct the inference trainer for a DINOv3 experiment.",
       "popular": [
+        "gpu_ids",
         "num_gpus",
-        "num_nodes",
-        "gpu_ids"
+        "num_nodes"
       ],
       "properties": {
         "batch_size": {
           "default": 8,
           "description": "Batch size",
+          "maximum": Infinity,
           "minimum": 1,
           "title": "Batch Size",
           "type": "int"
@@ -643,6 +648,7 @@
         "vis_after_n_batches": {
           "default": 1,
           "description": "Visualize evaluation segmentation results after n batches",
+          "maximum": Infinity,
           "minimum": 1,
           "type": "int"
         }
@@ -708,12 +714,12 @@
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
       "popular": [
         "backbone",
-        "centering_method",
-        "gram",
+        "lora",
         "distill",
         "head",
-        "lora",
-        "preservation"
+        "preservation",
+        "centering_method",
+        "gram"
       ],
       "properties": {
         "backbone": {
@@ -729,11 +735,11 @@
           },
           "description": "Configuration for the DINOv3 backbone",
           "popular": [
+            "patch_size",
+            "rope_theta",
             "img_size",
             "num_register_tokens",
-            "drop_path_rate",
-            "rope_theta",
-            "patch_size"
+            "drop_path_rate"
           ],
           "properties": {
             "drop_path_rate": {
@@ -758,6 +764,7 @@
             "num_register_tokens": {
               "default": 4,
               "description": "Number of register tokens (DINOv3 ViT-B uses 4)",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "num register tokens",
@@ -775,7 +782,7 @@
             },
             "rope_theta": {
               "default": 100.0,
-              "description": "Frequency base for 2D axial RoPE. Defaults to 100.0 and may be tuned; changing it alters rotary position encoding.",
+              "description": "Frequency base for 2D axial RoPE. Must match the timm DINOv3 reference; verified by the step-4 feature-parity smoke test.",
               "popular": true,
               "title": "RoPE theta",
               "type": "float"
@@ -831,8 +838,8 @@
           },
           "description": "Configuration for distillation (reused from nvdinov2)",
           "popular": [
-            "disable_masking",
-            "enable"
+            "enable",
+            "disable_masking"
           ],
           "properties": {
             "disable_masking": {
@@ -869,9 +876,9 @@
           },
           "description": "Configuration for DINOv3 Gram anchoring",
           "popular": [
-            "w_gram",
             "start_step",
-            "enable"
+            "enable",
+            "w_gram"
           ],
           "properties": {
             "enable": {
@@ -884,6 +891,7 @@
             "refresh_interval": {
               "default": 0,
               "description": "Steps between refreshing the Gram teacher from the EMA teacher (only when teacher_source='ema'). 0 = never refresh (frozen snapshot, Phase 0 behavior).",
+              "maximum": Infinity,
               "minimum": 0,
               "title": "gram refresh interval",
               "type": "int"
@@ -891,6 +899,7 @@
             "start_step": {
               "default": 0,
               "description": "Global step at which the Gram term activates",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "gram start step",
@@ -931,14 +940,15 @@
           },
           "description": "Configuration for the DINOv3 head (reused from nvdinov2)",
           "popular": [
-            "hidden_dim",
             "bottleneck_dim",
-            "num_layers"
+            "num_layers",
+            "hidden_dim"
           ],
           "properties": {
             "bottleneck_dim": {
               "default": 384,
               "description": "Dimension of the bottleneck layer in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "bottleneck dimension",
@@ -947,6 +957,7 @@
             "hidden_dim": {
               "default": 2048,
               "description": "Dimension of the hidden layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "hidden dimension",
@@ -955,6 +966,7 @@
             "num_layers": {
               "default": 3,
               "description": "Number of layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "number of Layers",
@@ -981,11 +993,11 @@
           },
           "description": "Configuration for LoRA parameter-efficient continual pre-training",
           "popular": [
+            "rank",
+            "num_last_blocks",
             "alpha",
             "target_modules",
-            "enable",
-            "num_last_blocks",
-            "rank"
+            "enable"
           ],
           "properties": {
             "alpha": {
@@ -1051,8 +1063,8 @@
           },
           "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
           "popular": [
-            "cls_cosine_weight",
             "cls_mse_weight",
+            "cls_cosine_weight",
             "enable"
           ],
           "properties": {
@@ -1113,10 +1125,9 @@
         "checkpoint_interval_unit": "epoch",
         "checkpointer": {
           "auto_insert_metric_name": false,
-          "dirpath": "",
           "enable_topk": false,
           "filename": "model_best_{epoch:03d}",
-          "monitor": "",
+          "replace_periodic": false,
           "save_top_k": 1
         },
         "clip_grad_norm": 3.0,
@@ -1129,6 +1140,7 @@
           0
         ],
         "layerwise_decay": 1.0,
+        "log_every_n_steps": 1,
         "num_epochs": 10,
         "num_gpus": 1,
         "num_nodes": 1,
@@ -1137,22 +1149,21 @@
           "optim": "adamw"
         },
         "precision": "16-mixed",
-        "pretrained_model_path": "",
         "results_dir": "",
         "resume_training_checkpoint_path": "",
         "schedulers": {
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -1180,25 +1191,24 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1,
-        "log_every_n_steps": 1
+        "validation_interval": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
-        "schedulers",
-        "num_prototypes",
-        "checkpoint_interval",
-        "use_custom_attention",
-        "num_gpus",
-        "clip_grad_norm",
-        "validation_interval",
         "layerwise_decay",
+        "checkpoint_interval",
         "optim",
-        "num_nodes",
-        "distributed_strategy",
-        "num_epochs",
         "gpu_ids",
-        "precision"
+        "validation_interval",
+        "num_gpus",
+        "precision",
+        "num_prototypes",
+        "schedulers",
+        "distributed_strategy",
+        "num_nodes",
+        "clip_grad_norm",
+        "num_epochs",
+        "use_custom_attention"
       ],
       "properties": {
         "checkpoint_interval": {
@@ -1223,10 +1233,9 @@
           "automl_enabled": false,
           "default": {
             "auto_insert_metric_name": false,
-            "dirpath": "",
             "enable_topk": false,
             "filename": "model_best_{epoch:03d}",
-            "monitor": "",
+            "replace_periodic": false,
             "save_top_k": 1
           },
           "properties": {
@@ -1235,13 +1244,12 @@
               "type": "bool"
             },
             "dirpath": {
-              "default": "",
               "description": "Directory for best checkpoints. Defaults to results_dir.",
               "type": "string"
             },
             "enable_topk": {
               "default": false,
-              "description": "Save the top-K checkpoints ranked by a monitored metric, in addition to the periodic checkpoints.",
+              "description": "Save checkpoint(s) ranked by a monitored metric. This is additive to periodic checkpoints unless replace_periodic is enabled.",
               "title": "Enable best-checkpoint saving",
               "type": "bool"
             },
@@ -1251,7 +1259,7 @@
               "type": "string"
             },
             "mode": {
-              "description": "Override direction. 'min' for losses, 'max' for accuracy/mAP/mIoU. Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default direction.",
               "enum": [
                 "min",
                 "max"
@@ -1260,14 +1268,18 @@
               "type": "categorical"
             },
             "monitor": {
-              "default": "",
-              "description": "Override the network's default monitored metric (e.g. val_loss, val_acc, val_miou, mAP). Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default metric.",
               "title": "Monitored metric",
               "type": "string"
             },
+            "replace_periodic": {
+              "default": false,
+              "description": "When best-checkpoint saving is enabled, replace periodic history with one metric-best checkpoint and its latest symlink.",
+              "title": "Replace periodic checkpoints",
+              "type": "bool"
+            },
             "save_top_k": {
               "default": 1,
-              "description": "How many best checkpoints to keep (1 = only the single best).",
               "minimum": 1,
               "title": "Number of best checkpoints",
               "type": "int"
@@ -1288,6 +1300,7 @@
             "benchmark": true,
             "deterministic": false
           },
+          "description": "CuDNN settings compatible with DINOv3 custom attention.",
           "properties": {
             "benchmark": {
               "default": true,
@@ -1333,9 +1346,17 @@
           "title": "layerwise decay factor",
           "type": "float"
         },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
+        },
         "num_epochs": {
           "default": 10,
           "description": "Number of epochs to run the training.",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "Number of epochs",
@@ -1424,15 +1445,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1462,9 +1483,9 @@
           "popular": [
             "learning_rate",
             "weight_decay",
-            "last_layer_learning_rate",
             "teacher_temperature",
-            "momentum"
+            "momentum",
+            "last_layer_learning_rate"
           ],
           "properties": {
             "last_layer_learning_rate": {
@@ -1472,8 +1493,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1481,10 +1502,10 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
-                "freeze_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "freeze_steps",
+                "max_decay_steps"
               ],
               "properties": {
                 "freeze_steps": {
@@ -1502,14 +1523,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1536,8 +1557,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1545,9 +1566,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1558,14 +1579,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1601,9 +1622,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1657,9 +1678,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1713,9 +1734,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1762,6 +1783,7 @@
         "seed": {
           "default": 1234,
           "description": "The seed for the initializer in PyTorch. If < 0, disable fixed seed.",
+          "maximum": Infinity,
           "minimum": -1,
           "title": "Seed for randomization",
           "type": "int"
@@ -1779,13 +1801,6 @@
           "minimum": 1,
           "popular": true,
           "title": "Validation interval",
-          "type": "int"
-        },
-        "log_every_n_steps": {
-          "default": 1,
-          "description": "Number of training steps between logger updates.",
-          "minimum": 1,
-          "title": "logging interval",
           "type": "int"
         }
       },

--- a/skills/models/tao-train-dinov3/schemas/inference.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/inference.schema.json
@@ -35,7 +35,9 @@
     "dataset.transform.local_crops_scale",
     "train.optim",
     "inference",
-    "dataset.transform.global_crops_scale"
+    "dataset.transform.global_crops_scale",
+    "model.lora.target_modules",
+    "model.preservation"
   ],
   "default": {
     "dataset": {
@@ -107,8 +109,19 @@
       },
       "lora": {
         "alpha": 16.0,
+        "dropout": 0.05,
         "enable": false,
-        "rank": 8
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "model_name": "",
@@ -149,15 +162,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -185,7 +198,8 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1
+      "validation_interval": 1,
+      "log_every_n_steps": 1
     },
     "wandb": {
       "enable": true,
@@ -265,6 +279,21 @@
         "bottleneck_dim": 384,
         "hidden_dim": 2048,
         "num_layers": 3
+      },
+      "lora": {
+        "alpha": 16.0,
+        "enable": false,
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "train": {
@@ -287,15 +316,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -626,7 +655,8 @@
         "model.backbone",
         "model.head",
         "model.gram",
-        "model.lora"
+        "model.lora",
+        "model.preservation"
       ],
       "automl_enabled": false,
       "default": {
@@ -660,8 +690,19 @@
         },
         "lora": {
           "alpha": 16.0,
+          "dropout": 0.05,
           "enable": false,
-          "rank": 8
+          "num_last_blocks": 0,
+          "rank": 8,
+          "target_modules": [
+            "qkv",
+            "proj"
+          ]
+        },
+        "preservation": {
+          "cls_cosine_weight": 0.05,
+          "cls_mse_weight": 0.05,
+          "enable": false
         }
       },
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
@@ -670,7 +711,9 @@
         "centering_method",
         "gram",
         "distill",
-        "head"
+        "head",
+        "lora",
+        "preservation"
       ],
       "properties": {
         "backbone": {
@@ -921,32 +964,122 @@
           "type": "collection"
         },
         "lora": {
+          "automl_disabled_parameters": [
+            "model.lora.target_modules"
+          ],
           "automl_enabled": false,
           "default": {
             "alpha": 16.0,
+            "dropout": 0.05,
             "enable": false,
-            "rank": 8
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
           },
-          "description": "Disabled LoRA stub for forward-compatibility",
+          "description": "Configuration for LoRA parameter-efficient continual pre-training",
+          "popular": [
+            "alpha",
+            "target_modules",
+            "enable",
+            "num_last_blocks",
+            "rank"
+          ],
           "properties": {
             "alpha": {
               "default": 16.0,
-              "description": "LoRA scaling alpha",
+              "description": "LoRA scaling alpha; the applied scale is alpha / rank.",
+              "popular": true,
               "title": "lora alpha",
+              "type": "float"
+            },
+            "dropout": {
+              "default": 0.05,
+              "description": "Dropout applied to the LoRA branch input only (the frozen base path is untouched).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "lora dropout",
               "type": "float"
             },
             "enable": {
               "default": false,
-              "description": "Whether to apply LoRA adapters (disabled in v1)",
+              "description": "Whether to apply LoRA adapters to the backbone (parameter-efficient SSL)",
+              "popular": true,
               "title": "enable lora",
               "type": "bool"
             },
+            "num_last_blocks": {
+              "default": 0,
+              "description": "Adapt only the last N transformer blocks. 0 = all blocks.",
+              "maximum": Infinity,
+              "minimum": 0,
+              "popular": true,
+              "title": "lora num last blocks",
+              "type": "int"
+            },
             "rank": {
               "default": 8,
-              "description": "LoRA rank",
+              "description": "LoRA rank (r). The low-rank update is dW = (alpha/r) * B @ A.",
+              "maximum": Infinity,
               "minimum": 1,
+              "popular": true,
               "title": "lora rank",
               "type": "int"
+            },
+            "target_modules": {
+              "automl_enabled": false,
+              "default": [
+                "qkv",
+                "proj"
+              ],
+              "description": "Projections to adapt inside each targeted ViT block. 'qkv' and 'proj' are the attention projections (the v1 default); 'fc1'/'fc2' additionally adapt the FFN. SwiGLU backbones (ViT-S+/H+/7B) expose a fused fc1 and are deferred in v1.",
+              "popular": true,
+              "title": "lora target modules",
+              "type": "list"
+            }
+          },
+          "type": "collection"
+        },
+        "preservation": {
+          "automl_enabled": false,
+          "default": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
+          },
+          "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
+          "popular": [
+            "cls_cosine_weight",
+            "cls_mse_weight",
+            "enable"
+          ],
+          "properties": {
+            "cls_cosine_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token cosine preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls cosine weight",
+              "type": "float"
+            },
+            "cls_mse_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token MSE preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls mse weight",
+              "type": "float"
+            },
+            "enable": {
+              "default": false,
+              "description": "Whether to add CLS-token preservation losses against the frozen anchor teacher. Recommended alongside LoRA for continual pre-training.",
+              "popular": true,
+              "title": "enable preservation",
+              "type": "bool"
             }
           },
           "type": "collection"
@@ -1011,15 +1144,15 @@
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -1047,7 +1180,8 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1
+        "validation_interval": 1,
+        "log_every_n_steps": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
@@ -1290,15 +1424,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1338,8 +1472,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1368,14 +1502,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1402,8 +1536,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1424,14 +1558,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1646,6 +1780,13 @@
           "popular": true,
           "title": "Validation interval",
           "type": "int"
+        },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
         }
       },
       "type": "collection"
@@ -1725,6 +1866,6 @@
     "network_arch": "dinov3",
     "schema_action": "inference",
     "schema_version": 1,
-    "source": "tao-pytorch dataclass config"
+    "source": "tao-core dataclass config"
   }
 }

--- a/skills/models/tao-train-dinov3/schemas/manifest.json
+++ b/skills/models/tao-train-dinov3/schemas/manifest.json
@@ -25,6 +25,8 @@
         "model.gram",
         "model.head",
         "model.lora",
+        "model.lora.target_modules",
+        "model.preservation",
         "train",
         "train.checkpointer",
         "train.cudnn",
@@ -104,6 +106,21 @@
             "bottleneck_dim": 384,
             "hidden_dim": 2048,
             "num_layers": 3
+          },
+          "lora": {
+            "alpha": 16.0,
+            "enable": false,
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
+          },
+          "preservation": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
           }
         },
         "train": {
@@ -192,6 +209,8 @@
         "model.gram",
         "model.head",
         "model.lora",
+        "model.lora.target_modules",
+        "model.preservation",
         "train",
         "train.checkpointer",
         "train.cudnn",
@@ -271,6 +290,21 @@
             "bottleneck_dim": 384,
             "hidden_dim": 2048,
             "num_layers": 3
+          },
+          "lora": {
+            "alpha": 16.0,
+            "enable": false,
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
+          },
+          "preservation": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
           }
         },
         "train": {
@@ -359,6 +393,8 @@
         "model.gram",
         "model.head",
         "model.lora",
+        "model.lora.target_modules",
+        "model.preservation",
         "train",
         "train.checkpointer",
         "train.cudnn",
@@ -438,6 +474,21 @@
             "bottleneck_dim": 384,
             "hidden_dim": 2048,
             "num_layers": 3
+          },
+          "lora": {
+            "alpha": 16.0,
+            "enable": false,
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
+          },
+          "preservation": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
           }
         },
         "train": {
@@ -526,6 +577,8 @@
         "model.gram",
         "model.head",
         "model.lora",
+        "model.lora.target_modules",
+        "model.preservation",
         "train",
         "train.checkpointer",
         "train.cudnn",
@@ -605,6 +658,21 @@
             "bottleneck_dim": 384,
             "hidden_dim": 2048,
             "num_layers": 3
+          },
+          "lora": {
+            "alpha": 16.0,
+            "enable": false,
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
+          },
+          "preservation": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
           }
         },
         "train": {

--- a/skills/models/tao-train-dinov3/schemas/train.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/train.schema.json
@@ -1,43 +1,43 @@
 {
   "automl_default_parameters": [
-    "dataset.batch_size",
-    "dataset.workers"
+    "dataset.workers",
+    "dataset.batch_size"
   ],
   "automl_disabled_parameters": [
-    "gen_trt_engine",
-    "gen_trt_engine.tensorrt",
-    "train.schedulers.momentum",
-    "inference.gpu_ids",
+    "dataset.train_dataset",
+    "wandb.tags",
+    "inference",
+    "train.cudnn",
+    "train.gpu_ids",
+    "train.schedulers",
+    "model",
+    "model.head",
     "model.backbone",
     "dataset",
-    "wandb",
-    "dataset.train_dataset",
-    "train.schedulers",
-    "train.schedulers.weight_decay",
-    "model.gram",
-    "train.schedulers.teacher_temperature",
-    "wandb.tags",
-    "train.schedulers.learning_rate",
-    "convert",
-    "dataset.transform",
-    "train.gpu_ids",
-    "export",
     "train.checkpointer",
-    "train.schedulers.last_layer_learning_rate",
-    "model.lora",
-    "train.cudnn",
-    "model.head",
-    "train",
-    "model.distill",
-    "dataset.test_dataset",
-    "gen_trt_engine.tensorrt.layers_precision",
-    "model",
-    "dataset.transform.local_crops_scale",
     "train.optim",
-    "inference",
-    "dataset.transform.global_crops_scale",
+    "model.gram",
+    "gen_trt_engine",
+    "model.preservation",
+    "train.schedulers.weight_decay",
     "model.lora.target_modules",
-    "model.preservation"
+    "train.schedulers.last_layer_learning_rate",
+    "dataset.transform.global_crops_scale",
+    "train.schedulers.learning_rate",
+    "wandb",
+    "model.distill",
+    "train",
+    "train.schedulers.teacher_temperature",
+    "inference.gpu_ids",
+    "dataset.transform",
+    "train.schedulers.momentum",
+    "gen_trt_engine.tensorrt.layers_precision",
+    "dataset.transform.local_crops_scale",
+    "gen_trt_engine.tensorrt",
+    "convert",
+    "dataset.test_dataset",
+    "model.lora",
+    "export"
   ],
   "default": {
     "dataset": {
@@ -119,10 +119,9 @@
       "checkpoint_interval_unit": "epoch",
       "checkpointer": {
         "auto_insert_metric_name": false,
-        "dirpath": "",
         "enable_topk": false,
         "filename": "model_best_{epoch:03d}",
-        "monitor": "",
+        "replace_periodic": false,
         "save_top_k": 1
       },
       "clip_grad_norm": 3.0,
@@ -135,6 +134,7 @@
         0
       ],
       "layerwise_decay": 1.0,
+      "log_every_n_steps": 1,
       "num_epochs": 10,
       "num_gpus": 1,
       "num_nodes": 1,
@@ -143,22 +143,21 @@
         "optim": "adamw"
       },
       "precision": "16-mixed",
-      "pretrained_model_path": "",
       "results_dir": "",
       "resume_training_checkpoint_path": "",
       "schedulers": {
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -186,8 +185,7 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1,
-      "log_every_n_steps": 1
+      "validation_interval": 1
     },
     "wandb": {
       "enable": true,
@@ -304,15 +302,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 0.00000707,
-          "val_final": 0.000001,
+          "val_base": 7.07e-06,
+          "val_final": 1e-06,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -401,6 +399,7 @@
           "automl_enabled": true,
           "default": 4,
           "description": "The batch size for training",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -422,7 +421,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -439,7 +438,7 @@
           "properties": {
             "images_dir": {
               "default": "",
-              "description": "Path to an extracted images directory for the dataset. Archive files such as .tar, .tar.gz, .tgz, and .zip are not supported.",
+              "description": "Path to the extracted images directory for the dataset (not an archive such as .tar.gz)",
               "title": "image directory",
               "type": "string"
             }
@@ -469,11 +468,11 @@
           },
           "description": "Configuration parameters for data transformation",
           "popular": [
-            "local_crops_size",
-            "global_crops_size",
-            "global_crops_scale",
-            "local_crops_scale",
             "n_global_crops",
+            "global_crops_size",
+            "local_crops_scale",
+            "global_crops_scale",
+            "local_crops_size",
             "n_local_crops"
           ],
           "properties": {
@@ -491,6 +490,7 @@
             "global_crops_size": {
               "default": 256,
               "description": "Size of global crops for DINOv3 training.",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Global Crops Size",
@@ -510,6 +510,7 @@
             "local_crops_size": {
               "default": 112,
               "description": "Size of local crops (multiple of patch 16)",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Local Crops Size",
@@ -518,6 +519,7 @@
             "n_global_crops": {
               "default": 2,
               "description": "Number of global crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Global Crops",
@@ -526,6 +528,7 @@
             "n_local_crops": {
               "default": 8,
               "description": "Number of local crops to generate",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "Number of Local Crops",
@@ -539,6 +542,7 @@
           "automl_enabled": true,
           "default": 8,
           "description": "The number of parallel workers processing data",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "batch size",
@@ -612,12 +616,12 @@
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
       "popular": [
         "backbone",
-        "centering_method",
-        "gram",
+        "lora",
         "distill",
         "head",
-        "lora",
-        "preservation"
+        "preservation",
+        "centering_method",
+        "gram"
       ],
       "properties": {
         "backbone": {
@@ -633,11 +637,11 @@
           },
           "description": "Configuration for the DINOv3 backbone",
           "popular": [
+            "patch_size",
+            "rope_theta",
             "img_size",
             "num_register_tokens",
-            "drop_path_rate",
-            "rope_theta",
-            "patch_size"
+            "drop_path_rate"
           ],
           "properties": {
             "drop_path_rate": {
@@ -662,6 +666,7 @@
             "num_register_tokens": {
               "default": 4,
               "description": "Number of register tokens (DINOv3 ViT-B uses 4)",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "num register tokens",
@@ -679,7 +684,7 @@
             },
             "rope_theta": {
               "default": 100.0,
-              "description": "Frequency base for 2D axial RoPE. Defaults to 100.0 and may be tuned; changing it alters rotary position encoding.",
+              "description": "Frequency base for 2D axial RoPE. Must match the timm DINOv3 reference; verified by the step-4 feature-parity smoke test.",
               "popular": true,
               "title": "RoPE theta",
               "type": "float"
@@ -735,8 +740,8 @@
           },
           "description": "Configuration for distillation (reused from nvdinov2)",
           "popular": [
-            "disable_masking",
-            "enable"
+            "enable",
+            "disable_masking"
           ],
           "properties": {
             "disable_masking": {
@@ -773,9 +778,9 @@
           },
           "description": "Configuration for DINOv3 Gram anchoring",
           "popular": [
-            "w_gram",
             "start_step",
-            "enable"
+            "enable",
+            "w_gram"
           ],
           "properties": {
             "enable": {
@@ -788,6 +793,7 @@
             "refresh_interval": {
               "default": 0,
               "description": "Steps between refreshing the Gram teacher from the EMA teacher (only when teacher_source='ema'). 0 = never refresh (frozen snapshot, Phase 0 behavior).",
+              "maximum": Infinity,
               "minimum": 0,
               "title": "gram refresh interval",
               "type": "int"
@@ -795,6 +801,7 @@
             "start_step": {
               "default": 0,
               "description": "Global step at which the Gram term activates",
+              "maximum": Infinity,
               "minimum": 0,
               "popular": true,
               "title": "gram start step",
@@ -835,14 +842,15 @@
           },
           "description": "Configuration for the DINOv3 head (reused from nvdinov2)",
           "popular": [
-            "hidden_dim",
             "bottleneck_dim",
-            "num_layers"
+            "num_layers",
+            "hidden_dim"
           ],
           "properties": {
             "bottleneck_dim": {
               "default": 384,
               "description": "Dimension of the bottleneck layer in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "bottleneck dimension",
@@ -851,6 +859,7 @@
             "hidden_dim": {
               "default": 2048,
               "description": "Dimension of the hidden layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "hidden dimension",
@@ -859,6 +868,7 @@
             "num_layers": {
               "default": 3,
               "description": "Number of layers in the NVDINOv2 head",
+              "maximum": Infinity,
               "minimum": 1,
               "popular": true,
               "title": "number of Layers",
@@ -885,11 +895,11 @@
           },
           "description": "Configuration for LoRA parameter-efficient continual pre-training",
           "popular": [
+            "rank",
+            "num_last_blocks",
             "alpha",
             "target_modules",
-            "enable",
-            "num_last_blocks",
-            "rank"
+            "enable"
           ],
           "properties": {
             "alpha": {
@@ -955,8 +965,8 @@
           },
           "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
           "popular": [
-            "cls_cosine_weight",
             "cls_mse_weight",
+            "cls_cosine_weight",
             "enable"
           ],
           "properties": {
@@ -1017,10 +1027,9 @@
         "checkpoint_interval_unit": "epoch",
         "checkpointer": {
           "auto_insert_metric_name": false,
-          "dirpath": "",
           "enable_topk": false,
           "filename": "model_best_{epoch:03d}",
-          "monitor": "",
+          "replace_periodic": false,
           "save_top_k": 1
         },
         "clip_grad_norm": 3.0,
@@ -1033,6 +1042,7 @@
           0
         ],
         "layerwise_decay": 1.0,
+        "log_every_n_steps": 1,
         "num_epochs": 10,
         "num_gpus": 1,
         "num_nodes": 1,
@@ -1041,22 +1051,21 @@
           "optim": "adamw"
         },
         "precision": "16-mixed",
-        "pretrained_model_path": "",
         "results_dir": "",
         "resume_training_checkpoint_path": "",
         "schedulers": {
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 0.00000707,
-            "val_final": 0.000001,
+            "val_base": 7.07e-06,
+            "val_final": 1e-06,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -1084,25 +1093,24 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1,
-        "log_every_n_steps": 1
+        "validation_interval": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
-        "schedulers",
-        "num_prototypes",
-        "checkpoint_interval",
-        "use_custom_attention",
-        "num_gpus",
-        "clip_grad_norm",
-        "validation_interval",
         "layerwise_decay",
+        "checkpoint_interval",
         "optim",
-        "num_nodes",
-        "distributed_strategy",
-        "num_epochs",
         "gpu_ids",
-        "precision"
+        "validation_interval",
+        "num_gpus",
+        "precision",
+        "num_prototypes",
+        "schedulers",
+        "distributed_strategy",
+        "num_nodes",
+        "clip_grad_norm",
+        "num_epochs",
+        "use_custom_attention"
       ],
       "properties": {
         "checkpoint_interval": {
@@ -1127,10 +1135,9 @@
           "automl_enabled": false,
           "default": {
             "auto_insert_metric_name": false,
-            "dirpath": "",
             "enable_topk": false,
             "filename": "model_best_{epoch:03d}",
-            "monitor": "",
+            "replace_periodic": false,
             "save_top_k": 1
           },
           "properties": {
@@ -1139,13 +1146,12 @@
               "type": "bool"
             },
             "dirpath": {
-              "default": "",
               "description": "Directory for best checkpoints. Defaults to results_dir.",
               "type": "string"
             },
             "enable_topk": {
               "default": false,
-              "description": "Save the top-K checkpoints ranked by a monitored metric, in addition to the periodic checkpoints.",
+              "description": "Save checkpoint(s) ranked by a monitored metric. This is additive to periodic checkpoints unless replace_periodic is enabled.",
               "title": "Enable best-checkpoint saving",
               "type": "bool"
             },
@@ -1155,7 +1161,7 @@
               "type": "string"
             },
             "mode": {
-              "description": "Override direction. 'min' for losses, 'max' for accuracy/mAP/mIoU. Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default direction.",
               "enum": [
                 "min",
                 "max"
@@ -1164,14 +1170,18 @@
               "type": "categorical"
             },
             "monitor": {
-              "default": "",
-              "description": "Override the network's default monitored metric (e.g. val_loss, val_acc, val_miou, mAP). Leave unset to use the network default.",
+              "description": "Leave unset to use the network's default metric.",
               "title": "Monitored metric",
               "type": "string"
             },
+            "replace_periodic": {
+              "default": false,
+              "description": "When best-checkpoint saving is enabled, replace periodic history with one metric-best checkpoint and its latest symlink.",
+              "title": "Replace periodic checkpoints",
+              "type": "bool"
+            },
             "save_top_k": {
               "default": 1,
-              "description": "How many best checkpoints to keep (1 = only the single best).",
               "minimum": 1,
               "title": "Number of best checkpoints",
               "type": "int"
@@ -1192,6 +1202,7 @@
             "benchmark": true,
             "deterministic": false
           },
+          "description": "CuDNN settings compatible with DINOv3 custom attention.",
           "properties": {
             "benchmark": {
               "default": true,
@@ -1237,9 +1248,17 @@
           "title": "layerwise decay factor",
           "type": "float"
         },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
+        },
         "num_epochs": {
           "default": 10,
           "description": "Number of epochs to run the training.",
+          "maximum": Infinity,
           "minimum": 1,
           "popular": true,
           "title": "Number of epochs",
@@ -1328,15 +1347,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 0.00000707,
-              "val_final": 0.000001,
+              "val_base": 7.07e-06,
+              "val_final": 1e-06,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1366,9 +1385,9 @@
           "popular": [
             "learning_rate",
             "weight_decay",
-            "last_layer_learning_rate",
             "teacher_temperature",
-            "momentum"
+            "momentum",
+            "last_layer_learning_rate"
           ],
           "properties": {
             "last_layer_learning_rate": {
@@ -1376,8 +1395,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1385,10 +1404,10 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
-                "freeze_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "freeze_steps",
+                "max_decay_steps"
               ],
               "properties": {
                 "freeze_steps": {
@@ -1406,14 +1425,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1440,8 +1459,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 0.00000707,
-                "val_final": 0.000001,
+                "val_base": 7.07e-06,
+                "val_final": 1e-06,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1449,9 +1468,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1462,14 +1481,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 0.00000707,
+                  "default": 7.07e-06,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 0.000001,
+                  "default": 1e-06,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1505,9 +1524,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1561,9 +1580,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1617,9 +1636,9 @@
               "popular": [
                 "val_base",
                 "val_final",
-                "max_decay_steps",
+                "val_start",
                 "warm_up_steps",
-                "val_start"
+                "max_decay_steps"
               ],
               "properties": {
                 "max_decay_steps": {
@@ -1666,6 +1685,7 @@
         "seed": {
           "default": 1234,
           "description": "The seed for the initializer in PyTorch. If < 0, disable fixed seed.",
+          "maximum": Infinity,
           "minimum": -1,
           "title": "Seed for randomization",
           "type": "int"
@@ -1683,13 +1703,6 @@
           "minimum": 1,
           "popular": true,
           "title": "Validation interval",
-          "type": "int"
-        },
-        "log_every_n_steps": {
-          "default": 1,
-          "description": "Number of training steps between logger updates.",
-          "minimum": 1,
-          "title": "logging interval",
           "type": "int"
         }
       },

--- a/skills/models/tao-train-dinov3/schemas/train.schema.json
+++ b/skills/models/tao-train-dinov3/schemas/train.schema.json
@@ -35,7 +35,9 @@
     "dataset.transform.local_crops_scale",
     "train.optim",
     "inference",
-    "dataset.transform.global_crops_scale"
+    "dataset.transform.global_crops_scale",
+    "model.lora.target_modules",
+    "model.preservation"
   ],
   "default": {
     "dataset": {
@@ -95,8 +97,19 @@
       },
       "lora": {
         "alpha": 16.0,
+        "dropout": 0.05,
         "enable": false,
-        "rank": 8
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "model_name": "",
@@ -137,15 +150,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -173,7 +186,8 @@
       },
       "seed": 1234,
       "use_custom_attention": true,
-      "validation_interval": 1
+      "validation_interval": 1,
+      "log_every_n_steps": 1
     },
     "wandb": {
       "enable": true,
@@ -253,6 +267,21 @@
         "bottleneck_dim": 384,
         "hidden_dim": 2048,
         "num_layers": 3
+      },
+      "lora": {
+        "alpha": 16.0,
+        "enable": false,
+        "num_last_blocks": 0,
+        "rank": 8,
+        "target_modules": [
+          "qkv",
+          "proj"
+        ]
+      },
+      "preservation": {
+        "cls_cosine_weight": 0.05,
+        "cls_mse_weight": 0.05,
+        "enable": false
       }
     },
     "train": {
@@ -275,15 +304,15 @@
         "last_layer_learning_rate": {
           "freeze_steps": 1250,
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
         "learning_rate": {
           "max_decay_steps": 2500000,
-          "val_base": 7.07e-06,
-          "val_final": 1e-06,
+          "val_base": 0.00000707,
+          "val_final": 0.000001,
           "val_start": 0.0,
           "warm_up_steps": 100000
         },
@@ -530,7 +559,8 @@
         "model.backbone",
         "model.head",
         "model.gram",
-        "model.lora"
+        "model.lora",
+        "model.preservation"
       ],
       "automl_enabled": false,
       "default": {
@@ -564,8 +594,19 @@
         },
         "lora": {
           "alpha": 16.0,
+          "dropout": 0.05,
           "enable": false,
-          "rank": 8
+          "num_last_blocks": 0,
+          "rank": 8,
+          "target_modules": [
+            "qkv",
+            "proj"
+          ]
+        },
+        "preservation": {
+          "cls_cosine_weight": 0.05,
+          "cls_mse_weight": 0.05,
+          "enable": false
         }
       },
       "description": "Configurable parameters to construct the model for a DINOv3 experiment.",
@@ -574,7 +615,9 @@
         "centering_method",
         "gram",
         "distill",
-        "head"
+        "head",
+        "lora",
+        "preservation"
       ],
       "properties": {
         "backbone": {
@@ -825,32 +868,122 @@
           "type": "collection"
         },
         "lora": {
+          "automl_disabled_parameters": [
+            "model.lora.target_modules"
+          ],
           "automl_enabled": false,
           "default": {
             "alpha": 16.0,
+            "dropout": 0.05,
             "enable": false,
-            "rank": 8
+            "num_last_blocks": 0,
+            "rank": 8,
+            "target_modules": [
+              "qkv",
+              "proj"
+            ]
           },
-          "description": "Disabled LoRA stub for forward-compatibility",
+          "description": "Configuration for LoRA parameter-efficient continual pre-training",
+          "popular": [
+            "alpha",
+            "target_modules",
+            "enable",
+            "num_last_blocks",
+            "rank"
+          ],
           "properties": {
             "alpha": {
               "default": 16.0,
-              "description": "LoRA scaling alpha",
+              "description": "LoRA scaling alpha; the applied scale is alpha / rank.",
+              "popular": true,
               "title": "lora alpha",
+              "type": "float"
+            },
+            "dropout": {
+              "default": 0.05,
+              "description": "Dropout applied to the LoRA branch input only (the frozen base path is untouched).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "lora dropout",
               "type": "float"
             },
             "enable": {
               "default": false,
-              "description": "Whether to apply LoRA adapters (disabled in v1)",
+              "description": "Whether to apply LoRA adapters to the backbone (parameter-efficient SSL)",
+              "popular": true,
               "title": "enable lora",
               "type": "bool"
             },
+            "num_last_blocks": {
+              "default": 0,
+              "description": "Adapt only the last N transformer blocks. 0 = all blocks.",
+              "maximum": Infinity,
+              "minimum": 0,
+              "popular": true,
+              "title": "lora num last blocks",
+              "type": "int"
+            },
             "rank": {
               "default": 8,
-              "description": "LoRA rank",
+              "description": "LoRA rank (r). The low-rank update is dW = (alpha/r) * B @ A.",
+              "maximum": Infinity,
               "minimum": 1,
+              "popular": true,
               "title": "lora rank",
               "type": "int"
+            },
+            "target_modules": {
+              "automl_enabled": false,
+              "default": [
+                "qkv",
+                "proj"
+              ],
+              "description": "Projections to adapt inside each targeted ViT block. 'qkv' and 'proj' are the attention projections (the v1 default); 'fc1'/'fc2' additionally adapt the FFN. SwiGLU backbones (ViT-S+/H+/7B) expose a fused fc1 and are deferred in v1.",
+              "popular": true,
+              "title": "lora target modules",
+              "type": "list"
+            }
+          },
+          "type": "collection"
+        },
+        "preservation": {
+          "automl_enabled": false,
+          "default": {
+            "cls_cosine_weight": 0.05,
+            "cls_mse_weight": 0.05,
+            "enable": false
+          },
+          "description": "Configuration for CLS-token preservation against the frozen anchor teacher",
+          "popular": [
+            "cls_cosine_weight",
+            "cls_mse_weight",
+            "enable"
+          ],
+          "properties": {
+            "cls_cosine_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token cosine preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls cosine weight",
+              "type": "float"
+            },
+            "cls_mse_weight": {
+              "default": 0.05,
+              "description": "Weight of the CLS-token MSE preservation term (0 disables just this term).",
+              "maximum": Infinity,
+              "minimum": 0.0,
+              "popular": true,
+              "title": "cls mse weight",
+              "type": "float"
+            },
+            "enable": {
+              "default": false,
+              "description": "Whether to add CLS-token preservation losses against the frozen anchor teacher. Recommended alongside LoRA for continual pre-training.",
+              "popular": true,
+              "title": "enable preservation",
+              "type": "bool"
             }
           },
           "type": "collection"
@@ -915,15 +1048,15 @@
           "last_layer_learning_rate": {
             "freeze_steps": 1250,
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
           "learning_rate": {
             "max_decay_steps": 2500000,
-            "val_base": 7.07e-06,
-            "val_final": 1e-06,
+            "val_base": 0.00000707,
+            "val_final": 0.000001,
             "val_start": 0.0,
             "warm_up_steps": 100000
           },
@@ -951,7 +1084,8 @@
         },
         "seed": 1234,
         "use_custom_attention": true,
-        "validation_interval": 1
+        "validation_interval": 1,
+        "log_every_n_steps": 1
       },
       "description": "Configurable parameters to construct the trainer for a DINOv3 experiment.",
       "popular": [
@@ -1194,15 +1328,15 @@
             "last_layer_learning_rate": {
               "freeze_steps": 1250,
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
             "learning_rate": {
               "max_decay_steps": 2500000,
-              "val_base": 7.07e-06,
-              "val_final": 1e-06,
+              "val_base": 0.00000707,
+              "val_final": 0.000001,
               "val_start": 0.0,
               "warm_up_steps": 100000
             },
@@ -1242,8 +1376,8 @@
               "default": {
                 "freeze_steps": 1250,
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1272,14 +1406,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler.",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1306,8 +1440,8 @@
               "automl_enabled": false,
               "default": {
                 "max_decay_steps": 2500000,
-                "val_base": 7.07e-06,
-                "val_final": 1e-06,
+                "val_base": 0.00000707,
+                "val_final": 0.000001,
                 "val_start": 0.0,
                 "warm_up_steps": 100000
               },
@@ -1328,14 +1462,14 @@
                   "type": "int"
                 },
                 "val_base": {
-                  "default": 7.07e-06,
+                  "default": 0.00000707,
                   "description": "The value after warm-up for scheduler",
                   "popular": true,
                   "title": "base value",
                   "type": "float"
                 },
                 "val_final": {
-                  "default": 1e-06,
+                  "default": 0.000001,
                   "description": "Final value for scheduler",
                   "popular": true,
                   "title": "final value",
@@ -1550,6 +1684,13 @@
           "popular": true,
           "title": "Validation interval",
           "type": "int"
+        },
+        "log_every_n_steps": {
+          "default": 1,
+          "description": "Number of training steps between logger updates.",
+          "minimum": 1,
+          "title": "logging interval",
+          "type": "int"
         }
       },
       "type": "collection"
@@ -1629,6 +1770,6 @@
     "network_arch": "dinov3",
     "schema_action": "train",
     "schema_version": 1,
-    "source": "tao-pytorch dataclass config"
+    "source": "tao-core dataclass config"
   }
 }

--- a/skills/models/tao-train-visual-changenet/SKILL.md
+++ b/skills/models/tao-train-visual-changenet/SKILL.md
@@ -29,14 +29,11 @@ Visual ChangeNet is a TAO Toolkit model for visual inspection and defect detecti
 - **Classify** — Binary image classification using a siamese-style architecture with a shared backbone (C-RADIO ViT) and a learnable difference module. Compares image pairs to classify defects as PASS/NO_PASS.
 - **Segment** — Pixel-level change segmentation using a ViT-Large NVDINOv2 backbone. Compares before/after image pairs to produce a binary change mask.
 
-The backbone weight (`c_radio_v2_vit_base_patch16_224`) is the **public** `nvidia/C-RADIOv2-B` model from HuggingFace, distributed as `model.safetensors` (~393 MB). **The TAO container does not auto-fetch from HF URLs** — `ptm_utils.load_pretrained_weights()` hands the `pretrained_backbone_path` value to `torch.load(path)` / `safetensors.torch.load_file(path)` directly. Passing an `https://huggingface.co/...` URL or a repo id produces `FileNotFoundError` and the run fails with `Execution status: FAIL` within a few seconds. Stage the file locally before launch with the bundled helper (idempotent — reuses an already-staged file):
-
-```bash
-python3 skills/models/tao-train-visual-changenet/scripts/stage_backbone.py --workspace <workspace>
-# -> <workspace>/pretrained_models/C-RADIOv2_B.safetensors
-```
-
-This is a **public** download — **no NGC CLI, no NGC org, and no credentials** are required, and there is **no `ngc://` transfer-learning checkpoint dependency** (VCN trains from this backbone). Run it in the CPU shell, where host network and `HF_TOKEN` live; `HF_TOKEN` is read only if set (gated mirror / rate limit) and is needed at staging time only, never inside the training container. Mount the staged file into the container (`-v <workspace>/pretrained_models/C-RADIOv2_B.safetensors:/data/pretrained_models/C-RADIOv2_B.safetensors`) and set the spec `model.backbone.pretrained_backbone_path` to the container path.
+Classify supports the public C-RADIOv2-B backbone and six frozen DINOv3
+variants. Read `references/dinov3-backbones.md` before selecting DINOv3; it
+contains the exact variant map, freeze requirement, Hugging Face access rules,
+and local-staging overlay. For C-RADIO, use the bundled
+`scripts/stage_backbone.py` and the mount in `references/local-docker.md`.
 
 Segment specs use `model.backbone.type: vit_large_nvdinov2` and the NVDINOv2
 checkpoint family. Keep the checkpoint architecture aligned with the backbone

--- a/skills/models/tao-train-visual-changenet/references/dinov3-backbones.md
+++ b/skills/models/tao-train-visual-changenet/references/dinov3-backbones.md
@@ -1,0 +1,44 @@
+# Frozen DINOv3 backbones
+
+Visual ChangeNet classify can use these frozen DINOv3 backbones:
+
+| `model.backbone.type` | Hugging Face/timm model |
+|---|---|
+| `vit_small_dinov3` | `timm/vit_small_patch16_dinov3.lvd1689m` |
+| `vit_small_plus_dinov3` | `timm/vit_small_plus_patch16_dinov3.lvd1689m` |
+| `vit_base_dinov3` | `timm/vit_base_patch16_dinov3.lvd1689m` |
+| `vit_large_dinov3` | `timm/vit_large_patch16_dinov3.lvd1689m` |
+| `vit_huge_plus_dinov3` | `timm/vit_huge_plus_patch16_dinov3.lvd1689m` |
+| `vit_7b_dinov3` | `timm/vit_7b_patch16_dinov3.lvd1689m` |
+
+Accept the DINOv3 license and export `HF_TOKEN` before a gated download.
+DINOv3 is supported only as a frozen Visual ChangeNet backbone:
+
+```yaml
+model:
+  backbone:
+    type: vit_base_dinov3
+    freeze_backbone: true
+    # Empty selects the matching timm/Hugging Face weights at container startup.
+    pretrained_backbone_path: ''
+```
+
+Pass `HF_TOKEN` into the container when `pretrained_backbone_path` is empty.
+This automatic fetch is DINOv3-specific; C-RADIO paths are always local files.
+
+For a reproducible or air-gapped standalone run, use Hugging Face tooling to
+stage `model.safetensors` from the mapped repository, then point the spec at
+its in-container mount. When the full skill bank is installed, the DEFT helper
+can stage any supported profile and reads `HF_TOKEN` only on the host:
+
+```bash
+python3 skills/applications/tao-run-deft-aoi/scripts/stage_backbone.py \
+  --workspace <workspace> --backbone-type vit_base_dinov3
+# -> <workspace>/augmentation/backbone/vit_base_dinov3.safetensors
+```
+
+Then mount that exact file and replace the empty value above with, for example,
+`/data/pretrained_models/vit_base_dinov3.safetensors`. The backbone type,
+staged filename, and checkpoint architecture must agree. In the full DEFT AOI
+workflow, follow `tao-run-deft-aoi/references/visual-changenet.md`; its preflight
+validates this pairing and rewrites the container path.

--- a/skills/models/tao-train-visual-changenet/references/local-docker.md
+++ b/skills/models/tao-train-visual-changenet/references/local-docker.md
@@ -32,7 +32,10 @@ file or mount its parent directory, and set
 `model.backbone.pretrained_backbone_path` to the container path
 `/data/pretrained_models/C-RADIOv2_B.safetensors`.
 
-Override checkpoint and results_dir on the command line to avoid editing the spec:
+Select an actual `model_epoch_*_step_*.pth` checkpoint or the
+`changenet_model_classify_latest.pth` symlink produced by training. Override it
+with an explicit container path; `${results_dir}` is action-local and must not
+be used to cross from inference/evaluate/export back into the train directory:
 ```bash
 visual_changenet inference -e /data/workspace/specs/spec.yaml \
     inference.checkpoint=/results/<iter>/train/model_epoch_<EEE>_step_<SSS>.pth \

--- a/skills/models/tao-train-visual-changenet/references/spec_template_train.yaml
+++ b/skills/models/tao-train-visual-changenet/references/spec_template_train.yaml
@@ -12,6 +12,8 @@ train:
   num_nodes: 1
   validation_interval: 50
   checkpoint_interval: 200
+  # For FAR-optimized retention, set enable_topk=true, monitor=val_far, and
+  # mode=min. optim.monitor_name alone does not select checkpoints.
   checkpointer:
     enable_topk: false
     replace_periodic: false
@@ -113,7 +115,9 @@ dataset:
       augment: true
     num_classes: 2
 evaluate:
-  checkpoint: ${results_dir}/train/changenet_model_classify_latest.pth
+  # Resolve a concrete parent-training checkpoint; do not interpolate results_dir
+  # across action-specific output directories.
+  checkpoint: ''
   trt_engine: ${results_dir}/gen_trt_engine/changenet-classify.trt
   batch_size: ${dataset.classify.batch_size}
 inference:
@@ -122,7 +126,7 @@ inference:
   batch_size: ${dataset.classify.batch_size}
 export:
   gpu_id: 0
-  checkpoint: ${results_dir}/train/changenet_model_classify_latest.pth
+  checkpoint: ''
   onnx_file: ${results_dir}/export/changenet-classify.onnx
   input_width: 128
   input_height: 512

--- a/skills/models/tao-train-visual-changenet/references/troubleshooting.md
+++ b/skills/models/tao-train-visual-changenet/references/troubleshooting.md
@@ -3,12 +3,12 @@
 ## Error Patterns
 
 **Checkpoint not found**: The evaluate, inference, export, and quantize actions
-require a valid checkpoint path. Current TAO 6.25.10 Visual ChangeNet training
-emits epoch/step checkpoint files such as `model_epoch_000_step_00012.pth`;
-it does not necessarily write `changenet_model_classify_latest.pth` or
-`changenet_model_segment_latest.pth`. Use the model-skill `parent_model`
-resolver for downstream actions and `resume_model` for resume, or pass the exact
-epoch/step checkpoint when running local Docker directly.
+require a concrete checkpoint path. Training emits files such as
+`model_epoch_000_step_00012.pth` and the task-specific latest symlink. Use the
+model-skill `parent_model` resolver for downstream actions and `resume_model`
+for resume, or pass the exact container path when running local Docker. Do not
+build a cross-action path from `${results_dir}`; TAO rebases it to the current
+action's output directory.
 
 **CSV format mismatch**: The classify CSV must have exactly four columns:
 `input_path`, `golden_path`, `label`, and `object_name`. Missing columns or
@@ -20,8 +20,6 @@ characters and uses comma delimiters (not semicolons or tabs).
 **OOM during training**: Reduce `dataset.classify.batch_size` (16 -> 8 -> 4). With the default image size of 224x224, batch_size=16 typically fits on a 16GB GPU. If using larger images via `image_width`/`image_height`, reduce batch size proportionally.
 
 **Low evaluation accuracy with correct training loss**: The `eval_margin` threshold may be miscalibrated for your data. After training, run inference on a validation set and inspect the embedding distance distribution to pick an appropriate threshold. The default 0.3 is tuned for the reference dataset and may not generalize.
-
-**`AssertionError: Contrastive loss only supports Euclidean distance module`** at evaluate/inference: the spec dropped the `train` subtree. Model `__init__` reads `train.classify.loss` regardless of action; omitting it falls back to contrastive loss, which then conflicts with non-default `model.classify.difference_module` (e.g. `learnable`) saved in the checkpoint. Keep `train.classify.loss` (and `train.classify.cls_weight`) in the spec for evaluate and inference too.
 
 **Checkpoint load key mismatch at evaluate/inference**: Keep the classify model
 architecture fields aligned with the train spec. C-RADIO classify checkpoints

--- a/skills/models/tao-train-visual-changenet/references/tuning-parameters.md
+++ b/skills/models/tao-train-visual-changenet/references/tuning-parameters.md
@@ -24,6 +24,29 @@ with the single best checkpoint. When retention is disabled, periodic saving
 remains in effect. Checkpointer fields control artifact lifecycle and must not
 be included in the AutoML search space.
 
+### Retain the best FAR checkpoint
+
+`train.optim.monitor_name` is scheduler metadata; it does not configure
+checkpoint selection. `val_far` is FAR at 100% defect recall. If validation is
+missing either PASS or defect samples, it reports the explicit worst-case
+`100.0` sentinel; use a two-class validation split for meaningful retention.
+To retain the lowest validation false-alarm rate, set the checkpointer
+explicitly:
+
+```yaml
+train:
+  checkpointer:
+    enable_topk: true
+    monitor: val_far
+    mode: min
+    save_top_k: 1
+    replace_periodic: false
+```
+
+With `replace_periodic: false`, metric-best retention is additive to periodic
+checkpoints. Set it to `true` only when the single best-FAR checkpoint should
+replace periodic history and drive the latest symlink.
+
 ## Hardware
 
 - **Minimum**: 1 GPU with 16GB+ VRAM (V100 or A100). Single-GPU training works for small datasets (<10k images).


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Refresh the generated DINOv3 skill schemas and templates with complete LoRA and preservation configuration plus configurable loss-log cadence.
- Document all six frozen DINOv3 Visual ChangeNet backbones, gated Hugging Face access, local staging, and exact architecture/path matching.
- Add the `val_far` best-checkpoint recipe and define its FAR-at-100%-recall semantics, including the single-class `100.0` sentinel.
- Require explicit downstream Visual ChangeNet checkpoints and retain only the narrow `train.classify.loss` compatibility stub while the documented image baseline remains TAO 7.1; tao-pytorch #107 removes that requirement in TAO 7.2.
- Add executable release-contract and schema-drift coverage for these workflows.

### Why are the changes needed?

The TAO 7.2 skill contracts had drifted from the runtime and source-of-truth dataclasses. This caused incomplete DINOv3 specs, ambiguous Visual ChangeNet checkpoint retention, unavailable backbone guidance, and an unclear compatibility boundary between the pinned TAO 7.1 image and the TAO 7.2 runtime fix.

### Related issues

- [TLT-5942](https://jirasw.nvidia.com/browse/TLT-5942) / [NVBug 6642016](https://nvbugs.nvidia.com/bug/6642016) — expose DINOv3 loss-log cadence.
- [TLT-5937](https://jirasw.nvidia.com/browse/TLT-5937) / [NVBug 6642001](https://nvbugs.nvidia.com/bug/6642001) — retain the best Visual ChangeNet FAR checkpoint.
- [TLT-5932](https://jirasw.nvidia.com/browse/TLT-5932) / [NVBug 6641994](https://nvbugs.nvidia.com/bug/6641994) — document frozen DINOv3 and gated-weight staging.
- [TLT-5931](https://jirasw.nvidia.com/browse/TLT-5931) / [NVBug 6641991](https://nvbugs.nvidia.com/bug/6641991) — complete DINOv3 LoRA and preservation contracts.
- [TLT-5928](https://jirasw.nvidia.com/browse/TLT-5928) / [NVBug 6641956](https://nvbugs.nvidia.com/bug/6641956) — cover all six DINOv3 backbone variants.
- [TLT-5921](https://jirasw.nvidia.com/browse/TLT-5921) / [NVBug 6602769](https://nvbugs.nvidia.com/bug/6602769) — require explicit downstream checkpoints.
- [TLT-5925](https://jirasw.nvidia.com/browse/TLT-5925) / [NVBug 6604829](https://nvbugs.nvidia.com/bug/6604829) — documents the version boundary and preserves the current pinned-image handoff while tao-pytorch #107 removes the runtime requirement.

### Does this PR introduce _any_ user-facing change?

Yes. DINOv3 specs expose the supported TAO 7.2 controls, and Visual ChangeNet guidance now produces explicit, reproducible checkpoint and frozen-backbone handoffs.

### How was this patch tested?

- `git diff --check origin/main...HEAD`
- `pre-commit run --from-ref origin/main --to-ref HEAD --show-diff-on-failure`
- `./scripts/validate-skills.sh --all`
- Focused schema-drift, release-contract, and executable inference-handoff suite: 36 passed in the pinned TAO container.
- Full `scripts/tests` suite: 269 tests passed before the final panel-only documentation/test-assertion cleanup; the affected suite was rerun afterward.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)

### Release note

Align TAO 7.2 DINOv3 and Visual ChangeNet skill contracts with the runtime, including LoRA/preservation fields, loss-log cadence, DINOv3 frozen backbones, FAR checkpoint retention, and explicit downstream checkpoints.

### Checklist

- [x] Commits include DCO sign-offs.
- [x] New and changed Python files include SPDX headers.
- [x] Local focused tests and skill validation pass.
- [x] User-facing reference material and templates are updated.
- [x] All related Jira tickets and NVBugs are linked.

### Notes for reviewers

Dependencies:

- Schema provenance: [tao-core #35](https://github.com/NVIDIA-TAO/tao-core/pull/35).
- Runtime behavior: [tao-pytorch #107](https://github.com/NVIDIA-TAO/tao-pytorch/pull/107).

The tao-core and tao-pytorch PRs may merge independently. This skill-bank PR must merge/backport last, after tao-core #35 is merged and the TAO 7.2 image pin includes tao-pytorch #107. If tao-core #35 changes before merge, regenerate and recheck the DINOv3 schemas.
