### PR TITLE
[TAO-2230][Bugfix] deft-od: make the documented commands runnable as written

### DIFF
--- a/skills/applications/tao-run-deft-object-detection/SKILL.md
+++ b/skills/applications/tao-run-deft-object-detection/SKILL.md
@@ -139,6 +139,8 @@ Run bundled scripts through `<skill_root>/scripts/deft_python.sh`. Resolve every
 
 Each stage maps to one underlying skill or to bundled glue. **Read only the current stage's overlay, then invoke.**
 
+The overlays are written against two loop variables that Pre-Flight sets and every stage uses: `N`, the current iteration number, and `PHASE`, which is `baseline` or `iter${N}`. They are stated here because a stage overlay is read on its own — see `references/preflight.md` for the full set.
+
 If an *overlay* is missing, stop and ask the user to reinstall the plugin — the loop cannot run a stage whose settings it does not have. If a mapped *skill* is unavailable, do not stop and do not improvise: fall back to the overlay's documented `docker run` as described in `references/scripts-and-agents.md`, and record `execution_path=direct-container`. The overlay carries everything the invocation needs, so the fallback produces the same artifacts.
 
 | Stage | Overlay | Underlying skill |

--- a/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
+++ b/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
@@ -117,8 +117,10 @@ nobody applies. They are therefore held in `assets/overlays/grounding_dino_infer
 and applied on every run:
 
 ```bash
+INFER_SPEC="${RESULTS_DIR}/<phase>/infer_grounding_dino.yaml"
+
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/apply_spec_overrides.py \
-  --spec "${RESULTS_DIR}/<phase>/infer_grounding_dino.yaml" \
+  --spec "$INFER_SPEC" \
   --apply-workflow-defaults <skill_root>/assets/overlays/grounding_dino_inference.yaml \
   --set inference.checkpoint=<checkpoint> \
   --set inference.num_gpus="$NUM_GPUS" \
@@ -153,8 +155,8 @@ Nothing about this is enforced by TAO, so check it before every inference:
 
 ```bash
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/verify_class_contract.py \
-  --inference-spec "$GDINO_INFER_SPEC" \
-  --kpi-mapping "$KPI_CLASS_MAPPING" \
+  --inference-spec "$INFER_SPEC" \
+  --kpi-mapping "$CLASS_MAPPING" \
   --state "${RESULTS_DIR}/deft_state.json" \
   --labelmap "${RESULTS_DIR}/iter${N}/tmm/annotations/labelmap.json"
 ```
@@ -185,8 +187,12 @@ Wait on the labels, the same way training does — `results_dir` gains the actio
 so both the labels and `status.json` sit under `inference/`:
 
 ```bash
+LAUNCH_MARKER="${RESULTS_DIR}/<phase>/.inference_launched"
+mkdir -p "$(dirname "$LAUNCH_MARKER")" && touch "$LAUNCH_MARKER"
+# ... launch the container ...
+
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/await_stage.py \
-  --artifact "${RESULTS_DIR}/<phase>/inference/labels" \
+  --newer-than "$LAUNCH_MARKER" \
   --status-json "${RESULTS_DIR}/<phase>/inference/status.json" \
   --status-contains "finished successfully"
 ```
@@ -248,10 +254,14 @@ mkdir -p "$(dirname "$LAUNCH_MARKER")" && touch "$LAUNCH_MARKER"
 
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/await_stage.py \
   --newer-than "$LAUNCH_MARKER" \
-  --artifact "${RESULTS_DIR}/iter${N}/train/gdino_model_latest.pth" \
   --status-json "${RESULTS_DIR}/iter${N}/train/status.json" \
   --status-contains "finished successfully"
 ```
+
+`gdino_model_latest.pth` is deliberately not an `--artifact` here: training rewrites it
+at every checkpoint interval, so a wait naming it returns at the first interval and the
+stage is read as finished several epochs early. `status.json` is the only artifact that
+appears once, at the end.
 
 `results_dir` and `train.num_gpus` are Hydra overrides, not flags. Everything else must already be in the spec — do not add further overrides on the command line.
 

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -359,7 +359,24 @@ export TAO_PYT_IMAGE TAO_DS_IMAGE EXTRA_MOUNTS DOCKER_IDENTITY
 
 # Prep runs only
 export POOL_IMAGES CODETR_CHECKPOINT CODETR_CLASSMAP CLASSES_YAML
+
+# Read by the init block below; unset ones simply drop out of it
+export TARGET_CLASSES KPI_CONF_THRESHOLD
+export SOURCE_DETECTION_FILE TARGET_DETECTION_FILE   # class_stratified only
+export POOL_REPORT RARE_CLASS_LIST                   # an already-prepared pool only
+export EXTRA_MOUNTS_IN                               # space-separated extra mounts, if any
 ```
+
+Two more are set per iteration rather than once, and every stage reference uses them:
+
+```bash
+N=<current iteration number>       # 1, 2, ... — the loop counter; paths read iter${N}
+PHASE=<baseline|iter${N}>          # which phase's output tree this stage writes to
+```
+
+`N` is the iteration being run. `PHASE` is `baseline` for the zero-shot pass and
+`iter${N}` inside the loop; the two differ only because the baseline is not an
+iteration. Re-export both at the top of each iteration.
 
 An unset variable is not an error in a `docker run`: it expands to empty, so
 `-e ""` reaches TAO as a blank spec path and the failure reads as a spec problem rather

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -80,12 +80,20 @@ Resolve everything you can before asking the user. Parameter precedence is stric
    side effect and belongs after the gate, with the container pulls:
 
    ```bash
-   ZERO_SHOT_CHECKPOINT=$(<skill_root>/scripts/deft_python.sh \
+   # --plan reports what it would fetch; it prints a sentence, not a path.
+   <skill_root>/scripts/deft_python.sh \
      <skill_root>/scripts/fetch_gdino_checkpoint.py --plan \
+     --dest "$WORKSPACE/checkpoints/gdino"
+
+   # After approval, the same command without --plan downloads and prints the path.
+   ZERO_SHOT_CHECKPOINT=$(<skill_root>/scripts/deft_python.sh \
+     <skill_root>/scripts/fetch_gdino_checkpoint.py \
      --dest "$WORKSPACE/checkpoints/gdino")
    ```
 
-   After approval, run the same command without `--plan` to perform the download.
+   Capture the variable from the real run, not from `--plan`: under `--plan` the script
+   prints `WILL DOWNLOAD after approval: ... -> <dir>`, so capturing it puts an English
+   sentence in a variable every later stage uses as a path.
 
    That resolves `nvidia/tao/grounding_dino:grounding_dino_swin_tiny_commercial_trainable_v1.1`
    (1.93 GB) and prints the checkpoint path on stdout. It is idempotent — an existing
@@ -168,6 +176,8 @@ Resolve everything you can before asking the user. Parameter precedence is stric
      done
    fi
    [ -n "$resolved_siglip" ] && export SIGLIP_MODEL_PATH="$(realpath "$resolved_siglip")"
+   # init takes it as --embedding-model-path; bind it here or the resolution is lost.
+   export EMBEDDING_MODEL_PATH="${SIGLIP_MODEL_PATH:-}"
    ```
 
    Rules:
@@ -330,6 +340,35 @@ gap_analysis -> embed -> mine -> stage -> train -> inference -> kpi_analyze
 ```
 
 Remind the user to enable auto-mode (shift+tab) before approving — the post-gate loop is continuously side-effecting.
+
+## Run variables
+
+Every stage reference launches containers with shell variables. They are set once here
+and used unchanged for the rest of the run; nothing later re-derives them. Export them
+before the first stage:
+
+```bash
+# Resolved at the gate above
+export WORKSPACE RESULTS_DIR MAX_ITERATIONS NUM_GPUS NUM_EPOCHS LEARNING_RATE
+export MULTIPLIER ALLOCATION_POLICY AP50_THRESHOLDS_JSON
+export ZERO_SHOT_CHECKPOINT TRAIN_SPEC_TEMPLATE
+export SOURCE_POOL_EMBEDDINGS SOURCE_POOL_ANNOTATIONS
+export EMBEDDING_MODEL EMBEDDING_MODEL_PATH
+export KPI_IMAGES_DIR GROUND_TRUTH_LABELS_DIR CLASS_MAPPING
+export TAO_PYT_IMAGE TAO_DS_IMAGE EXTRA_MOUNTS DOCKER_IDENTITY
+
+# Prep runs only
+export POOL_IMAGES CODETR_CHECKPOINT CODETR_CLASSMAP CLASSES_YAML
+```
+
+An unset variable is not an error in a `docker run`: it expands to empty, so
+`-e ""` reaches TAO as a blank spec path and the failure reads as a spec problem rather
+than a missing export. Set them all, and prefer `set -u` in the shell driving the run so
+a typo fails at the point of use.
+
+Each stage's own spec path is bound in that stage's reference, next to the path it
+documents — `$CODETR_SPEC`, `$INFER_SPEC`, `$OD_GAP_SPEC`, `$EMBED_SPEC`, `$MINE_SPEC`
+and `$KPI_SPEC`.
 
 ## Immediately After Approval
 

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -15,6 +15,17 @@ Every command below uses `${PREP_DIR}`. Export it before the first step:
 ```bash
 export PREP_DIR="${RESULTS_DIR}/prep"
 mkdir -p "$PREP_DIR"
+
+export CLASSES_YAML="<path to the run's classes.yaml>"
+export POOL_IMAGES="<config.pool_images>"   # the raw images this prep labels
+export CODETR_SPEC="${PREP_DIR}/codetr_inference.yaml"
+```
+
+Emit `$CODETR_SPEC` before step 3 overrides it:
+
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/emit_default_spec.py \
+  --stage codetr_inference --pyt-image "$TAO_PYT_IMAGE" --out "$CODETR_SPEC"
 ```
 
 `${RESULTS_DIR}/prep` is the layout the rest of the workflow expects: the output tree
@@ -232,16 +243,26 @@ Runtime scales with pool size, so on a large pool this is the longest stage in t
 workflow. Wait on its artifacts, not on the process:
 
 ```bash
+LAUNCH_MARKER="${PREP_DIR}/.codetr_launched"
+mkdir -p "$(dirname "$LAUNCH_MARKER")" && touch "$LAUNCH_MARKER"
+# ... launch the container ...
+
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/await_stage.py \
-  --artifact "${PREP_DIR}/inference/labels" \
+  --newer-than "$LAUNCH_MARKER" \
   --status-json "${PREP_DIR}/inference/status.json" \
   --status-contains "finished successfully"
 ```
 
 TAO appends the action name to `results_dir`, so passing `results_dir=${PREP_DIR}`
 puts every output under `${PREP_DIR}/inference/`. A wait pointed at
-`${PREP_DIR}/status.json` never matches and times out while the stage runs
-normally.
+`${PREP_DIR}/status.json` never matches and times out while the stage runs normally.
+
+Do not add `--artifact "${PREP_DIR}/inference/labels"` here. `await_stage.py` returns on
+the first condition that holds, and TAO creates the labels directory when it starts, so
+the wait would return within seconds and prep would convert a fraction of the pool as
+though it were complete. Wait on `status.json` alone for any stage whose outputs appear
+before it finishes, and use `--newer-than` so a previous attempt's status cannot satisfy
+it.
 
 `dataset.infer_data_sources.classmap` is the detector's **own** vocabulary — one class name per line in `category_id` order starting at 1, COCO-80 for a COCO-trained checkpoint. It is not the target list; `category_mapping` names are matched against it. `results_dir` auto-appends the action, so labels land in `${PREP_DIR}/inference/labels/` already carrying target class names.
 

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -393,8 +393,40 @@ First build the input list. Do not hand-write it:
   --out        "${PREP_DIR}/pool_input.parquet"
 ```
 
-Then invoke `tao-skill-bank:tao-generate-image-embeddings` over it, writing
-`source_pool/source_embeddings.parquet`, with the encoder resolved in Pre-Flight check 9.
+Then embed it. `tao-skill-bank:tao-generate-image-embeddings` covers this stage, but its
+spec block is written for an iteration — `weak_images.parquet` in, embeddings for the weak
+set out. Prep embeds the **pool**, so the two paths differ and the encoder fields do not:
+
+```bash
+EMBED_SPEC="${PREP_DIR}/image_embeddings.yaml"
+
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/emit_default_spec.py \
+  --stage embedding --ds-image "$TAO_DS_IMAGE" --out "$EMBED_SPEC"
+
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/apply_spec_overrides.py \
+  --spec "$EMBED_SPEC" \
+  --set input_parquet="${PREP_DIR}/pool_input.parquet" \
+  --set output_parquet="<workspace>/source_pool/source_embeddings.parquet" \
+  --set model="$EMBEDDING_MODEL" \
+  --set model_path="$EMBEDDING_MODEL_PATH" \
+  --set model_config_path='""' \
+  --set batch_size=64
+```
+
+```bash
+docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+  -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
+  "$TAO_DS_IMAGE" \
+  embedding image_embeddings -e "$EMBED_SPEC"
+```
+
+The encoder is whatever Pre-Flight check 9 resolved, and it must be the same one every
+iteration uses: mining compares an iteration's embeddings against this pool parquet, so
+two encoders produce vectors that are not comparable and the failure is silent — mining
+succeeds and returns confidently wrong neighbours.
+
+`model_config_path` needs the doubled quoting shown above; see
+`references/tao-generate-image-embeddings.md` for why.
 
 **Embed the whole pool, not just what reached the COCO.** Step 3 skips images with no surviving
 box — 35 of 5,000 on the reference pool — so `coco.json` is not the image list. Mining searches

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -30,12 +30,15 @@ Do not hand-write it. Emit `analytics default_specs`, then apply the overlay —
 cannot keep a TAO default just because nobody typed it:
 
 ```bash
+PHASE=<baseline|iter${N}>          # names the container and this phase's output tree
+KPI_SPEC="${RESULTS_DIR}/${PHASE}/kpi_spec.yaml"
+
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/emit_default_spec.py \
   --stage kpi_analyze --ds-image "$TAO_DS_IMAGE" \
-  --out "${RESULTS_DIR}/<phase>/kpi_spec.yaml"
+  --out "$KPI_SPEC"
 
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/apply_spec_overrides.py \
-  --spec "${RESULTS_DIR}/<phase>/kpi_spec.yaml" \
+  --spec "$KPI_SPEC" \
   --apply-workflow-defaults <skill_root>/assets/overlays/kpi_analyze.yaml \
   --set results_dir="${RESULTS_DIR}/<phase>/kpi" \
   --set kpi.conf_threshold=<state.config.kpi_conf_threshold> \

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
@@ -38,6 +38,31 @@ Write per-iteration under `${RESULTS_DIR}/iter${N}/gaps/od_gap_spec.yaml` — th
 OD_GAP_SPEC="${RESULTS_DIR}/iter${N}/gaps/od_gap_spec.yaml"
 ```
 
+Build it the same way every other stage does — emit, then fill the run-specific fields:
+
+```bash
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/emit_default_spec.py \
+  --stage gap_analysis --out "$OD_GAP_SPEC"
+
+<skill_root>/scripts/deft_python.sh <skill_root>/scripts/apply_spec_overrides.py \
+  --spec "$OD_GAP_SPEC" \
+  --set ground_truth_ann_path="$GROUND_TRUTH_LABELS_DIR" \
+  --set inference_ann_path="<previous phase's inference/labels>" \
+  --set images_dir="$KPI_IMAGES_DIR" \
+  --set results_dir="${RESULTS_DIR}/iter${N}/gaps" \
+  --set kpi="iter${N}" \
+  --set-from-file weak_thresholds="<the threshold mapping from the section above>"
+```
+
+`gap_analysis` is absent from TAO's `default_specs` list, so unlike the other stages
+there is no container to emit from: `emit_default_spec.py` copies
+`assets/gap_analysis_object_detection.yaml`, which is hand-maintained for exactly that
+reason. That asset is a **starting spec, not an overlay** — do not pass it to
+`--apply-workflow-defaults`. It carries a nested `weak_thresholds` mapping, and the
+overlay mechanism takes one dotted key per leaf, so it is rejected with
+`'weak_thresholds' has a mapping value`. There is no `--apply-workflow-defaults` step
+for this stage; the emitted spec already holds every documented default.
+
 
 ```yaml
 ground_truth_ann_path: <config.ground_truth_labels_dir>

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
@@ -31,7 +31,13 @@ Everything else already matches: an image is weak if it fails on **any** class (
 
 ## Spec
 
-Write per-iteration under `${RESULTS_DIR}/iter${N}/gaps/od_gap_spec.yaml`:
+Write per-iteration under `${RESULTS_DIR}/iter${N}/gaps/od_gap_spec.yaml` — the invocation below reads it from
+`$OD_GAP_SPEC`, so bind the two:
+
+```bash
+OD_GAP_SPEC="${RESULTS_DIR}/iter${N}/gaps/od_gap_spec.yaml"
+```
+
 
 ```yaml
 ground_truth_ann_path: <config.ground_truth_labels_dir>

--- a/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
@@ -19,7 +19,13 @@ Resolve `model` / `model_path` once in Pre-Flight (check 9) and reuse those exac
 
 ## Spec
 
-Write per-iteration under `${RESULTS_DIR}/iter${N}/embeddings/image_embeddings.yaml`:
+Write per-iteration under `${RESULTS_DIR}/iter${N}/embeddings/image_embeddings.yaml` — the invocation below reads it from
+`$EMBED_SPEC`, so bind the two:
+
+```bash
+EMBED_SPEC="${RESULTS_DIR}/iter${N}/embeddings/image_embeddings.yaml"
+```
+
 
 ```yaml
 input_parquet:  <absolute path to iter${N}/gaps/weak_images.parquet>

--- a/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
@@ -51,7 +51,13 @@ it would need; tracked separately as a TAO DS request.
 
 ## Spec
 
-Write per-iteration under `${RESULTS_DIR}/iter${N}/mining/unique_neighbor_matching.yaml`:
+Write per-iteration under `${RESULTS_DIR}/iter${N}/mining/unique_neighbor_matching.yaml` — the invocation below reads it from
+`$MINE_SPEC`, so bind the two:
+
+```bash
+MINE_SPEC="${RESULTS_DIR}/iter${N}/mining/unique_neighbor_matching.yaml"
+```
+
 
 ```yaml
 source_path:            <config.source_pool_embeddings>

--- a/skills/applications/tao-run-deft-object-detection/scripts/await_stage.py
+++ b/skills/applications/tao-run-deft-object-detection/scripts/await_stage.py
@@ -6,6 +6,11 @@
 
 Polls for whichever condition is given:
 
+The first condition that holds ends the wait. So an ``--artifact`` the stage creates
+while starting up — an output directory, a labels directory — ends it immediately and
+the stage reads as finished when it has barely begun. Name only artifacts that appear
+on success; when the outputs appear before completion, wait on ``--status-json`` alone.
+
 * ``--artifact`` — a path the stage writes on success. A checkpoint symlink counts
   only once it resolves, so a dangling link is not mistaken for completion.
 * ``--status-json`` with ``--status-contains`` — TAO writes one JSON object per
@@ -86,7 +91,12 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--artifact", action="append", default=[],
-                        help="Path the stage writes on success. Repeatable; any one ends "
+                        help="Path the stage writes ON SUCCESS -- not one it creates while "
+                             "starting. Any one ending the wait is the point, so a directory "
+                             "the stage opens up front (an output dir, a labels dir) ends it "
+                             "immediately and the stage reads as finished when it has barely "
+                             "begun. When outputs appear before completion, wait on "
+                             "--status-json alone. Repeatable; any one ends "
                              "the wait.")
     parser.add_argument("--status-json", default=None,
                         help="TAO status.json to watch (JSON-lines).")


### PR DESCRIPTION
## Why

Several documented commands could not be run as written, and each failed in a way that pointed away from the documentation.

- Every stage names its spec in a shell variable that nothing assigned. An unset variable expands to empty, so `-e ""` reaches TAO as a blank spec and reads as a spec bug.
- Three values had two names each, so defining one left the other empty. One was live: pre-flight resolved the encoder into a variable init never read.
- The documented waits paired an artifact with a status file. The wait ends on the first condition that holds and the artifact appears at startup, so a stage was treated as finished when it had barely begun.
- `gap_analysis` had no documented spec build, and prep's embed step deferred to a spec written for a different stage.

## What

- Bind every spec variable beside the path its own reference documents, and settle on one name per value.
- Add a pre-flight block naming the run variables, so the set is stated once.
- Wait on `status.json` alone for stages whose outputs appear before they finish; `await_stage.py` now says so too.
- Document the `gap_analysis` and prep-embed spec builds.

Verified by running the documented commands against the real images.
