### PR TITLE
[TAO-2230][Bugfix] deft-od: name the containers each stage launches

### DIFF
--- a/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
+++ b/skills/applications/tao-run-deft-object-detection/references/grounding-dino.md
@@ -174,7 +174,7 @@ pool's `classes.yaml`, not a class list. Pass it in every phase.
 No training at baseline. Score the user-supplied zero-shot / pretrained checkpoint:
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_${PHASE}_infer" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   grounding_dino inference -e "$INFER_SPEC" \
@@ -232,7 +232,7 @@ that cannot train.
 Then:
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_iter${N}_train" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   grounding_dino train -e "${RESULTS_DIR}/iter${N}/train_grounding_dino.yaml" \
@@ -288,7 +288,7 @@ Required output: a newly emitted checkpoint under `${RESULTS_DIR}/iter${N}/train
 ## Iteration inference
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_${PHASE}_infer" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   grounding_dino inference -e "$INFER_SPEC" \

--- a/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
+++ b/skills/applications/tao-run-deft-object-detection/references/prep-source-pool.md
@@ -227,7 +227,7 @@ The emitted file's single top-level `category_mapping:` key is unwrapped, so its
 value lands directly on `inference.category_mapping`.
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_prep_codetr" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_PYT_IMAGE" \
   $CODETR inference -e "$CODETR_SPEC" \
@@ -305,7 +305,7 @@ the targets. `results_dir` is **not** a scratch dir — see below. The overlay p
 step and the ODVG conversion both look for.
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
+docker run --rm --name "deft_prep_kitti2coco" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" annotations convert -e "${PREP_DIR}/kitti_to_coco.yaml"
 ```
 
@@ -375,7 +375,7 @@ Pass `--allow-empty-classes` only when a class is listed defensively and its abs
 ```
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
+docker run --rm --name "deft_prep_coco2odvg" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" annotations convert -e "${PREP_DIR}/coco_to_odvg.yaml"
 ```
 
@@ -414,7 +414,7 @@ EMBED_SPEC="${PREP_DIR}/image_embeddings.yaml"
 ```
 
 ```bash
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_prep_embed" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   embedding image_embeddings -e "$EMBED_SPEC"

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-gaps-od-map.md
@@ -94,7 +94,7 @@ class_mapping: {}
 <skill_root>/scripts/deft_python.sh <skill_bank>/skills/data/tao-analyze-gaps-od-map/scripts/verify_object_detection_spec.py \
   --spec "$OD_GAP_SPEC"
 
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_iter${N}_gap" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   gap_analysis object_detection -e "$OD_GAP_SPEC"

--- a/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-generate-image-embeddings.md
@@ -47,7 +47,7 @@ batch_size:     64
 <skill_root>/scripts/deft_python.sh <skill_bank>/skills/data/tao-generate-image-embeddings/scripts/verify_image_embeddings_spec.py \
   --spec "$EMBED_SPEC"
 
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_iter${N}_embed" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   embedding image_embeddings -e "$EMBED_SPEC"

--- a/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-mine-od-images.md
@@ -96,7 +96,7 @@ still unset, since allocation apportions the budget by exactly that list.
 <skill_root>/scripts/deft_python.sh <skill_bank>/skills/data/tao-mine-od-images/scripts/verify_unique_neighbor_matching_spec.py \
   --spec "$MINE_SPEC"
 
-docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
+docker run --rm --name "deft_iter${N}_mine" --gpus all --ipc=host --user "$(id -u):$(id -g)" $DOCKER_IDENTITY \
   -v "$WORKSPACE:$WORKSPACE" $EXTRA_MOUNTS -w "$WORKSPACE" \
   "$TAO_DS_IMAGE" \
   tmm unique_neighbor_matching -e "$MINE_SPEC"


### PR DESCRIPTION
## Why

The documented launches passed no `--name`, so their containers took Docker's generated names. On a shared host the run cannot tell its own containers from anyone else's, and cleanup after a failure is guesswork.

## What

Name each stage's container after that stage, matching the form the KPI stage already used.
