### PR TITLE
[TAO-0000][Bugfix] Derive the enroot URI assertion from the packaged backend image

### DIFF
--- a/scripts/tests/test_cosmos_skill_workflow.py
+++ b/scripts/tests/test_cosmos_skill_workflow.py
@@ -2420,10 +2420,10 @@ def test_omitted_sqsh_uses_packaged_backend_image_and_derived_cache_path(tmp_pat
     assert args.sqsh_path == str(expected_sqsh)
     assert plan["image"]["sqsh"]["conversion_required"] is True
     assert "enroot import" in plan["image"]["sqsh"]["command"]
-    assert (
-        "docker://nvcr.io#nvstaging/tao/cosmos-framework:"
-        in plan["image"]["sqsh"]["command"]
+    expected_enroot_uri = "docker://" + expected_image.replace(
+        "nvcr.io/", "nvcr.io#", 1
     )
+    assert expected_enroot_uri in plan["image"]["sqsh"]["command"]
     preflight = workflow.local_preflight(args, plan, env={"NGC_KEY": "SET"})
     assert not any(
         "source" in error or "repository" in error for error in preflight["errors"]


### PR DESCRIPTION
## Summary

- `test_omitted_sqsh_uses_packaged_backend_image_and_derived_cache_path` hardcodes the enroot URI prefix `docker://nvcr.io#nvstaging/tao/cosmos-framework:`, but on `release/7.2.0` the build-14 stamp pins `cosmos_framework` to `nvcr.io/nvstaging/tao/cosmos_framework:7.2.0-rc-283-multiarch` (underscore repo, same nvstaging convention as `cosmos_rl`). Since the #146 → #165 cherry-pick met build 14, this test fails on the base and blocks every `/build` on PRs targeting `release/7.2.0` (e.g. #170).
- Fix: derive the expected enroot URI from `expected_image` (which the test already resolves from `skill_info.yaml`), so the assertion holds on both `main` (hyphenated dev pin) and `release/7.2.0` (stamped RC pin) and future re-stamps cannot drift it. Same drift class as #162/#163 — cc @christinayyw @ramanathan831.

## Validation

- `pytest scripts/tests/test_cosmos_skill_workflow.py -k omitted_sqsh_uses_packaged` fails on the current `release/7.2.0` base and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
