### PR TITLE
[TAO-0000][Bugfix] NVBug 6410888, 6602820: AnomalyGen bootstrap, Guardrail, and PAIDF-1.1 checkpoint policy

### DIFF
--- a/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
@@ -351,7 +351,9 @@ output, or overlapping Proxy/Benchmark; a changed Benchmark hash; any Benchmark
 error used for routing; missing/empty mining output; a failed or empty
 AnomalyGen run while Proxy false accepts remain outstanding; an `anomalygen`
 skip not backed by zero false accepts in the driving RCCA; a synthetic record
-whose label is not `NG` or whose paired image is missing; a checkpoint outside
+whose label is not `NG` or whose paired image is missing; a missing or
+PAIDF-incompatible AnomalyGen fine-tuned checkpoint; a missing AnomalyGen
+Guardrail checkpoint or an SDG log showing disabled screening; a checkpoint outside
 the iteration result tree; an invalid nested TOML spec; unknown evaluator
 ground truth; or a program error.
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/air-gap.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/air-gap.md
@@ -43,3 +43,5 @@ In air-gap mode:
 The same user gate, job-record ordering, four verbs, state contract, frozen
 Benchmark hash, and bare annotation contract still apply.
 Never read `references/network-bootstrap.md` in this mode.
+
+When AnomalyGen will run, its base cache and Guardrail safety model must be fully pre-staged, and the base cache must be verified offline with the container's own check before SDG.

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/data-layout.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/data-layout.md
@@ -13,7 +13,9 @@ workspace/
 ├── augmentation/
 │   └── anomalygen/
 │       ├── base_checkpoints/          # Cosmos base checkpoints cache
-│       ├── checkpoints/<project>/     # ag_config.yaml + fine-tuned checkpoint
+│       ├── checkpoints/<project>/     # User pre-staged PAIDF-1.1-compatible LoRA package.
+│       │                                # BYO required, never auto-downloaded: ag_config.yaml + iter_<step>.pt
+│       │                                # (e.g. nvpcb/nvidia/Cosmos-AnomalyGen-PCB-2B/iter_000015000.pt).
 │       └── datasets/<project>/        # clean boards, cad masks, defect_spec.jsonl
 ├── images/
 │   ├── ... AOI images ...

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
@@ -137,13 +137,24 @@ rather than discovering them on the first GPU job:
   writing anything, which is what this gate requires. Run it again with
   `--output-dir` after approval to produce the mount.
 
-Probe the AnomalyGen assets read-only and report each as present or
-`WILL_AUTO_FETCH`: the fine-tuned checkpoint directory holding `ag_config.yaml`,
-the dataset directory with `defect_spec.jsonl` and
-`semantic_segmentation_labels.json`, and the Cosmos base-checkpoints cache.
-Probing only — the bootstrap that populates them is post-gate and is owned by
+Probe the AnomalyGen assets read-only. The fine-tuned checkpoint directory must
+contain one `ag_config.yaml` and one `iter_<step>.pt` in every network mode; it
+must match the pinned container's PAIDF major.minor. If it is missing or
+ambiguous, hard-stop and direct the user to finetune the AnomalyGen LoRA with
+the container's `texture_ft` recipe using the `uc1_pcb` layout
+(`dataset_path/<texture>/anomaly_image/` paired with
+`dataset_path/<texture>/mask/<defect>/`), then stage the resulting
+`ag_config.yaml` and `iter_<step>.pt` under
+`augmentation/anomalygen/checkpoints/<project>/...`. Never substitute the
+incompatible 1.0-era HF checkpoint. The dataset directory with
+`defect_spec.jsonl` and `semantic_segmentation_labels.json` and the Cosmos
+base-checkpoints cache may be `WILL_AUTO_FETCH` only in network-enabled mode;
+the uc1 reference dataset remains auto-downloadable.
+Probing only — their bootstrap is post-gate and is owned by
 `references/tao-generate-anomalies.md`. In air-gapped runs every asset must be
-pre-staged; report a missing one instead of planning a download.
+pre-staged; report a missing one instead of planning a download. Before Phase
+3, use the executable file check in that reference to gate the AnomalyGen
+Guardrail safety model; a missing file is a hard stop.
 
 ## 6. Model and evaluator contract
 
@@ -332,8 +343,9 @@ lines below the table instead:
 
 - the variant-matched VLM base for the prepared PTM (Edge and Super never
   inherit Nano's default; see step 7);
-- which AnomalyGen assets are staged; `WILL_AUTO_FETCH` is legal only in
-  network-enabled mode, plus their commercial-training approval.
+- which AnomalyGen assets are staged; the fine-tuned checkpoint must be a
+  local PAIDF-compatible path, while dataset/base-cache `WILL_AUTO_FETCH` is
+  legal only in network-enabled mode, plus their commercial-training approval.
 
 Then stop. Remind the user that approval permits checkpoint preparation,
 post-gate spec/state creation, any network-enabled AnomalyGen bootstrap, and GPU

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/tao-generate-anomalies.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/tao-generate-anomalies.md
@@ -9,14 +9,36 @@ committed.
 
 The generation mechanics are identical to the VCN loop; only the consumer
 differs. `skills/applications/tao-run-deft-aoi/references/tao-generate-anomalies.md`
-holds the shared shell setup, the one-time post-gate bootstrap, and the
-per-iteration `docker run` pair. Do not duplicate them here — read that file
-for the commands and apply the Cosmos3 values below.
+holds the shared shell setup, the container-owned one-time post-gate bootstrap,
+and the per-iteration `docker run` pair. Its download command explicitly
+requests Text2Image 2B for both loops. Do not duplicate them here — read that
+file for the commands and apply the Cosmos3 values below.
 
-## The published checkpoint is flat — normalize it first
+## The pre-staged PAIDF 1.1 checkpoint is flat — normalize it first
 
-This one is not optional reading: the official HF repo ships
-`iter_000014000.pt` and `ag_config.yaml` side by side, with no
+The fine-tuned checkpoint is **BYO/pre-staged REQUIRED**. It must match the
+major.minor version of the container resolved from
+`images.metropolis_sdg.paidf_anomalygen`: the GB-scale, full-finetune
+`iter_000014000.pt` from the 1.0-era Hugging Face repo
+`nvidia/Cosmos-AnomalyGen-PCB-2B` is incompatible with PAIDF 1.1's per-defect
+LoRA recipe on a Cosmos3 backbone. Finetune the AnomalyGen LoRA with the
+container's `texture_ft` recipe using the `uc1_pcb` layout
+(`dataset_path/<texture>/anomaly_image/` paired with
+`dataset_path/<texture>/mask/<defect>/`), then stage the resulting
+`ag_config.yaml` and `iter_<step>.pt` in the layout below. The uc1 reference
+dataset remains auto-downloadable; there is no fine-tuned checkpoint download
+fallback.
+
+Stage the known PCB package in this exact layout:
+
+```text
+augmentation/anomalygen/checkpoints/nvpcb/
+└── nvidia/Cosmos-AnomalyGen-PCB-2B/
+    ├── ag_config.yaml
+    └── iter_000015000.pt
+```
+
+The package has no
 `checkpoints/latest_checkpoint.txt` and no `checkpoints/model/`, while the
 container loads the nested layout. Every run hits it.
 
@@ -24,7 +46,8 @@ Build a symlink view under the run directory rather than touching the source
 cache, then take `step` from the view:
 
 ```bash
-CKPT=$(find -L "$AG_CHECKPOINT_DIR" -path '*/ag_config.yaml' -print -quit | xargs dirname)
+CKPT=$(find -L "$AG_CHECKPOINT_DIR" -path '*/ag_config.yaml' -print -quit | xargs -r dirname)
+: "${CKPT:?HARD STOP: PAIDF-compatible AnomalyGen checkpoint missing; finetune the AnomalyGen LoRA with the container texture_ft recipe using the uc1_pcb dataset layout to produce ag_config.yaml + iter_<step>.pt, then stage them under augmentation/anomalygen/checkpoints/<project>/...}"
 if [ ! -f "$CKPT/checkpoints/latest_checkpoint.txt" ]; then
   mapfile -t staged < <(
     find -L "$CKPT" -maxdepth 1 -type f -name 'iter_[0-9]*.pt' ! -name '*_reg_model.pt' | sort
@@ -43,7 +66,9 @@ STEP=$(sed 's/^iter_0*\([0-9]*\)\.pt$/\1/' "$CKPT/checkpoints/latest_checkpoint.
 
 This is a path adapter, not a download. Requiring exactly one root checkpoint
 is deliberate — several means the intended one is ambiguous, and silently
-picking is worse than stopping.
+picking is worse than stopping. The staged example resolves the nested
+directory and produces `STEP=15000`; a missing package is a hard stop in every
+network mode.
 
 ## Why the stage exists
 
@@ -94,8 +119,8 @@ on the host.
 | `output_dir` | `${RESULTS_DIR}/iter${N}/anomalygen/sdg/` — the stage-bound results directory |
 | `num_search_run` / `nn_threshold` | `0` / `0` |
 
-DEFT AOI is always a PCB workflow: select `--uc pcb` for the fine-tuned
-checkpoint. AnomalyGen runs in its own container
+DEFT AOI is always a PCB workflow and uses the pre-staged, version-compatible
+fine-tuned checkpoint. AnomalyGen runs in its own container
 (`config.anomalygen.container`, `images.metropolis_sdg.paidf_anomalygen`), not
 the Cosmos-RL image.
 
@@ -139,6 +164,20 @@ deliberately.
 
 The emitter hard-stops on a missing or empty image on either side of a pair,
 and de-duplicates by generated image.
+
+Wrap Phase 3 with these two one-line hard gates, using the shared VCN
+reference's `$COSMOS` and `$SDG_LOG` values:
+
+```bash
+test -s "$COSMOS/nvidia/Cosmos-Guardrail1/video_content_safety_filter/safety_filter.pt" || { echo "FATAL: AnomalyGen Guardrail checkpoint missing; guardrail=not_run" >&2; exit 2; }
+test -s "$SDG_LOG" && ! grep -Fqi "post-generation image checks are DISABLED" "$SDG_LOG" || { echo "FATAL: AnomalyGen Guardrail log missing or screening disabled; guardrail=not_run" >&2; exit 2; }
+```
+
+The first runs before SDG and the second after it. On either failure, end the
+stage as `anomalygen --status error` and do not emit generated data downstream.
+Record `passed` only when screening ran and accepted the rows, `failed` when it
+rejected them, and `not_run` when it was disabled or failed to initialize;
+`not_run` is unscreened and must never be reported as passed.
 
 ## Skip condition
 
@@ -196,7 +235,7 @@ be automatic.
   --anomalygen-allocation "$RESULTS_DIR/iter${N}/anomalygen/sdg/allocation.json" \
   --anomalygen-sharegpt "$RESULTS_DIR/iter${N}/anomalygen/sdg_sharegpt.json" \
   --duration-sec "$STAGE_DURATION_SEC" \
-  --summary "SDG: requested=N, AMP-allocated=M, generated=K by defect type"
+  --summary "SDG: requested=N, AMP-allocated=M, generated=K by defect type; guardrail=passed"
 ```
 
 `commit_stage.py` derives `M` by summing the committed defect-to-count

--- a/skills/applications/tao-run-deft-aoi/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi/SKILL.md
@@ -111,7 +111,8 @@ by `references/visual-changenet.md`; the spec always points to a local mounted
 file. `NGC_KEY` gates container pulls. SigLIP mining is owned by
 `references/tao-mine-aoi-images.md`; AnomalyGen assets and network/air-gap rules
 are owned by `references/tao-generate-anomalies.md` and
-`references/air-gap.md`.
+`references/air-gap.md`. The container owns its base-asset list; this workflow
+keeps bootstrap on Text2Image 2B by passing `--model_sizes 2B` explicitly.
 
 ## Train AutoML Policy
 
@@ -261,4 +262,4 @@ directory to `/results/iterN`.
 
 Run the full Pre-Flight (`references/preflight.md`), print the Pre-Flight Summary, then STOP at the one user gate. After approval, run the baseline (with the pre-seed/skip-train logic) and the 7-step iteration Pipeline, all detailed in `references/pipeline-and-state.md`.
 
-Hard-stop and never auto-retry on: any stage `status=error`; train/validation leakage; a missing or zero-row mining pool; a failed CSV existence check; silent-drop; and AMP allocation mismatch. The loop stops when the KPI target is met, `max_iterations` is reached, or an unrecoverable gate fires. Each terminal path commits `loop_stop` through `commit_stage.py`, then follows the loop-end sequence in `references/pipeline-and-state.md`.
+Hard-stop and never auto-retry on: any stage `status=error`; train/validation leakage; a missing or zero-row mining pool; a failed CSV existence check; silent-drop; AMP allocation mismatch; a missing or PAIDF-incompatible AnomalyGen fine-tuned checkpoint; a missing AnomalyGen Guardrail checkpoint; or an SDG log showing disabled screening. The loop stops when the KPI target is met, `max_iterations` is reached, or an unrecoverable gate fires. Each terminal path commits `loop_stop` through `commit_stage.py`, then follows the loop-end sequence in `references/pipeline-and-state.md`.

--- a/skills/applications/tao-run-deft-aoi/references/air-gap.md
+++ b/skills/applications/tao-run-deft-aoi/references/air-gap.md
@@ -51,6 +51,10 @@ The normal Pre-Flight approval gate still applies. Air-gap mode changes asset
 resolution and network behavior, not user authorization or stage ordering.
 Never read `references/network-bootstrap.md` in this mode.
 
+## AnomalyGen staged set
+
+When AnomalyGen will run, its base cache and Guardrail safety model must be fully pre-staged, and the base cache must be verified offline with the container's own check before SDG.
+
 ## Pre-Flight Evidence
 
 Include these rows in the Summary:

--- a/skills/applications/tao-run-deft-aoi/references/data-layout.md
+++ b/skills/applications/tao-run-deft-aoi/references/data-layout.md
@@ -55,14 +55,14 @@ creates (paths under `<workspace>` unless absolute):
 ├── augmentation/
 │   ├── mining_pool/
 │   │   └── mining_pool.csv                  # append-only production-line samples; VCN paths resolve against <workspace>/images
-│   └── anomalygen/                          # [Optional] User override slots for AnomalyGen assets.
-│       │                                    # If pre-staged, the loop uses these host paths verbatim.
-│       │                                    # If absent, the tao-generate-anomalies skill handles asset acquisition
-│       │                                    # internally — exact storage location is its concern, not the loop's.
+│   └── anomalygen/                          # AnomalyGen assets; required when the stage runs.
+│       │                                    # Fine-tuned checkpoint: user pre-staged PAIDF-1.1-compatible LoRA package.
+│       │                                    # BYO required, never auto-downloaded.
+│       │                                    # Dataset/base assets may auto-fetch in network-enabled mode.
 │       │                                    # `<project>` is the project label (e.g. UC1).
 │       │                                    # See references/tao-generate-anomalies.md for details.
-│       ├── checkpoints/<project>/           # Fine-tuned PCB AnomalyGen model override (ag_config.yaml + checkpoints/{latest_checkpoint.txt, model/iter_<step>.pt}).
-│       ├── base_checkpoints/                # Cosmos base models cache override (~22 GB for 2B-only, ~140 GB with 14B + T5-11b).
+│       ├── checkpoints/<project>/           # ag_config.yaml + iter_<step>.pt (e.g. nvpcb/nvidia/Cosmos-AnomalyGen-PCB-2B/iter_000015000.pt).
+│       ├── base_checkpoints/                # Manifest-pinned Cosmos base models cache (~22 GB; Predict2 Text2Image 2B).
 │       └── datasets/<project>/              # PCB reference data override — defect_spec.jsonl + per-texture image/mask subdirs.
 └── results/run_<YYYYMMDD_HHMMSS>/           # created/resumed by this workflow (= ${RESULTS_DIR})
 ```

--- a/skills/applications/tao-run-deft-aoi/references/preflight.md
+++ b/skills/applications/tao-run-deft-aoi/references/preflight.md
@@ -128,17 +128,25 @@ activation source; never load or execute the network bootstrap in air-gap mode.
    GPU when the selected backend is remote. Probe the three AnomalyGen override
    slots under `augmentation/anomalygen/` (`checkpoints/<project>/`,
    `base_checkpoints/`, `datasets/<project>/`) and report their status in the
-   Summary. In network-enabled mode, empty slots may be a post-approval fetch
-   plan. In air-gap mode every required slot must already be non-empty and a
-   missing asset is a hard stop. NVIDIA publishes the PCB fine-tuned
-   checkpoint (`nvidia/Cosmos-AnomalyGen-PCB-2B`) and the PCB reference dataset
-   (`nvidia/Cosmos-AnomalyGen-PCB-Dataset`) publicly on HuggingFace;
-   the `tao-generate-anomalies` skill downloads them automatically on first
-   use. Users who want to provide their own fine-tuned checkpoint or custom
-   dataset can pre-stage the directory to override. Do not ask the user about missing AnomalyGen
-   assets — treat empty slots as `will auto-fetch from HF (default)` and
-   proceed. If `base_checkpoints/` is pre-staged, export its host path as
-   `COSMOS_MODELS_DIR` for downstream mounts. Stage the ChangeNet pretrained
+   Summary. The fine-tuned checkpoint slot must be pre-staged in every network
+   mode. Resolve the single `ag_config.yaml` and `iter_<step>.pt` under
+   `checkpoints/<project>/...`; if either is missing or ambiguous, hard-stop
+   and direct the user to finetune the AnomalyGen LoRA with the container's
+   `texture_ft` recipe using the `uc1_pcb` layout
+   (`dataset_path/<texture>/anomaly_image/` paired with
+   `dataset_path/<texture>/mask/<defect>/`), then stage the resulting
+   `ag_config.yaml` and `iter_<step>.pt` under
+   `augmentation/anomalygen/checkpoints/<project>/...`. Its
+   major.minor must match the pinned AnomalyGen container; never substitute the
+   incompatible 1.0-era HF checkpoint. In network-enabled mode, an empty PCB
+   reference dataset (`nvidia/Cosmos-AnomalyGen-PCB-Dataset`) or base-model
+   cache may be a post-approval fetch plan. In air-gap mode both must already
+   be non-empty. The uc1 reference dataset remains auto-downloadable in
+   network-enabled mode. If `base_checkpoints/` is pre-staged, export its host
+   path as `COSMOS_MODELS_DIR` for downstream mounts. Before SDG, use the
+   executable file check in `references/tao-generate-anomalies.md` to gate the
+   AnomalyGen Guardrail safety model; a missing file is a hard stop.
+   Stage the ChangeNet pretrained
    backbone by running `scripts/stage_backbone.py --workspace <workspace>`,
    then set `specs/baseline_spec.yaml::model.backbone.pretrained_backbone_path`
    to the staged file and bind-mount it per `references/visual-changenet.md` →
@@ -164,9 +172,11 @@ Ask one consolidated question only for missing required inputs. Never ask about 
 - pretrained backbone: first staged weight under `augmentation/backbone/`;
   network-enabled mode may plan the documented post-approval fetch, while
   air-gap mode hard-stops when absent.
-- AnomalyGen checkpoint, dataset, and Cosmos base models: prefer the staged
-  `augmentation/anomalygen/` paths. Missing assets are fetch plans only in
-  network-enabled mode; in air-gap mode they are hard stops.
+- AnomalyGen checkpoint: the PAIDF-compatible package is required under
+  `augmentation/anomalygen/checkpoints/<project>/...` in every network mode;
+  missing or ambiguous files are a hard stop. Dataset and Cosmos base models:
+  prefer staged paths; missing assets are fetch plans only in network-enabled
+  mode and hard stops in air-gap mode.
 
 ## Pre-Flight Summary
 
@@ -201,14 +211,15 @@ Once all checks pass, print this summary and **STOP — wait for explicit user a
 | Mining CSV / image root        | <independent absolute paths; resolver status>                                  |
 
 ### Augmentation
-Show `WILL_FETCH` only in network-enabled mode. In air-gap mode every row must
-be a staged local path and no download fallback may appear.
+Show `WILL_FETCH` only for the dataset and base-model rows in network-enabled
+mode. The AnomalyGen checkpoint row must always be a staged local path. In
+air-gap mode every row must be local and no download fallback may appear.
 
 | Field              | Value                                                                                                              |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| AnomalyGen ckpt    | `<path>` (FOUND, step N) **or** will auto-fetch from HF (`nvidia/Cosmos-AnomalyGen-PCB-2B`, ~5 GB) **[default]** |
+| AnomalyGen ckpt    | `<path>` (PAIDF major.minor compatible; FOUND, step N) **[BYO/pre-staged REQUIRED; missing = HARD STOP]**              |
 | Defect spec        | `<N types: type1, type2, ...>` (from staged dataset) **or** will auto-fetch from HF **[default]**                 |
-| Cosmos base models | `<path>` (FOUND) **or** will auto-download on first container run (~22 GB for 2B, ~140 GB with 14B + T5-11b) **[default]** |
+| Cosmos base models | `<path>` (container check FOUND) **or** will auto-download the 2B workflow set on first container run (~22 GB) **[default]** |
 | SigLIP model       | `<cached / download / local path>`                                                                                 |
 | Backbone           | `<path>` (FOUND) **or** will auto-download from HF (`nvidia/C-RADIOv2-B`, ~393 MB) **[default]**                  |
 
@@ -257,6 +268,6 @@ done
 | train | ~11 min | train rows × epochs |
 | evaluate | ~2 min | KPI-test rows |
 
-`total ≈ baseline + max_iterations × ~33 min` + overhead (10 iters ≈ ~6.5h wall). Add the one-time ~22–140 GB base-checkpoint/image pull separately when image/Cosmos rows are `MISSING`.
+`total ≈ baseline + max_iterations × ~33 min` + overhead (10 iters ≈ ~6.5h wall). Add the one-time ~22 GB base-checkpoint/image pull separately when image/Cosmos rows are `MISSING`.
 
 **Ask the user to confirm before proceeding.** Wait for explicit approval ("looks good", "go", "yes"). Do not start the loop until the user confirms.

--- a/skills/applications/tao-run-deft-aoi/references/tao-generate-anomalies.md
+++ b/skills/applications/tao-run-deft-aoi/references/tao-generate-anomalies.md
@@ -14,9 +14,9 @@ by setting `num_search_run=0` and `nn_threshold=0`, or invoke the two
 wrappers directly (see *Per-iteration invocation* below).
 
 **Once, before the loop starts**, the post-gate bootstrap (SKILL.md →
-*Workflow* step 2) populates whichever assets are missing — Cosmos base
-checkpoints, PCB reference dataset, and the AnomalyGen fine-tuned
-checkpoint — all auto-download by default; bring-your-own to override.
+*Workflow* step 2) populates missing Cosmos base checkpoints and the PCB
+reference dataset. The AnomalyGen fine-tuned checkpoint is never downloaded:
+a PAIDF-compatible package must already be staged.
 Pre-Flight only **probes** status and reports it — no side-effecting work
 happens before the user gate.
 
@@ -29,12 +29,12 @@ input before running the per-iteration commands.
 Three independent inputs under `<workspace>/augmentation/anomalygen/` plus
 the Cosmos base-checkpoints cache.
 
-| Input | Path (e.g. `<project>=nvpcb`) | Holds | Source (bring-your-own OR auto-populate) |
+| Input | Path (e.g. `<project>=nvpcb`) | Holds | Source policy |
 |---|---|---|---|
-| `checkpoint_dir` | `augmentation/anomalygen/checkpoints/<project>/` | `ag_config.yaml` + `checkpoints/{latest_checkpoint.txt, model/iter_<step>.pt, …}` | **Auto-download** by default from HF (see *Fine-tuned checkpoint sources* below); **BYO** to override (pre-stage the dir). |
+| `checkpoint_dir` | `augmentation/anomalygen/checkpoints/<project>/` | A nested package such as `nvidia/Cosmos-AnomalyGen-PCB-2B/{ag_config.yaml,iter_000015000.pt}`; the flat model file is normalized below. | **BYO/pre-staged REQUIRED:** finetune the AnomalyGen LoRA with the container `texture_ft` recipe using the `uc1_pcb` layout, then stage `ag_config.yaml` and `iter_<step>.pt` as documented below. There is no checkpoint download fallback. |
 | `dataset_dir` | `augmentation/anomalygen/datasets/<project>/` | PCB reference data + `semantic_segmentation_labels.json` + `defect_spec.jsonl`. Sibling to `checkpoints/`. | **BYO:** pre-stage. **Auto:** `python3 -m scripts.utilities.prepare_dataset_uc1 <dir>` (HF `nvidia/Cosmos-AnomalyGen-PCB-Dataset`). `uc1` is the `tao-generate-anomalies` skill's identifier for the PCB use-case — the script name is unrelated to `<project>`. |
 | `defect_spec` | `${dataset_dir}/defect_spec.jsonl` | One entry per defect_type (`<T>+<A>`); `spatial_dependency ∈ {free, text, cad}` | Bundled with `dataset_dir` (either path). Template at `data/tao-generate-anomalies/assets/defect_spec_template.jsonl`. |
-| `cosmos_models_dir` | `${COSMOS_MODELS_DIR}` (resolved by Pre-Flight) | Cosmos base checkpoints — `nvidia/Cosmos-Predict2-2B-Text2Image/`, `google-t5/`, `NVDINOV2/`, … | **BYO:** pre-stage. **Auto:** container's `${ANOMALYGEN_SCRIPTS}/check.sh \|\| download_checkpoints.sh`. Post-gate bootstrap runs this once with a `:rw` mount; persists across runs. |
+| `cosmos_models_dir` | `${COSMOS_MODELS_DIR}` (resolved by Pre-Flight) | The container-required 2B workflow assets | **BYO:** pre-stage. **Auto:** the container's `check.sh` checks its own contract before the explicit Text2Image 2B download. Post-gate bootstrap runs this once with a `:rw` mount; persists across runs. |
 
 DEFT AOI is always a PCB workflow; the `<project>` placeholder is just the
 directory label the user picked for this AnomalyGen project's checkpoint +
@@ -47,27 +47,51 @@ container's first probe hit. The container handles both flat and
 split-by-texture layouts transparently via `validate_amp_inputs.py`; the
 loop passes the workspace dir verbatim, no pre-staging.
 
-## Fine-tuned checkpoint sources
+## PAIDF checkpoint compatibility and staging
 
-The 2B Cosmos-Predict2 finetunes for each UC are published on Hugging Face
-and can be downloaded with a helper script:
+The fine-tuned checkpoint must match the **major.minor** version of the
+container resolved from `images.metropolis_sdg.paidf_anomalygen`. PAIDF 1.0
+and 1.1 checkpoints are not interchangeable: the GB-scale, full-finetune
+`iter_000014000.pt` published in the 1.0-era Hugging Face repo
+`nvidia/Cosmos-AnomalyGen-PCB-2B` is incompatible with a PAIDF 1.1 container.
+PAIDF 1.1 uses the DEFT team's per-defect LoRA recipe on a Cosmos3 backbone.
 
-```bash
-scripts/utilities/download_anomalygen_checkpoints.sh --uc {pcb|metal|glass|all} \
-    [--checkpoint-dir checkpoints]
+Finetune the AnomalyGen LoRA with the container's `texture_ft` recipe using the
+`uc1_pcb` layout (`dataset_path/<texture>/anomaly_image/` paired with
+`dataset_path/<texture>/mask/<defect>/`), then stage the resulting
+`ag_config.yaml` and `iter_<step>.pt` before Pre-Flight. The uc1 reference
+dataset remains auto-downloadable, and the known PCB package uses this exact
+layout:
+
+```text
+augmentation/anomalygen/checkpoints/nvpcb/
+└── nvidia/Cosmos-AnomalyGen-PCB-2B/
+    ├── ag_config.yaml
+    └── iter_000015000.pt
 ```
 
-| UC | HF repo | Iter |
-|---|---|---|
-| pcb | [`nvidia/Cosmos-AnomalyGen-PCB-2B`](https://huggingface.co/nvidia/Cosmos-AnomalyGen-PCB-2B) | 14000 |
-| metal | [`nvidia/Cosmos-AnomalyGen-Metal-2B`](https://huggingface.co/nvidia/Cosmos-AnomalyGen-Metal-2B) | 10000 |
-| glass | [`nvidia/Cosmos-AnomalyGen-Glass-2B`](https://huggingface.co/nvidia/Cosmos-AnomalyGen-Glass-2B) | 9000 |
+Discover the package and derive its step from the single model file:
 
-Each repo ships the checkpoint plus its `ag_config.yaml` (which lists the
-supported anomaly types and trained `image_size`). Point the AnomalyGen
-pipeline at the downloaded directory via `checkpoint_dir=`. DEFT AOI is
-always a PCB workflow — the loop selects `--uc pcb` and reads
-`step=14000` from `${checkpoint_dir}/checkpoints/latest_checkpoint.txt`.
+```bash
+CKPT=$(find -L "$WS/augmentation/anomalygen/checkpoints/<project>" \
+  -path '*/ag_config.yaml' -print -quit | xargs -r dirname)
+: "${CKPT:?HARD STOP: PAIDF-compatible AnomalyGen checkpoint missing; finetune the AnomalyGen LoRA with the container texture_ft recipe using the uc1_pcb dataset layout to produce ag_config.yaml + iter_<step>.pt, then stage them under augmentation/anomalygen/checkpoints/<project>/...}"
+mapfile -t staged_models < <(
+  find -L "$CKPT" -maxdepth 1 -type f -name 'iter_[0-9]*.pt' \
+    ! -name '*_reg_model.pt' | sort
+)
+[ "${#staged_models[@]}" -eq 1 ] || {
+  echo "HARD STOP: expected exactly one PAIDF-compatible iter_<step>.pt in $CKPT" >&2
+  exit 2
+}
+model_name=$(basename "${staged_models[0]}")
+STEP=$(sed -n 's/^iter_0*\([0-9][0-9]*\)\.pt$/\1/p' <<<"$model_name")
+: "${STEP:?HARD STOP: cannot parse AnomalyGen step from $model_name}"
+```
+
+For the staged example, discovery resolves the nested directory and produces
+`STEP=15000`. A missing or ambiguous package is a hard stop in every network
+mode; never substitute an HF checkpoint.
 
 ## Invariants
 
@@ -135,7 +159,7 @@ directly) with:
 | `defect_spec` | `${dataset_dir}/defect_spec.jsonl` | |
 | `num_SDG` | per-iter budget from `deft_state.json` | proportionally allocated across defect types by mask count |
 | `num_gpus` | `1` | |
-| `model_size` | from `ag_config.yaml` (`2b` or `14b`) | |
+| `model_size` | `2b` (pinned by the DEFT AOI bootstrap and invocation) | |
 | `output_dir` | `${RESULTS_DIR}/iter${N}/anomalygen/sdg/` | receives `reconstructed_image/`, `original_image/`, `SDG_result.csv` |
 | `cosmos_models_dir` | `${COSMOS_MODELS_DIR}` | resolved in Pre-Flight |
 | `num_search_run` | `0` | skip Phase 5 search rounds |
@@ -149,10 +173,12 @@ Used by both the bootstrap and the per-iteration calls:
 # Per-iteration calls use staged assets and require no credential.
 WS=<workspace>
 DS=$WS/augmentation/anomalygen/datasets/<project>
-CKPT=$(find -L "$WS/augmentation/anomalygen/checkpoints/<project>" -path '*/ag_config.yaml' -print -quit | xargs dirname)  # -L follows a symlinked project checkpoint dir
-: "${CKPT:?no AnomalyGen checkpoint directory with ag_config.yaml found under checkpoints/<project>}"
+CKPT=$(find -L "$WS/augmentation/anomalygen/checkpoints/<project>" -path '*/ag_config.yaml' -print -quit | xargs -r dirname)  # -L follows a symlinked project checkpoint dir
+: "${CKPT:?HARD STOP: PAIDF-compatible AnomalyGen checkpoint missing; finetune the AnomalyGen LoRA with the container texture_ft recipe using the uc1_pcb dataset layout to produce ag_config.yaml + iter_<step>.pt, then stage them under augmentation/anomalygen/checkpoints/<project>/...}"
 COSMOS=$WS/augmentation/anomalygen/base_checkpoints
 RUN_DIR=$WS/results/run_<TS>/iter${N}/anomalygen
+TAO_SKILL_BANK_ROOT=<tao-skill-bank>
+DEFT_AOI_SKILL_ROOT=$TAO_SKILL_BANK_ROOT/skills/applications/tao-run-deft-aoi
 : "${AG_IMAGE:?AG_IMAGE unset — resolve images.metropolis_sdg.paidf_anomalygen from versions.yaml in Pre-Flight step 5}"
 mkdir -p $COSMOS $DS $(dirname $CKPT) $RUN_DIR/amp $RUN_DIR/sdg
 for p in "$COSMOS" "$DS" "$(dirname "$CKPT")" "$RUN_DIR"; do
@@ -165,10 +191,10 @@ for p in "$COSMOS" "$DS" "$(dirname "$CKPT")" "$RUN_DIR"; do
 done
 ```
 
-After approval, normalize a flat HuggingFace snapshot without modifying the
-source cache. The published repository may stage `iter_000014000.pt` beside
+After approval, normalize the flat, pre-staged PAIDF 1.1 package without
+modifying the source. The package stages `iter_000015000.pt` beside
 `ag_config.yaml`, while the container loads
-`checkpoints/model/iter_000014000.pt`. If the normal layout is already
+`checkpoints/model/iter_000015000.pt`. If the normal layout is already
 complete, keep `$CKPT` unchanged. Otherwise require exactly one root iteration
 file and build a lightweight view under the run directory:
 
@@ -213,21 +239,22 @@ host-side variables (like `$DS`, `$NUM_SDG`) expanded in the same line.
 ## Post-gate bootstrap (one-time, SKILL.md → Workflow step 2)
 
 Order matters — (a) populates the base checkpoints that (b) depends on.
-Run only the steps the Pre-Flight Summary flagged `WILL_AUTO_FETCH`. Both
+Run only the dataset/base-model steps the Pre-Flight Summary flagged
+`WILL_AUTO_FETCH`. Both
 are idempotent — re-running a completed step exits quickly.
 
 ```bash
 set -a; source /path/to/.env; set +a   # omit if already exported
 
-# (a) Cosmos base checkpoints (~22 GB for 2B-only, ~140 GB with 14B + T5-11b).
-# WRITABLE mount (no :ro) so download_checkpoints.sh can populate the cache.
+# (a) Container-owned Cosmos base checkpoints (~22 GB; Text2Image 2B only).
+# WRITABLE mount (no :ro) so the container downloader can populate it.
 docker run --pull=never --rm \
   --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
   -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
   -e HF_TOKEN -e HF_HUB_DISABLE_XET=1 -e PYTHONPATH=/workspace/paidf-anomalygen \
   -v $COSMOS:/workspace/paidf-anomalygen/checkpoints \
   -w /workspace/paidf-anomalygen $AG_IMAGE \
-  bash -lc '${ANOMALYGEN_SCRIPTS}/check.sh || ${ANOMALYGEN_SCRIPTS}/download_checkpoints.sh'
+  bash -lc '${ANOMALYGEN_SCRIPTS}/check.sh || python -m scripts.download_checkpoints --model_types text2image --model_sizes 2B'
 
 # (b) PCB reference dataset — prepare_dataset_uc1.py is the `tao-generate-anomalies`
 # skill's PCB-dataset fetcher (`uc1` = the skill's identifier for the PCB
@@ -242,41 +269,30 @@ if [ ! -f "$DS/defect_spec.jsonl" ]; then
 fi
 ```
 
-The AnomalyGen fine-tuned checkpoint at `$CKPT` auto-downloads by default
-from the per-UC HF repo (see *Fine-tuned checkpoint sources* above) via:
+The fine-tuned checkpoint is not part of this bootstrap. It must pass the
+pre-staged PAIDF compatibility and discovery checks above before either fetch
+step is eligible to run.
 
-```bash
-set -a; source /path/to/.env; set +a   # omit if already exported
+The container's `check.sh` owns asset completeness and skips the downloader
+when its contract is already satisfied. The fallback command explicitly
+requests `--model_sizes 2B`; a future larger model is a separate workflow
+opt-in, never an expansion of this default command.
 
-# (c) AnomalyGen fine-tuned checkpoint (PCB UC; ~5 GB).
-if [ ! -f "$CKPT/checkpoints/latest_checkpoint.txt" ]; then
-  docker run --pull=never --rm \
-    --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
-    -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
-    -e HF_TOKEN -e HF_HUB_DISABLE_XET=1 -e PYTHONPATH=/workspace/paidf-anomalygen \
-    -v $WS:$WS -w /workspace/paidf-anomalygen $AG_IMAGE \
-    bash -lc "scripts/utilities/download_anomalygen_checkpoints.sh \
-      --uc pcb --checkpoint-dir $CKPT"
-fi
-```
-
-Users who want to override pre-stage the dir before the loop starts.
-
-## Flat HF checkpoint layout — build a `checkpoint_view`
+## Flat BYO checkpoint layout — build a `checkpoint_view`
 
 `run_sdg.sh` resolves the model file as
-`<checkpoint_dir>/checkpoints/model/iter_<STEP>.pt`, but the HuggingFace
-checkpoint downloads land **flat** (`<dir>/iter_<STEP>.pt` + `ag_config.yaml`).
+`<checkpoint_dir>/checkpoints/model/iter_<STEP>.pt`, but the PAIDF 1.1 package
+is staged **flat** (`<dir>/iter_<STEP>.pt` + `ag_config.yaml`).
 Passing the flat directory fails with
-`FileNotFoundError: .../checkpoints/model/iter_000014000.pt`. Build a symlink
+`FileNotFoundError: .../checkpoints/model/iter_<STEP>.pt`. Build a symlink
 adapter once per iteration output dir and pass it as `--checkpoint_dir`:
 
 ```bash
 CV=${RUN_DIR}/checkpoint_view
 mkdir -p $CV/checkpoints/model
-ln -sf $CKPT_DIR/iter_000014000.pt $CV/checkpoints/model/iter_000014000.pt
+ln -sf $CKPT_DIR/iter_000015000.pt $CV/checkpoints/model/iter_000015000.pt
 ln -sf $CKPT_DIR/ag_config.yaml   $CV/ag_config.yaml
-echo "iter_000014000.pt" > $CV/checkpoints/latest_checkpoint.txt
+echo "iter_000015000.pt" > $CV/checkpoints/latest_checkpoint.txt
 ```
 
 ## Per-iteration invocation (every loop iteration)
@@ -286,6 +302,7 @@ calls — same image, READ-ONLY mount on the cosmos cache.
 
 ```bash
 STEP=$(sed 's/^iter_0*\([0-9]*\)\.pt$/\1/' $CKPT/checkpoints/latest_checkpoint.txt)
+SDG_LOG=$RUN_DIR/sdg.log
 
 # Phase 2: AMP routing → testcase.jsonl  (~10s, no GPU)
 docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
@@ -300,6 +317,9 @@ docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
     --amp-output-dir $RUN_DIR/amp --output-jsonl $RUN_DIR/testcase.jsonl"
 
 # Phase 3: SDG diffusion → reconstructed_image/ + original_image/  (1-3 min on Blackwell)
+test -s "$COSMOS/nvidia/Cosmos-Guardrail1/video_content_safety_filter/safety_filter.pt" || { echo "FATAL: AnomalyGen Guardrail checkpoint missing; guardrail=not_run" >&2; exit 2; }
+
+set -o pipefail
 docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
   --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
   -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
@@ -309,8 +329,19 @@ docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
   bash -lc "\${ANOMALYGEN_SCRIPTS}/run_sdg.sh \
     --checkpoint_dir $CKPT --step $STEP \
     --input_jsonl $RUN_DIR/testcase.jsonl --output_dir $RUN_DIR/sdg \
-    --model_size 2b --num_gpus 1"
+    --model_size 2b --num_gpus 1" 2>&1 | tee "$SDG_LOG"
+sdg_rc=${PIPESTATUS[0]}
+if [ "$sdg_rc" -ne 0 ]; then
+  echo "FATAL: SDG container exited $sdg_rc; guardrail=not_run" >&2
+  exit "$sdg_rc"
+fi
+
+test -s "$SDG_LOG" && ! grep -Fqi "post-generation image checks are DISABLED" "$SDG_LOG" || { echo "FATAL: AnomalyGen Guardrail log missing or screening disabled; guardrail=not_run" >&2; exit 2; }
 ```
+
+Both one-line checks are hard gates. On failure, end the `anomalygen` stage as
+`--status error`, include `guardrail=not_run` in the summary, and halt; never
+commit the generated output downstream.
 
 Required mounts (per-iteration): `<workspace>:<workspace>` (same path) +
 `<cosmos_models_dir>:/workspace/paidf-anomalygen/checkpoints:ro`.
@@ -331,8 +362,9 @@ sudo on resume.
 ```
 
 After verifying `SDG_result.csv`, `reconstructed_image/`, and
-`original_image/`, keep Phase 2's `allocation.json` beside those outputs and
-commit:
+`original_image/`, confirming the disabled-screening marker is absent, and
+checking that every CSV Guardrail verdict passed, keep Phase 2's
+`allocation.json` beside those outputs and commit:
 
 ```python
 phase = state["iterations"][f"iter{N}"]
@@ -354,7 +386,7 @@ This snippet documents the schema only; never execute it as inline Python.
     --anomalygen-sdg <absolute path to SDG_result.csv> \
     --anomalygen-allocation <absolute path to allocation.json> \
     --duration-sec "${STAGE_DURATION_SEC}" \
-    --summary "SDG: requested=N, AMP-allocated=M, generated=K by type"
+    --summary "SDG: requested=N, AMP-allocated=M, generated=K by type; guardrail=passed"
 ```
 
 `commit_stage.py` derives `M` by summing the committed defect-to-count
@@ -362,3 +394,18 @@ This snippet documents the schema only; never execute it as inline Python.
 yield gap), include both requested and allocated counts
 — that's the signal a reviewer needs to spot allocation-vs-generation
 bottlenecks.
+
+## Guardrail tri-state and container follow-up
+
+Interpret image screening as a tri-state, never a boolean default:
+
+- `passed`: screening ran and accepted the generated row;
+- `failed`: screening ran and rejected the row; fail the stage rather than
+  emitting that row into training data;
+- `not_run`: screening was disabled or failed to initialize; fail the stage,
+  record `guardrail=not_run` (never `passed`), and treat the rows as unscreened.
+
+The current container CSV schema cannot represent `not_run` and may write `1`
+when initialization failed. The disabled-marker log check above blocks that
+contradiction. The paired container follow-up must add the tri-state schema and
+stop emitting safety-passed values for unscreened content.

--- a/skills/applications/tao-run-deft-aoi/tests/test_runtime_hygiene.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_runtime_hygiene.py
@@ -33,11 +33,12 @@ class ApplicationDockerIdentityTests(unittest.TestCase):
     def test_all_anomalygen_launches_map_the_host_identity(self) -> None:
         reference = SKILL_ROOT / "references/tao-generate-anomalies.md"
         launch_blocks = _docker_blocks(reference)
-        self.assertEqual(len(launch_blocks), 5)
+        self.assertEqual(len(launch_blocks), 4)
         for block in launch_blocks:
             self._assert_mapped_identity(block)
         text = reference.read_text(encoding="utf-8")
         self.assertIn(".tao-write-probe", text)
+        self.assertNotIn("download_anomalygen_checkpoints", text)
 
     def test_consumer_inference_maps_identity_after_write_probe(self) -> None:
         reference = SKILL_ROOT / "references/prepare-for-inference.md"


### PR DESCRIPTION
NVBugs: [6410888](https://nvbugspro.nvidia.com/bug/6410888), [6602820](https://nvbugspro.nvidia.com/bug/6602820)

## Summary

- **NVBug 6410888** — Bootstrap downloads 2B Text2Image only; the unused 14B model is no longer requested (asset completeness stays with the container's own check; paired fix: cosmos-anomalygen MR 109).
- **NVBug 6602820** — The documented SDG flow gains two fail-closed gates: the Guardrail checkpoint must exist before SDG, and the SDG log must not show screening DISABLED — otherwise the stage ends `status=error` with `guardrail=not_run` and nothing is committed.
- **PAIDF 1.1 compatibility** — The fine-tuned AnomalyGen checkpoint is BYO/pre-staged (PAIDF 1.1 LoRA is incompatible with the 1.0-era HF checkpoint; HF auto-fetch removed). When it is missing, the docs guide users to finetune their own via the `texture_ft` recipe on the `uc1_pcb` dataset layout (producing `ag_config.yaml` + `iter_<step>.pt`). The uc1 dataset remains auto-downloadable.

## Validation

- Docs-only (10 files under `skills/applications/`); AOI 23 + Cosmos3 27 tests pass.
- Real-workspace check: discovery finds `ag_config.yaml`, step parses 15000; zero 14B references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
