### PR TITLE
[TAO-0000][Bugfix] NVBug 6569910: host UID:GID ownership for DEFT AOI Docker outputs

### DIFF
--- a/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
@@ -149,9 +149,12 @@ credential value.
 - Every spec is a nested dictionary serialized to TOML. Never write literal
   flat dotted keys into a spec.
 - Do not mount user data over `/workspace`; cosmos-rl is installed there.
-- Run every container that writes into the results tree as the invoking user,
-  not root, or the run's own outputs become undeletable by their owner. See
-  `references/cosmos-reason.md`.
+- Run every Docker container with a writable host mount as the invoking
+  UID:GID with `USER`, `LOGNAME`, `HOME=/tmp`, and the read-only host
+  passwd/group databases; never fall back to a root repair container. This
+  covers checkpoint preparation, Train, Proxy/Benchmark evaluate, AnomalyGen,
+  and mining. See `references/cosmos-reason.md` and
+  `references/tao-mine-aoi-images.md`.
 
 Read `skills/models/tao-finetune-cosmos-reason/SKILL.md` and its
 `references/skill_info.yaml` before authoring a spec. Start from the model

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/cosmos-reason.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/cosmos-reason.md
@@ -29,6 +29,14 @@ set -a; source /path/to/.env; set +a   # omit if already exported
 hf download nvidia/Cosmos3-Nano --local-dir "$COSMOS3_SOURCE_DIR" \
   --exclude 'assets/*' --exclude 'images/*'
 
+PREPARED_MODEL_PARENT=$(dirname "$PREPARED_MODEL_HOST_PATH")
+mkdir -p "$PREPARED_MODEL_PARENT"
+probe="$PREPARED_MODEL_PARENT/.tao-write-probe.$$"
+(umask 077 && : >"$probe" && rm -f "$probe") || {
+  echo "FATAL: $PREPARED_MODEL_PARENT is not writable by uid $(id -u)" >&2
+  exit 2
+}
+
 "$PYTHON" \
   "$TAO_SKILL_BANK_PATH/skills/models/tao-finetune-cosmos-reason/scripts/prepare_cosmos3_vlm_checkpoint.py" \
   --checkpoint-path "$COSMOS3_SOURCE_DIR" \
@@ -39,21 +47,10 @@ hf download nvidia/Cosmos3-Nano --local-dir "$COSMOS3_SOURCE_DIR" \
 Confirm `$COSMOS3_SOURCE_DIR` exists before launching; that check costs nothing
 and saves several minutes plus a large cache write.
 
-The helper runs its own containers as root and repairs ownership afterwards
-with a trailing `chown ... || true`, which covers only the paths it names and
-tolerates its own failure. Expect a handful of root-owned files to survive in
-the converted directory — `chat_template.json` and `.cache/huggingface/` were
-the observed leftovers. They make the PTM directory unremovable by its owner,
-so repair it before the run needs to move or delete it. No sudo required:
-
-```bash
-docker run --pull=never --rm -v "$(dirname "$PREPARED_MODEL_HOST_PATH"):/out" busybox:latest \
-  chown -R "$(id -u):$(id -g)" "/out/$(basename "$PREPARED_MODEL_HOST_PATH")"
-```
-
-Prefer chowning over deleting: the prepared PTM is ~17 GB across four shards
-and re-converting means re-downloading the source checkpoint too. Once the
-ownership is fixed the helper reports `status=skipped_existing` and reuses it.
+The model helper owns its internal Docker command and maps the invoking
+UID:GID before writing the prepared checkpoint. Treat any root-owned output as
+a helper regression and hard-stop; never launch a root repair container. A
+valid existing checkpoint is reported as `status=skipped_existing` and reused.
 
 The helper may clone NVIDIA/cosmos-framework, pull its conversion image, and
 write a large checkpoint, so never run it before approval. It forwards
@@ -85,8 +82,18 @@ and the run tree then cannot be deleted, re-rendered into, or cleaned up
 without `sudo`. On Docker:
 
 ```bash
---user $(id -u):$(id -g) -e USER="$(id -un)" -e HOME=/tmp \
--v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
+CR3_IDENTITY_ARGS=(
+  --user "$(id -u):$(id -g)"
+  -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp
+  -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro
+)
+```
+
+Insert `"${CR3_IDENTITY_ARGS[@]}"` into every Docker Train, Proxy evaluate,
+and Benchmark evaluate launch, including resumed actions, and use the
+stage-local writable working directory:
+
+```bash
 -w "$RESULTS_DIR/<label>/<stage>/cwd"
 ```
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/tao-mine-aoi-images.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/tao-mine-aoi-images.md
@@ -29,7 +29,8 @@ workflow already carries the fix — pass the account databases along with the
 mapping:
 
 ```bash
---user $(id -u):$(id -g) -e USER="$(id -un)" -e HOME=/tmp \
+--user $(id -u):$(id -g) \
+-e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro
 ```
 
@@ -38,13 +39,8 @@ resolves and `transformers` imports cleanly. This matters because mining writes
 into `${RESULTS_DIR}/iterN/mining`, a tree the operator owns; run as root and
 the parquet files come back root-owned and cannot be cleaned up afterwards.
 
-If a future image genuinely rejects the mapping, repair ownership through a
-container rather than assuming sudo:
-
-```bash
-docker run --pull=never --rm -v "$WORKSPACE:/ws" busybox:latest \
-  chown -R "$(id -u):$(id -g)" /ws/<relative/path/to/mining>
-```
+If a future image genuinely rejects the mapping, hard-stop and fix the image
+contract. Never launch mining as root or use a root repair container.
 
 ## Cosine floor
 

--- a/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
+++ b/skills/applications/tao-run-deft-aoi/references/prepare-for-inference.md
@@ -97,21 +97,33 @@ TAO_PYT_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-pyt  # versions-key: images.t
 HANDOFF="${RESULTS_DIR}/best_model.json"
 BACKBONE=$(jq -er '.backbone | strings | select(length > 0)' "$HANDOFF")
 BACKBONE_CONTAINER_PATH=$(jq -er '.backbone_container_path | strings | select(startswith("/"))' "$HANDOFF")
+HOST_RESULTS=<output_dir>
+mkdir -p "$HOST_RESULTS"
+probe="$HOST_RESULTS/.tao-write-probe.$$"
+(umask 077 && : >"$probe" && rm -f "$probe") || {
+    echo "FATAL: $HOST_RESULTS is not writable by uid $(id -u)" >&2
+    exit 2
+}
 
 docker run --pull=never --rm --gpus all --shm-size=8g \
     --user "$(id -u):$(id -g)" \
+    -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
+    -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
     -v <your_csv_dir>:/data/infer \
     -v "$(jq -er .images_dir "$HANDOFF"):/data/images:ro" \
     -v "$(jq -er .checkpoint "$HANDOFF"):/model/best.pth:ro" \
     -v "${BACKBONE}:${BACKBONE_CONTAINER_PATH}:ro" \
     -v /tmp/my_inference.yaml:/specs/inference.yaml \
-    -v <output_dir>:/results \
+    -v "$HOST_RESULTS:/results" \
     "$TAO_PYT_IMAGE" \
     visual_changenet inference -e /specs/inference.yaml
 ```
 
 The `--shm-size=8g` is required — TAO dataloaders crash with bus errors on the
 default 64MB allocation.
+
+The output tree is owned by the submitting host user, so it can be updated or
+removed without sudo.
 
 ## Threshold Contract
 

--- a/skills/applications/tao-run-deft-aoi/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-aoi/references/scripts-and-agents.md
@@ -56,7 +56,9 @@ persisted policy:
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/deft_context.py \
   --state "${RESULTS_DIR}/deft_state.json" --stage data_mining
 <skill_root>/scripts/deft_python.sh <skill_root>/scripts/deft_exec.py \
-  --state "${RESULTS_DIR}/deft_state.json" -- docker run ...
+  --state "${RESULTS_DIR}/deft_state.json" -- \
+  docker run --user "$(id -u):$(id -g)" \
+    -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp ...
 ```
 
 Set `STAGE_DURATION_SEC` from measured wall-clock evidence before committing:

--- a/skills/applications/tao-run-deft-aoi/references/tao-generate-anomalies.md
+++ b/skills/applications/tao-run-deft-aoi/references/tao-generate-anomalies.md
@@ -155,8 +155,13 @@ COSMOS=$WS/augmentation/anomalygen/base_checkpoints
 RUN_DIR=$WS/results/run_<TS>/iter${N}/anomalygen
 : "${AG_IMAGE:?AG_IMAGE unset — resolve images.metropolis_sdg.paidf_anomalygen from versions.yaml in Pre-Flight step 5}"
 mkdir -p $COSMOS $DS $(dirname $CKPT) $RUN_DIR/amp $RUN_DIR/sdg
-for p in "$COSMOS" "$DS" "$(dirname "$CKPT")"; do
-  chmod 777 "$p" 2>/dev/null || echo "warning: could not chmod $p; continuing if it is readable"
+for p in "$COSMOS" "$DS" "$(dirname "$CKPT")" "$RUN_DIR"; do
+  probe="$p/.tao-write-probe.$$"
+  (umask 077 && : >"$probe" && rm -f "$probe") || {
+    rm -f "$probe" 2>/dev/null || true
+    echo "FATAL: $p is not writable by uid $(id -u)" >&2
+    exit 2
+  }
 done
 ```
 
@@ -217,7 +222,7 @@ set -a; source /path/to/.env; set +a   # omit if already exported
 # (a) Cosmos base checkpoints (~22 GB for 2B-only, ~140 GB with 14B + T5-11b).
 # WRITABLE mount (no :ro) so download_checkpoints.sh can populate the cache.
 docker run --pull=never --rm \
-  --user $(id -u):$(id -g) -e USER="$(id -un)" -e HOME=/tmp \
+  --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
   -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
   -e HF_TOKEN -e HF_HUB_DISABLE_XET=1 -e PYTHONPATH=/workspace/paidf-anomalygen \
   -v $COSMOS:/workspace/paidf-anomalygen/checkpoints \
@@ -229,7 +234,7 @@ docker run --pull=never --rm \
 # use-case; unrelated to the host-side <project> directory label).
 if [ ! -f "$DS/defect_spec.jsonl" ]; then
   docker run --pull=never --rm \
-    --user $(id -u):$(id -g) -e USER="$(id -un)" -e HOME=/tmp \
+    --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
     -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
     -e HF_TOKEN -e HF_HUB_DISABLE_XET=1 -e PYTHONPATH=/workspace/paidf-anomalygen \
     -v $WS:$WS -w /workspace/paidf-anomalygen $AG_IMAGE \
@@ -246,7 +251,7 @@ set -a; source /path/to/.env; set +a   # omit if already exported
 # (c) AnomalyGen fine-tuned checkpoint (PCB UC; ~5 GB).
 if [ ! -f "$CKPT/checkpoints/latest_checkpoint.txt" ]; then
   docker run --pull=never --rm \
-    --user $(id -u):$(id -g) -e USER="$(id -un)" -e HOME=/tmp \
+    --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
     -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
     -e HF_TOKEN -e HF_HUB_DISABLE_XET=1 -e PYTHONPATH=/workspace/paidf-anomalygen \
     -v $WS:$WS -w /workspace/paidf-anomalygen $AG_IMAGE \
@@ -284,7 +289,7 @@ STEP=$(sed 's/^iter_0*\([0-9]*\)\.pt$/\1/' $CKPT/checkpoints/latest_checkpoint.t
 
 # Phase 2: AMP routing → testcase.jsonl  (~10s, no GPU)
 docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
-  --user $(id -u):$(id -g) -e USER="$(id -un)" -e HOME=/tmp \
+  --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
   -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
   -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -e PYTHONPATH=/workspace/paidf-anomalygen \
   -v $WS:$WS -v $COSMOS:/workspace/paidf-anomalygen/checkpoints:ro \
@@ -296,7 +301,7 @@ docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
 
 # Phase 3: SDG diffusion → reconstructed_image/ + original_image/  (1-3 min on Blackwell)
 docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
-  --user $(id -u):$(id -g) -e USER="$(id -un)" -e HOME=/tmp \
+  --user $(id -u):$(id -g) -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp \
   -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
   -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -e PYTHONPATH=/workspace/paidf-anomalygen \
   -v $WS:$WS -v $COSMOS:/workspace/paidf-anomalygen/checkpoints:ro \
@@ -309,6 +314,9 @@ docker run --pull=never --rm --gpus all --ipc=host --shm-size=16g \
 
 Required mounts (per-iteration): `<workspace>:<workspace>` (same path) +
 `<cosmos_models_dir>:/workspace/paidf-anomalygen/checkpoints:ro`.
+All bootstrap and per-iteration calls map the submitting UID:GID, so their
+writable workspace/results artifacts remain updateable and removable without
+sudo on resume.
 
 ## Output layout
 

--- a/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
+++ b/skills/applications/tao-run-deft-aoi/references/visual-changenet.md
@@ -24,6 +24,31 @@ Pre-Flight fallback).
 `BACKBONE_CONTAINER_PATH` is the matching container path written into the
 training spec. Use this resolved pair for every train, evaluate, and inference launch.
 
+For every direct Docker action in the underlying reference, first verify the
+DEFT results root is writable, then compose this application-owned identity
+block:
+
+```bash
+mkdir -p "$RESULTS_DIR"
+probe="$RESULTS_DIR/.tao-write-probe.$$"
+(umask 077 && : >"$probe" && rm -f "$probe") || {
+  echo "FATAL: $RESULTS_DIR is not writable by uid $(id -u)" >&2
+  exit 2
+}
+
+VCN_IDENTITY_ARGS=(
+  --user "$(id -u):$(id -g)"
+  -e USER="$(id -un)" -e LOGNAME="$(id -un)" -e HOME=/tmp
+  -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro
+)
+```
+
+Insert `"${VCN_IDENTITY_ARGS[@]}"` into the underlying `docker run` command for
+train, evaluate, inference, export, and quantize, including resumed actions.
+Every resulting checkpoint, status file, inference CSV, and export is then
+owned by the submitting host user, so two-checkpoint evaluation and cleanup
+need no sudo.
+
 ```
 -v <workspace>:/data/workspace                                  # combined iter CSVs + staged images
 -v ${RESULTS_DIR}:/results                                      # canonical run root; never /results/iterN

--- a/skills/applications/tao-run-deft-aoi/tests/test_runtime_hygiene.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_runtime_hygiene.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _docker_blocks(path: pathlib.Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [
+        "\n".join(lines[index : index + 6])
+        for index, line in enumerate(lines)
+        if line.lstrip().startswith("docker run")
+    ]
+
+
+class ApplicationDockerIdentityTests(unittest.TestCase):
+    def _assert_mapped_identity(self, block: str) -> None:
+        self.assertIn("--user", block)
+        self.assertIn("$(id -u):$(id -g)", block)
+        self.assertIn("USER=", block)
+        self.assertIn("LOGNAME=", block)
+        self.assertIn("HOME=/tmp", block)
+        self.assertIn("/etc/passwd:/etc/passwd:ro", block)
+        self.assertIn("/etc/group:/etc/group:ro", block)
+
+    def test_all_anomalygen_launches_map_the_host_identity(self) -> None:
+        reference = SKILL_ROOT / "references/tao-generate-anomalies.md"
+        launch_blocks = _docker_blocks(reference)
+        self.assertEqual(len(launch_blocks), 5)
+        for block in launch_blocks:
+            self._assert_mapped_identity(block)
+        text = reference.read_text(encoding="utf-8")
+        self.assertIn(".tao-write-probe", text)
+
+    def test_consumer_inference_maps_identity_after_write_probe(self) -> None:
+        reference = SKILL_ROOT / "references/prepare-for-inference.md"
+        launch_blocks = _docker_blocks(reference)
+        self.assertEqual(len(launch_blocks), 1)
+        self._assert_mapped_identity(launch_blocks[0])
+        text = reference.read_text(encoding="utf-8")
+        self.assertIn(".tao-write-probe", text)
+        self.assertIn("owned by the submitting host user", text)
+
+    def test_visual_changenet_overlay_maps_every_action(self) -> None:
+        reference = (SKILL_ROOT / "references/visual-changenet.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("VCN_IDENTITY_ARGS", reference)
+        self.assertIn('--user "$(id -u):$(id -g)"', reference)
+        self.assertIn('LOGNAME="$(id -un)"', reference)
+        self.assertIn("/etc/passwd:/etc/passwd:ro", reference)
+        self.assertIn("train, evaluate, inference, export, and quantize", reference)
+        self.assertIn("including resumed actions", reference)
+
+    def test_direct_fallback_carries_runtime_identity(self) -> None:
+        reference = (SKILL_ROOT / "references/scripts-and-agents.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('docker run --user "$(id -u):$(id -g)"', reference)
+        self.assertIn('USER="$(id -un)"', reference)
+        self.assertIn('LOGNAME="$(id -un)"', reference)
+        self.assertIn("HOME=/tmp", reference)
+
+    def test_cosmos3_maps_or_delegates_every_writable_launch(self) -> None:
+        applications = SKILL_ROOT.parent
+        cosmos3_root = applications / "tao-run-deft-aoi-cosmos3"
+        direct_launches = []
+        for reference in sorted((cosmos3_root / "references").glob("*.md")):
+            direct_launches.extend(
+                (reference.relative_to(cosmos3_root), block)
+                for block in _docker_blocks(reference)
+            )
+        for reference, block in direct_launches:
+            with self.subTest(reference=reference):
+                self._assert_mapped_identity(block)
+
+        cosmos_reason = (cosmos3_root / "references/cosmos-reason.md").read_text(
+            encoding="utf-8"
+        )
+        cosmos_mining = (
+            cosmos3_root / "references/tao-mine-aoi-images.md"
+        ).read_text(encoding="utf-8")
+        cosmos_anomalygen = (
+            cosmos3_root / "references/tao-generate-anomalies.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(direct_launches, [])
+        self.assertIn("CR3_IDENTITY_ARGS", cosmos_reason)
+        self.assertIn('--user "$(id -u):$(id -g)"', cosmos_reason)
+        self.assertIn('LOGNAME="$(id -un)"', cosmos_reason)
+        self.assertIn("/etc/passwd:/etc/passwd:ro", cosmos_reason)
+        self.assertIn("Train, Proxy evaluate", cosmos_reason)
+        self.assertIn("including resumed actions", cosmos_reason)
+        self.assertIn(".tao-write-probe", cosmos_reason)
+        self.assertIn("--user $(id -u):$(id -g)", cosmos_mining)
+        self.assertIn('LOGNAME="$(id -un)"', cosmos_mining)
+        self.assertIn("/etc/passwd:/etc/passwd:ro", cosmos_mining)
+        self.assertIn("never launch mining as root", cosmos_mining.lower())
+        self.assertIn(
+            "skills/applications/tao-run-deft-aoi/references/"
+            "tao-generate-anomalies.md",
+            cosmos_anomalygen,
+        )
+        self.assertIn("Do not duplicate them here", cosmos_anomalygen)
+
+    def test_other_deft_variants_already_map_writable_launches(self) -> None:
+        applications = SKILL_ROOT.parent
+        iaa_runner = (
+            applications / "tao-run-deft-iaa/scripts/run_deft_container.py"
+        ).read_text(encoding="utf-8")
+        object_detection = (
+            applications
+            / "tao-run-deft-object-detection/references/pipeline-and-state.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('"--user",', iaa_runner)
+        self.assertIn('f"{os.getuid()}:{os.getgid()}"', iaa_runner)
+        self.assertIn(
+            'Every TAO invocation in this skill passes `--user "$(id -u):$(id -g)"`',
+            object_detection,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
NVBugs: [6569910](https://nvbugspro.nvidia.com/bug/6569910)

## Summary

- **NVBug 6569910** — Every documented DEFT AOI container invocation that writes to host mounts now carries host identity (`--user "$(id -u):$(id -g)"` with USER/LOGNAME/HOME handling), in both variants: VCN loop (train/inference/export, AnomalyGen bootstrap/AMP/SDG) and CR3 loop (cosmos-reason training/eval, mining). Results trees are owned by the submitting host user — rewrite/delete needs no sudo, and no documented flow prescribes `chmod 777`.

## Validation

- A hygiene test scans both variants' docs and fails on any documented container run without host-identity mapping; suites pass (AOI 29, Cosmos3 27).
- App-layer only (8 files under `skills/applications/`); platform/model/data-layer doc improvements deferred to their owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
