### PR TITLE
[TAO-0000][Bugfix] NVBug 6641996, 6642024: truthful Cosmos3 gap metrics and synthetic split validation

### DIFF
--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/analyze_gaps.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/analyze_gaps.py
@@ -124,7 +124,11 @@ def analyze(
     precision_ng = tp / predicted_ng if predicted_ng else 0.0
     false_accept_rate = fn / actual_ng if actual_ng else 0.0
     false_reject_rate = fp / actual_ok if actual_ok else 0.0
-    accuracy = (tp + tn) / (tp + tn + fp + fn) if (tp + tn + fp + fn) else 0.0
+    # Unknown predictions are incorrect predictions, not samples to omit from
+    # the reported accuracy. Keep the class-specific metrics based on their
+    # parseable confusion-matrix populations, but use the full evaluation set
+    # for accuracy so unparseable responses cannot inflate it.
+    accuracy = (tp + tn) / len(samples) if samples else 0.0
     f1_ng = (
         2 * precision_ng * recall_ng / (precision_ng + recall_ng)
         if precision_ng + recall_ng
@@ -250,6 +254,9 @@ def main(argv: list[str] | None = None) -> int:
                 "name": args.kpi_metric,
                 "value": summary["metrics"][args.kpi_metric],
                 "unit": "",
+                "samples": summary["samples"],
+                "parseable_samples": summary["parseable_samples"],
+                "unknown_samples": summary["unknown_samples"],
                 "constraints": {
                     "unknown_predictions": summary["unknown_samples"],
                 },
@@ -282,6 +289,9 @@ def main(argv: list[str] | None = None) -> int:
         f"precision_ng={metrics['precision_ng']:.6f} "
         f"false_accepts={confusion['fn_ng_to_ok_false_accept']} "
         f"false_rejects={confusion['fp_ok_to_ng_false_reject']} "
+        f"samples={summary['samples']} "
+        f"parseable_samples={summary['parseable_samples']} "
+        f"unknown_samples={summary['unknown_samples']} "
         f"kpi={kpi_text} "
         f"kpi_met={summary['kpi']['met']}"
     )

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/validate_split_contract.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/validate_split_contract.py
@@ -14,7 +14,7 @@ import pathlib
 import sys
 from itertools import combinations
 
-from validate_sharegpt import load_records
+from validate_sharegpt import load_records, prompt_and_label
 
 
 ROLE_PATHS = {
@@ -67,6 +67,15 @@ def validate(
     counts: dict[str, int] = {}
     for role, path in role_paths.items():
         records = load_records(path)
+        if role == "synthetic":
+            for index, record in enumerate(records):
+                context = f"{path}[{index}]"
+                _, label = prompt_and_label(record, context=context)
+                if label != "NG":
+                    raise ValueError(
+                        f"{context}: synthetic label must be exactly NG, "
+                        f"got {label!r}"
+                    )
         targets = {
             _target(record, path, index, media_root)
             for index, record in enumerate(records)

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_validator_truthfulness.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_validator_truthfulness.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for truthful Cosmos3 metrics and split validation."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+
+import analyze_gaps  # noqa: E402
+import validate_split_contract  # noqa: E402
+
+
+def _record(target: str, label: str) -> dict:
+    return {
+        "images": [target, "images/golden.png"],
+        "conversations": [
+            {"from": "human", "value": "Inspect this component."},
+            {"from": "gpt", "value": label},
+        ],
+    }
+
+
+def _write_json(path: pathlib.Path, payload: object) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    return path
+
+
+def _role_paths(root: pathlib.Path) -> dict[str, pathlib.Path]:
+    return {
+        role: _write_json(
+            root / f"{role}.json",
+            [_record(f"images/{role}.png", "OK")],
+        )
+        for role in ("proxy", "benchmark", "mining")
+    }
+
+
+class MetricTruthfulnessTests(unittest.TestCase):
+    def test_unknown_predictions_count_against_accuracy(self) -> None:
+        summary, *_ = analyze_gaps.analyze(
+            [
+                {"gt": "OK", "response": "OK"},
+                {"gt": "NG", "response": "NG"},
+                {"gt": "NG", "response": "Unable to classify"},
+            ],
+            kpi_metric="accuracy",
+            evaluation_role="benchmark",
+        )
+
+        self.assertEqual(summary["parseable_samples"], 2)
+        self.assertEqual(summary["unknown_samples"], 1)
+        self.assertAlmostEqual(summary["metrics"]["accuracy"], 2 / 3)
+
+    def test_unknown_count_is_reported_in_artifact_and_cli_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            results = _write_json(
+                root / "results.json",
+                [
+                    {"gt": "OK", "response": "OK"},
+                    {"gt": "NG", "response": "not sure"},
+                ],
+            )
+            output_dir = root / "metrics"
+            stdout = io.StringIO()
+
+            with contextlib.redirect_stdout(stdout):
+                exit_code = analyze_gaps.main(
+                    [
+                        "--results-json",
+                        str(results),
+                        "--output-dir",
+                        str(output_dir),
+                        "--evaluation-role",
+                        "benchmark",
+                        "--kpi-metric",
+                        "accuracy",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            metric_result = json.loads(
+                (output_dir / "metric_result.json").read_text()
+            )
+            self.assertEqual(metric_result["samples"], 2)
+            self.assertEqual(metric_result["parseable_samples"], 1)
+            self.assertEqual(metric_result["unknown_samples"], 1)
+            self.assertEqual(metric_result["constraints"]["unknown_predictions"], 1)
+            self.assertEqual(metric_result["value"], 0.5)
+            self.assertIn("unknown_samples=1", stdout.getvalue())
+
+
+class SyntheticSplitTruthfulnessTests(unittest.TestCase):
+    def test_ok_labelled_synthetic_record_is_rejected_with_row(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            role_paths = _role_paths(root)
+            synthetic = _write_json(
+                root / "synthetic.json",
+                [
+                    _record("images/synthetic-ng.png", "NG"),
+                    _record("images/synthetic-ok.png", "OK"),
+                ],
+            )
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr):
+                exit_code = validate_split_contract.main(
+                    [
+                        "--workspace",
+                        str(root),
+                        "--proxy",
+                        str(role_paths["proxy"]),
+                        "--benchmark",
+                        str(role_paths["benchmark"]),
+                        "--mining",
+                        str(role_paths["mining"]),
+                        "--synthetic",
+                        str(synthetic),
+                    ]
+                )
+
+            self.assertEqual(exit_code, 2)
+            self.assertRegex(
+                stderr.getvalue(),
+                r"synthetic\.json\[1\]: synthetic label must be exactly NG, got 'OK'",
+            )
+
+    def test_ng_only_synthetic_records_are_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            synthetic = _write_json(
+                root / "synthetic.json",
+                [
+                    _record("images/synthetic-1.png", "NG"),
+                    _record("images/synthetic-2.png", "NG"),
+                ],
+            )
+
+            summary = validate_split_contract.validate(
+                {**_role_paths(root), "synthetic": synthetic},
+                media_root=root,
+            )
+
+            self.assertEqual(summary["records"]["synthetic"], 2)
+            self.assertEqual(summary["roles"]["synthetic"], "anomalygen_sdg")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
NVBugs: [6641996](https://nvbugspro.nvidia.com/bug/6641996), [6642024](https://nvbugspro.nvidia.com/bug/6642024)

## Summary

- **NVBug 6641996** — `analyze_gaps.py` no longer computes accuracy over classified samples only: unknown/unparseable predictions now count against accuracy and the unknown count is reported explicitly, so the metric can no longer be silently inflated.
- **NVBug 6642024** — `validate_split_contract.py --synthetic` now rejects OK-labelled synthetic records with row-level actionable errors (synthetic records are NG-only per the loop contract).

## Validation

- New per-topic tests cover: unknowns counted + reported, OK-labelled synthetic rejected, NG-only accepted; both variants' suites pass.
- App-layer only (3 files, single squashed commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
