### PR TITLE
[TAO-0000][Bugfix] Bump paidf-anomalygen image pin to 1.1.0 (companion to #173)

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -44,7 +44,7 @@ images:
     vila:               nvcr.io/nvidia/tao/tao-toolkit:6.26.3-vila
 
   metropolis_sdg:
-    paidf_anomalygen: nvcr.io/nvidia/paidf-anomalygen:1.0.1
+    paidf_anomalygen: nvcr.io/nvidia/paidf-anomalygen:1.1.0
     paidf_augmentation: nvcr.io/nvidia/paidf-augmentation:1.0.0
 wheels:
   # TAO Python wheels, published to public PyPI. Skill Preflight sections


### PR DESCRIPTION
NVBugs: [6410888](https://nvbugspro.nvidia.com/bug/6410888), [6602820](https://nvbugspro.nvidia.com/bug/6602820) (companion to #173)

## Summary

- Bump `images.metropolis_sdg.paidf_anomalygen` from `nvcr.io/nvidia/paidf-anomalygen:1.0.1` to `1.1.0`. #173 made the fine-tuned AnomalyGen checkpoint BYO and PAIDF-1.1-only (the 1.0-era HF checkpoint is incompatible); without this bump the resolved `AG_IMAGE` (1.0.1) contradicts the documented checkpoint/container version-compatibility rule.

## Validation

- `scripts/stamp_versions.py` run after the edit: 0 additional stamped sites, 0 stray warnings (the pin is consumed at runtime via `resolve_versions_key.py`).
- Remaining `1.0.1` literal in `integrations/nemoclaw/AGENTS.md` is that integration owner's follow-up (out of app scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
