### PR TITLE
[TAO-0000][Bugfix] NVBug 6642004, 6642023: validate DEFT init state and preserve the venv interpreter

### DIFF
--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/init_deft_state.py
@@ -91,6 +91,7 @@ BASE_MODEL_ALIASES = {
     "cosmos3-super": "nvidia/Cosmos3-Super",
     "nvidia/cosmos3-super": "nvidia/Cosmos3-Super",
 }
+SUPPORTED_BASE_MODELS = tuple(dict.fromkeys(BASE_MODEL_ALIASES.values()))
 
 
 def canonicalize_base_model(value: str) -> str:
@@ -98,6 +99,22 @@ def canonicalize_base_model(value: str) -> str:
     if not stripped:
         raise ValueError("--base-model must not be empty")
     return BASE_MODEL_ALIASES.get(stripped.lower(), stripped)
+
+
+def validate_base_model(value: str) -> str:
+    canonical = canonicalize_base_model(value)
+    if canonical not in SUPPORTED_BASE_MODELS:
+        allowed = ", ".join(SUPPORTED_BASE_MODELS)
+        raise ValueError(
+            f"unsupported --base-model {value!r}; allowed values: {allowed} "
+            "(aliases: nano, edge, super)"
+        )
+    return canonical
+
+
+def _absolute_executable(path: pathlib.Path | str) -> pathlib.Path:
+    """Make an interpreter path absolute without resolving a venv symlink."""
+    return pathlib.Path(os.path.abspath(pathlib.Path(path).expanduser()))
 
 
 def _resolve_specs(
@@ -236,16 +253,16 @@ def build_state(args: argparse.Namespace) -> dict[str, Any]:
     )
     benchmark_hash = _sha256(annotations["benchmark"])
     media_root = (args.media_root or workspace).expanduser().resolve()
-    base_model = canonicalize_base_model(args.base_model)
+    base_model = validate_base_model(args.base_model)
     network_mode = getattr(args, "network_mode", None) or (
         "airgap" if os.environ.get("AIR_GAPPED") == "1" else "network-enabled"
     )
     network_source = getattr(args, "network_mode_source", None) or (
         "environment:AIR_GAPPED" if os.environ.get("AIR_GAPPED") == "1" else "default"
     )
-    python_executable = pathlib.Path(
+    python_executable = _absolute_executable(
         getattr(args, "python_executable", None) or sys.executable
-    ).expanduser().resolve()
+    )
     offline = network_mode == "airgap"
 
     return {
@@ -508,13 +525,14 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
     if args.python_executable is not None:
-        executable = args.python_executable.expanduser()
+        executable = _absolute_executable(args.python_executable)
         if not executable.is_file() or not os.access(executable, os.X_OK):
             print(
                 f"init_deft_state: --python-executable must be executable: {executable}",
                 file=sys.stderr,
             )
             return 2
+        args.python_executable = executable
     positive = {
         "max_iterations": args.max_iterations,
         "num_gpus": args.num_gpus,

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_init_state_contract.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_cosmos3_init_state_contract.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+for module_name in ("init_deft_state", "metric_contract", "render_report"):
+    sys.modules.pop(module_name, None)
+sys.path.insert(0, str(SCRIPTS))
+
+import init_deft_state  # noqa: E402
+
+
+class Cosmos3InitStateContractTests(unittest.TestCase):
+    @staticmethod
+    def _workspace(root: pathlib.Path) -> pathlib.Path:
+        workspace = root / "workspace"
+        (workspace / "annotations").mkdir(parents=True)
+        (workspace / "specs").mkdir()
+        for filename in (
+            "proxy_kpi.json",
+            "benchmark_kpi.json",
+            "mining_pool.json",
+        ):
+            (workspace / "annotations" / filename).write_text(
+                "[]\n", encoding="utf-8"
+            )
+        (workspace / "specs/train_spec.toml").write_text(
+            "value = 1\n", encoding="utf-8"
+        )
+        (workspace / "specs/evaluate_spec.toml").write_text(
+            "value = 1\n", encoding="utf-8"
+        )
+        return workspace
+
+    @staticmethod
+    def _argv(
+        root: pathlib.Path,
+        workspace: pathlib.Path,
+        *extra: str,
+    ) -> list[str]:
+        return [
+            "--results-dir",
+            str(root / "results"),
+            "--workspace",
+            str(workspace),
+            "--platform",
+            "docker",
+            "--max-iterations",
+            "1",
+            "--num-epochs",
+            "1",
+            "--num-sdg",
+            "20",
+            "--num-gpus",
+            "1",
+            "--num-nodes",
+            "1",
+            "--gpu-model",
+            "NVIDIA H100 80GB",
+            "--cosmos-container",
+            "example/cosmos:1",
+            "--mining-container",
+            "example/mining:1",
+            *extra,
+        ]
+
+    def test_valid_base_model_alias_is_accepted_and_canonicalized(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            workspace = self._workspace(root)
+
+            rc = init_deft_state.main(
+                self._argv(root, workspace, "--base-model", "EDGE")
+            )
+
+            self.assertEqual(rc, 0)
+            state = json.loads((root / "results/deft_state.json").read_text())
+            self.assertEqual(state["config"]["base_model"], "nvidia/Cosmos3-Edge")
+
+    def test_unknown_base_model_is_rejected_with_allowed_values(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            workspace = self._workspace(root)
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr):
+                rc = init_deft_state.main(
+                    self._argv(root, workspace, "--base-model", "bogus-model")
+                )
+
+            self.assertEqual(rc, 2)
+            self.assertFalse((root / "results/deft_state.json").exists())
+            message = stderr.getvalue()
+            self.assertIn("unsupported --base-model 'bogus-model'", message)
+            for model in init_deft_state.SUPPORTED_BASE_MODELS:
+                self.assertIn(model, message)
+
+    def test_venv_python_symlink_survives_state_initialization(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            workspace = self._workspace(root)
+            venv_bin = root / "venv/bin"
+            venv_bin.mkdir(parents=True)
+            (venv_bin / "python3").symlink_to(sys.executable)
+            venv_python = venv_bin / "python"
+            venv_python.symlink_to("python3")
+
+            rc = init_deft_state.main(
+                self._argv(
+                    root,
+                    workspace,
+                    "--python-executable",
+                    str(venv_python),
+                )
+            )
+
+            self.assertEqual(rc, 0)
+            state = json.loads((root / "results/deft_state.json").read_text())
+            self.assertEqual(
+                state["execution_policy"]["python_executable"],
+                str(venv_python),
+            )
+            self.assertNotEqual(str(venv_python), str(venv_python.resolve()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/applications/tao-run-deft-aoi/scripts/init_deft_state.py
+++ b/skills/applications/tao-run-deft-aoi/scripts/init_deft_state.py
@@ -58,6 +58,11 @@ _COMPLETED_STEP_VALUES = [
 _STATUS_VALUES = ["pending", "in_progress", "complete", "failed"]
 
 
+def _absolute_executable(path: pathlib.Path | str) -> pathlib.Path:
+    """Make an interpreter path absolute without resolving a venv symlink."""
+    return pathlib.Path(os.path.abspath(pathlib.Path(path).expanduser()))
+
+
 def _resolve_image_from_versions_yaml(*path: str) -> str | None:
     """Return a resolved image URI from versions.yaml at the given key path.
 
@@ -148,9 +153,9 @@ def build_state(args: argparse.Namespace) -> dict:
     network_source = getattr(args, "network_mode_source", None) or (
         "environment:AIR_GAPPED" if os.environ.get("AIR_GAPPED") == "1" else "default"
     )
-    python_executable = pathlib.Path(
+    python_executable = _absolute_executable(
         getattr(args, "python_executable", None) or sys.executable
-    ).expanduser().resolve()
+    )
     offline = network_mode == "airgap"
     state = {
         "version": 4,
@@ -560,13 +565,14 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
     if args.python_executable is not None:
-        executable = args.python_executable.expanduser()
+        executable = _absolute_executable(args.python_executable)
         if not executable.is_file() or not os.access(executable, os.X_OK):
             print(
                 f"init_deft_state: --python-executable must be executable: {executable}",
                 file=sys.stderr,
             )
             return 2
+        args.python_executable = executable
     positive_ints = {
         "max_iterations": args.max_iterations,
         "num_gpus": args.num_gpus,

--- a/skills/applications/tao-run-deft-aoi/tests/test_changenet_init_state_contract.py
+++ b/skills/applications/tao-run-deft-aoi/tests/test_changenet_init_state_contract.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+for module_name in ("init_deft_state", "metric_contract", "render_report"):
+    sys.modules.pop(module_name, None)
+sys.path.insert(0, str(SCRIPTS))
+
+import init_deft_state  # noqa: E402
+
+
+class ChangeNetInitStateContractTests(unittest.TestCase):
+    def test_venv_python_symlink_survives_state_initialization(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            venv_bin = root / "venv/bin"
+            venv_bin.mkdir(parents=True)
+            (venv_bin / "python3").symlink_to(sys.executable)
+            venv_python = venv_bin / "python"
+            venv_python.symlink_to("python3")
+            results = root / "results"
+
+            rc = init_deft_state.main(
+                [
+                    "--results-dir",
+                    str(results),
+                    "--workspace",
+                    str(root / "workspace"),
+                    "--python-executable",
+                    str(venv_python),
+                    "--kpi-target",
+                    "FAR <= 1% at recall=100%",
+                    "--max-iterations",
+                    "1",
+                    "--num-gpus",
+                    "1",
+                    "--gpu-model",
+                    "NVIDIA RTX PRO 6000 Blackwell (96 GB)",
+                    "--num-epochs",
+                    "1",
+                    "--num-sdg",
+                    "2",
+                    "--project",
+                    "nvpcb",
+                    "--step",
+                    "1",
+                    "--train-container",
+                    "example/train:1",
+                    "--ag-container",
+                    "example/anomalygen:1",
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            state = json.loads((results / "deft_state.json").read_text())
+            self.assertEqual(
+                state["execution_policy"]["python_executable"],
+                str(venv_python),
+            )
+            self.assertNotEqual(str(venv_python), str(venv_python.resolve()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
NVBugs: [6642004](https://nvbugspro.nvidia.com/bug/6642004), [6642023](https://nvbugspro.nvidia.com/bug/6642023)

## Summary

- **NVBug 6642004** — `init_deft_state.py` no longer accepts arbitrary `--base-model` values into immutable state: unknown models are rejected up front with an actionable error listing the allowed set.
- **NVBug 6642023** — the selected venv Python is preserved: the path is made absolute without `.resolve()`-ing through the venv symlink, so state no longer records the base interpreter (dependency-incomplete) in place of the venv one. Fixed in both variants.

## Validation

- Per-topic regression tests: valid/invalid base-model, venv-symlink preservation (ChangeNet 30 + Cosmos3 30 tests pass, incl. 4 new init-state contract tests).
- App-layer only (4 files, single squashed commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
