### PR TITLE
[TAO-0000][Bugfix] NVBug 6642020, 6642025: handle pinned Cosmos-RL and PAIDF SDG artifacts robustly

### DIFF
--- a/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/SKILL.md
@@ -134,10 +134,11 @@ credential value.
   application skill.
 - Train action: `cosmos-rl --config <spec.toml>
   /opt/cosmos_rl/tao_sft_example.py`.
-- The pinned image caps vLLM evaluation at one image per prompt, which this
-  two-image contract cannot satisfy. Run `scripts/patch_eval_image_cap.py`
-  before the first evaluate job and mount its output read-only into every
-  evaluation container; see `references/cosmos-reason.md`.
+- Before the first evaluate job, run `scripts/patch_eval_image_cap.py` to
+  source-classify the selected image. Mount its output read-only into every
+  evaluation container only when it reports `patch_required`; no mount is
+  needed for `already_sufficient` or `cap_absent`. An unrecognized cap/vLLM
+  shape is a hard stop; see `references/cosmos-reason.md`.
 - Workflow override: `automl_policy: off`. DEFT owns iteration and checkpoint
   selection; this is a workflow argument, not a TOML key.
 - Default adaptation: LoRA over the language-side projections
@@ -294,7 +295,9 @@ For each `iterN` when the frozen Benchmark gate is unmet:
    `inference_only` mode, then turn each generated pair into a bare `NG`
    record with `scripts/emit_sdg_sharegpt.py`. `--skip` is permitted only when
    the driving Proxy RCCA recorded zero false accepts, and even then generating
-   is often still worthwhile — see `references/tao-generate-anomalies.md`.
+   is often still worthwhile. The emitter accepts PAIDF 1.0.1 repo-root-relative
+   and documented output-dir-relative paths, with `--sdg-root` as an explicit
+   additional base — see `references/tao-generate-anomalies.md`.
 3. `data_mining` — invoke `tao-mine-aoi-images`, apply the configured cosine
    floor with `scripts/filter_mined_by_cosine.py`, then run the mapped skill's
    history-aware post-processing so a filepath selected by a prior iteration

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/cosmos-reason.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/cosmos-reason.md
@@ -219,14 +219,14 @@ annotation, bound output directory, and save-folder label differ. For a LoRA
 export, set `model.enable_lora=true` and keep `model.base_model_path` aligned
 with Train's prepared Qwen3-VL PTM.
 
-### Lift the image's 1-image-per-prompt cap
+### Classify and, when needed, lift the evaluation image cap
 
-`cosmos_rl/evaluation/base.py` hardcodes
-`limit_mm_per_prompt={"video": 1, "image": 1}` when it builds the vLLM engine.
-Every AOI record carries two images, so both evaluation stages fail with
-`ValueError: At most 1 image(s) may be provided in one prompt` until that cap
-is raised. There is no spec key and no environment override; the rest of the
-file is already multi-image correct.
+Some `cosmos-rl` images build vLLM with
+`limit_mm_per_prompt={"video": 1, "image": 1}`. Every AOI record carries two
+images, so those images fail evaluation until the cap is raised. Other images,
+including framework-evaluator builds, contain neither that literal nor a vLLM
+engine construction and need no patch. Image tags are not a stable way to tell
+the two apart.
 
 Run this once per run, before the first evaluate job:
 
@@ -237,16 +237,21 @@ Run this once per run, before the first evaluate job:
   --summary "$RESULTS_DIR/patches/cosmos_rl_eval/summary.json"
 ```
 
-It reads `base.py` out of the image actually pinned, rewrites only that
-literal, and prints `MOUNT_ARG=<host>:<container>:ro`. Add that as a read-only
-mount to every `cosmos-rl-evaluate` job. Nothing is vendored into the skill, so
-the patch cannot mask a newer image.
+It reads `base.py` out of the selected image and reports one source-driven
+classification, independent of whether the tag is semver, a custom build name,
+or a future tag:
 
-When the image already allows enough images the script writes no file and
-prints `no patch needed` — drop the mount in that case rather than overriding a
-file that no longer needs it. If it reports the cap was not found, the image
-changed shape: re-verify the defect instead of forcing a rewrite. Train jobs
-never need this mount; only evaluation builds the vLLM engine.
+- `patch_required`: the recognized cap is below two; the script rewrites only
+  that literal and prints `MOUNT_ARG=<host>:<container>:ro`. Add it as a
+  read-only mount to every `cosmos-rl-evaluate` job.
+- `already_sufficient`: the recognized cap is at least two; no file or mount.
+- `cap_absent`: the source contains neither the cap nor vLLM engine evidence;
+  no file or mount.
+
+If the source still references `limit_mm_per_prompt` or vLLM without the
+recognized literal, the script fails with `classification=unknown`; verify the
+new evaluator shape instead of guessing. Nothing is vendored into the skill,
+and Train jobs never need this mount.
 
 The evaluator writes `results.json` with per-sample `video_id`, `response`,
 `question`, and `gt`. Run `analyze_gaps.py` afterward:

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/preflight.md
@@ -119,23 +119,19 @@ pulling requires a credential, report the missing variable name only. A
 `~/.docker/config.json`, not a missing key — retry once with a throwaway empty
 `DOCKER_CONFIG` before reporting a credential problem.
 
-Known defects in the model skill's selected `cosmos-rl` image (verified
-2026-07-29). Both break evaluation only; training is unaffected. Check whether
-the pinned tag still carries them, and report them in the Pre-Flight Summary
-rather than discovering them on the first GPU job:
+Run these evaluator compatibility checks against the model skill's selected
+`cosmos-rl` image and report them in the Pre-Flight Summary rather than
+discovering them on the first GPU job. Training is unaffected:
 
 - `cosmos_rl/evaluation/evaluator.py` hard-indexes `item["id"]` on the
   conversations branch, so evaluation annotations need an `id` (step 3).
-- `cosmos_rl/evaluation/base.py` hardcodes
-  `limit_mm_per_prompt={"video": 1, "image": 1}`, which rejects the two-image
-  AOI record outright. There is no spec key or env override.
-  `scripts/patch_eval_image_cap.py` handles this: it reads `base.py` out of the
-  pinned image, raises only that literal, and returns the read-only mount for
-  the evaluate jobs. Report its `cap_in_image` here so the Summary states
-  whether the workaround is still needed — the script emits nothing once the
-  image is fixed. Use `--probe` at this point: it reports the cap without
-  writing anything, which is what this gate requires. Run it again with
-  `--output-dir` after approval to produce the mount.
+- `scripts/patch_eval_image_cap.py` reads `cosmos_rl/evaluation/base.py` from
+  the selected image and reports `patch_required`, `already_sufficient`, or
+  `cap_absent` from the source rather than parsing its tag. Use `--probe` here:
+  it reports `classification`, `cap_in_image`, and `patch_needed` without
+  writing. After approval, run it with `--output-dir` and mount the emitted
+  file only for `patch_required`. If it reports `classification=unknown`, the
+  evaluator still references a changed cap/vLLM shape; hard-stop and verify it.
 
 Probe the AnomalyGen assets read-only and report each as present or
 `WILL_AUTO_FETCH`: the fine-tuned checkpoint directory holding `ag_config.yaml`,

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/scripts-and-agents.md
@@ -16,9 +16,9 @@ paths before invoking a script.
 | `validate_sharegpt.py` | Enforce two-image, exact bare OK/NG ShareGPT records. |
 | `validate_split_contract.py` | Enforce split isolation, monotonic generated-Train lineage, and Benchmark hash. |
 | `check_annotations.py` | Per-role field-contract check over all three workspace annotation files. `ROLE_CONTRACT` is the authoritative field list. |
-| `patch_eval_image_cap.py` | Raises the pinned image's 1-image-per-prompt evaluation cap to what bare_okng needs, and returns the read-only mount. Retires itself once the image is fixed. |
+| `patch_eval_image_cap.py` | Source-classifies the selected image's evaluation cap, raises a recognized undersized literal, and returns the read-only mount only when required. |
 | `analyze_gaps.py` | Proxy RCCA artifacts or Benchmark aggregate metric evidence. |
-| `emit_sdg_sharegpt.py` | AnomalyGen SDG output as bare `NG` ShareGPT records. |
+| `emit_sdg_sharegpt.py` | Resolve documented or PAIDF 1.0.1 SDG path forms and emit bare `NG` ShareGPT records. |
 | `filter_mined_by_cosine.py` | Recompute max cosine to Proxy targets and enforce the floor. |
 | `emit_mined_sharegpt.py` | Align filtered paths to Mining prompts, golden images, and labels. |
 | `assemble_training_json.py` | Monotonic bare training-data merge with dedupe/leakage checks. |

--- a/skills/applications/tao-run-deft-aoi-cosmos3/references/tao-generate-anomalies.md
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/references/tao-generate-anomalies.md
@@ -130,6 +130,23 @@ record whose assistant response is exactly `NG`:
   --summary "$RESULTS_DIR/$LABEL/anomalygen/emit_sdg_summary.json"
 ```
 
+The emitter supports both producer contracts without editing the CSV:
+
+- documented paths relative to the CSV/output directory, such as
+  `reconstructed_image/X.png` and `original_image/X.png`;
+- PAIDF 1.0.1 `output_filename` values that echo the repo-root-relative
+  `--output_dir`, such as `results/run/sdg/reconstructed_image/X.png`, plus its
+  `image_filename` clean-source column.
+
+For a relative path it tries the CSV parent, the CSV parent with an echoed
+output prefix removed, then the optional `--sdg-root <paidf-repo-root>`. Use
+`--sdg-root` when the CSV was moved away from the producer tree. If the
+recorded clean source is unavailable, it derives
+`original_image/<generated-name>` beside the resolved reconstructed directory.
+Missing/empty failures list every attempted path. A future schema with no
+recognized generated-image column fails with its available columns instead of
+silently guessing.
+
 `--prompt-from` inherits the single inspection prompt recorded in the Mining
 pool so synthetic and mined records ask the model the same question; it
 hard-stops when the pool carries more than one distinct prompt. Use `--prompt`
@@ -138,7 +155,7 @@ records, and never emit a label other than `NG` — the defect was painted on
 deliberately.
 
 The emitter hard-stops on a missing or empty image on either side of a pair,
-and de-duplicates by generated image.
+and de-duplicates by resolved generated image.
 
 ## Skip condition
 

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/emit_sdg_sharegpt.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/emit_sdg_sharegpt.py
@@ -10,6 +10,11 @@ the ``original_image/<T>+<A>_<idx>.png`` clean board it was painted onto. That
 is exactly the Cosmos3 AOI pair shape ``[AOI, golden_reference]``, so every
 generated sample becomes one ``NG`` record.
 
+PAIDF 1.0.1 may echo a repo-root-relative output directory into
+``output_filename`` and records the clean source as ``image_filename``. Path
+resolution accepts that form, the output-dir-relative documented form, and an
+explicit ``--sdg-root`` base without rewriting the producer CSV.
+
 The prompt is never invented. It is inherited from the recorded Mining pool so
 that synthetic and mined records ask the model the same question, or supplied
 verbatim with ``--prompt``.
@@ -37,11 +42,17 @@ RECONSTRUCTED_COLUMNS = (
     "sdg_image",
     "output_filename",
 )
-# Deliberately excludes 1.0.0's "image_filename": that points at the dataset
-# clean_image, not the paired copy under original_image/. Adding it would
-# silently change which image lands in images[1]. The stem fallback below is
-# the correct source for that container.
-ORIGINAL_COLUMNS = ("original_image", "original", "clean_image", "golden_image")
+# PAIDF 1.0.1 records its clean source as image_filename. If that producer path
+# is unavailable to the consumer, resolution falls back to the paired copy
+# beside the resolved reconstructed image.
+ORIGINAL_COLUMNS = (
+    "original_image",
+    "original",
+    "clean_image",
+    "golden_image",
+    "image_filename",
+)
+PAIR_DIRECTORIES = ("reconstructed_image", "original_image")
 
 
 def _column(row: dict[str, str], candidates: tuple[str, ...]) -> str | None:
@@ -74,42 +85,107 @@ def _inherited_prompt(path: pathlib.Path) -> str:
     return prompts.pop()
 
 
+def _dedupe_paths(paths: list[pathlib.Path]) -> list[pathlib.Path]:
+    unique: list[pathlib.Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return unique
+
+
+def _echo_prefix_base(
+    raw: pathlib.Path, *, sdg_dir: pathlib.Path
+) -> pathlib.Path | None:
+    """Remove a producer-echoed output prefix from the CSV-parent base."""
+    if raw.is_absolute():
+        return None
+    marker_indexes = [
+        raw.parts.index(marker)
+        for marker in PAIR_DIRECTORIES
+        if marker in raw.parts
+    ]
+    if not marker_indexes:
+        return None
+    prefix = raw.parts[: min(marker_indexes)]
+    if not prefix or tuple(sdg_dir.parts[-len(prefix) :]) != prefix:
+        return None
+    return pathlib.Path(*sdg_dir.parts[: -len(prefix)]).resolve()
+
+
+def _path_candidates(
+    value: str,
+    *,
+    sdg_dir: pathlib.Path,
+    sdg_root: pathlib.Path | None,
+) -> list[pathlib.Path]:
+    raw = pathlib.Path(value).expanduser()
+    if raw.is_absolute():
+        return [raw.resolve()]
+    bases = [sdg_dir]
+    echoed_base = _echo_prefix_base(raw, sdg_dir=sdg_dir)
+    if echoed_base is not None:
+        bases.append(echoed_base)
+    if sdg_root is not None:
+        bases.append(sdg_root)
+    return _dedupe_paths([(base / raw).resolve() for base in bases])
+
+
+def _resolve_existing(
+    candidates: list[pathlib.Path], *, role: str, row_number: int
+) -> pathlib.Path:
+    for candidate in candidates:
+        if candidate.is_file() and candidate.stat().st_size > 0:
+            return candidate
+    attempted = []
+    for candidate in candidates:
+        status = "empty" if candidate.is_file() else "missing"
+        attempted.append(f"{candidate} ({status})")
+    detail = "; ".join(attempted) if attempted else "none"
+    raise ValueError(
+        f"SDG_result.csv row {row_number}: {role} image could not be resolved; "
+        f"attempted paths: {detail}"
+    )
+
+
 def _resolve_pair(
     row: dict[str, str],
     *,
     sdg_dir: pathlib.Path,
     row_number: int,
+    sdg_root: pathlib.Path | None = None,
 ) -> tuple[pathlib.Path, pathlib.Path]:
     reconstructed = _column(row, RECONSTRUCTED_COLUMNS)
     if reconstructed is None:
         raise ValueError(
             f"SDG_result.csv row {row_number}: no reconstructed-image column "
-            f"among {list(RECONSTRUCTED_COLUMNS)}"
+            f"among {list(RECONSTRUCTED_COLUMNS)}; available columns: "
+            f"{sorted(row)}; attempted paths: none"
         )
-    generated = pathlib.Path(reconstructed)
-    if not generated.is_absolute():
-        generated = sdg_dir / generated
-    generated = generated.resolve()
+    generated = _resolve_existing(
+        _path_candidates(
+            reconstructed, sdg_dir=sdg_dir, sdg_root=sdg_root
+        ),
+        role="reconstructed",
+        row_number=row_number,
+    )
 
     original = _column(row, ORIGINAL_COLUMNS)
+    clean_candidates: list[pathlib.Path] = []
     if original is not None:
-        clean = pathlib.Path(original)
-        if not clean.is_absolute():
-            clean = sdg_dir / clean
-    else:
-        # No explicit column: AnomalyGen mirrors the stem into original_image/.
-        clean = sdg_dir / "original_image" / generated.name
-    clean = clean.resolve()
-
-    for role, path in (("reconstructed", generated), ("original", clean)):
-        if not path.is_file():
-            raise ValueError(
-                f"SDG_result.csv row {row_number}: {role} image does not exist: {path}"
-            )
-        if path.stat().st_size == 0:
-            raise ValueError(
-                f"SDG_result.csv row {row_number}: {role} image is empty: {path}"
-            )
+        clean_candidates.extend(
+            _path_candidates(original, sdg_dir=sdg_dir, sdg_root=sdg_root)
+        )
+    # The producer mirrors the generated stem into original_image/. Derive
+    # this from the resolved generated path, not from the CSV location.
+    clean_candidates.append(
+        (generated.parent.parent / "original_image" / generated.name).resolve()
+    )
+    clean = _resolve_existing(
+        _dedupe_paths(clean_candidates), role="original", row_number=row_number
+    )
     return generated, clean
 
 
@@ -131,6 +207,7 @@ def emit_records(
     prompt: str,
     relative: bool,
     label: str = "NG",
+    sdg_root: pathlib.Path | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     sdg_dir = sdg_csv.parent.resolve()
     with sdg_csv.open(newline="") as handle:
@@ -143,7 +220,12 @@ def emit_records(
     duplicates = 0
     defects: Counter[str] = Counter()
     for offset, row in enumerate(rows, start=2):
-        generated, clean = _resolve_pair(row, sdg_dir=sdg_dir, row_number=offset)
+        generated, clean = _resolve_pair(
+            row,
+            sdg_dir=sdg_dir,
+            row_number=offset,
+            sdg_root=sdg_root,
+        )
         key = str(generated)
         if key in seen:
             duplicates += 1
@@ -168,6 +250,7 @@ def emit_records(
         "mode": "bare_okng",
         "source": "anomalygen_sdg",
         "sdg_result_csv": str(sdg_csv),
+        "sdg_root": str(sdg_root) if sdg_root is not None else None,
         "generated_rows": len(rows),
         "output_records": len(output),
         "duplicates_skipped": duplicates,
@@ -185,6 +268,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="AnomalyGen SDG_result.csv under iterN/anomalygen/sdg/.",
     )
     parser.add_argument("--media-root", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--sdg-root",
+        type=pathlib.Path,
+        help="Additional base for producer-recorded relative image paths, "
+        "normally the paidf-anomalygen repository root.",
+    )
     parser.add_argument("--output", required=True, type=pathlib.Path)
     parser.add_argument("--summary", default=None, type=pathlib.Path)
     parser.add_argument("--emit-relative", action="store_true")
@@ -216,6 +305,11 @@ def main(argv: list[str] | None = None) -> int:
             media_root=args.media_root.expanduser().resolve(),
             prompt=prompt,
             relative=args.emit_relative,
+            sdg_root=(
+                args.sdg_root.expanduser().resolve()
+                if args.sdg_root is not None
+                else None
+            ),
         )
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(records, indent=2) + "\n")

--- a/skills/applications/tao-run-deft-aoi-cosmos3/scripts/patch_eval_image_cap.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/scripts/patch_eval_image_cap.py
@@ -2,24 +2,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Lift the pinned Cosmos-RL image's 1-image-per-prompt evaluation cap.
+"""Classify and, when necessary, lift a Cosmos-RL evaluation image cap.
 
-`cosmos_rl/evaluation/base.py` hardcodes
+Affected `cosmos_rl/evaluation/base.py` versions hardcode
 ``limit_mm_per_prompt={"video": 1, "image": 1}`` when it builds the vLLM
 engine. The bare OK/NG contract mandates exactly two images per record
 ([AOI, golden_reference]), so evaluation fails with::
 
     ValueError: At most 1 image(s) may be provided in one prompt.
 
-There is no spec key and no environment override, and the rest of that file is
-already multi-image correct — only the cap is wrong.
+Those versions have no spec key or environment override, and the rest of that
+file is already multi-image correct — only the cap is wrong.
 
-This reads `base.py` **out of the image being used**, rewrites just that
-literal, and writes the result under the run's results directory. Nothing is
-vendored into the skill, so the patch tracks whatever image is pinned instead
-of silently masking a newer one. When the image no longer carries the defect
-the script emits nothing and exits 0, which is how the workaround retires
-itself.
+This reads `base.py` **out of the image being used** and classifies its source,
+independent of the image tag format. A recognized undersized literal is
+rewritten under the run's results directory. A sufficient literal or a source
+with neither the cap nor vLLM engine construction retires the workaround with
+an explicit no-patch verdict. An unrecognized cap/vLLM shape fails closed for
+manual verification.
 """
 
 from __future__ import annotations
@@ -37,6 +37,13 @@ CONTAINER_PATH = "/workspace/cosmos_rl_merged/cosmos_rl/evaluation/base.py"
 CAP_PATTERN = re.compile(
     r"(limit_mm_per_prompt\s*=\s*\{[^}]*?[\"']image[\"']\s*:\s*)(\d+)"
 )
+VLLM_EVIDENCE_PATTERN = re.compile(
+    r"(?:\bfrom\s+vllm\b|\bimport\s+vllm\b|\b(?:LLM|AsyncLLMEngine)\s*\()"
+)
+
+PATCH_REQUIRED = "patch_required"
+ALREADY_SUFFICIENT = "already_sufficient"
+CAP_ABSENT = "cap_absent"
 
 
 def read_from_image(image: str, container_path: str, *, docker: str) -> str:
@@ -84,6 +91,27 @@ def apply_cap(source: str, images: int) -> tuple[str, int]:
     return patched, current
 
 
+def classify_cap(source: str, images: int) -> tuple[str, int | None]:
+    """Return a source-driven verdict and the detected cap, if any."""
+    matches = CAP_PATTERN.findall(source)
+    if len(matches) > 1:
+        raise ValueError(
+            f"expected exactly one image cap, found {len(matches)}; "
+            "re-verify by hand rather than rewriting all of them"
+        )
+    if matches:
+        current = int(matches[0][1])
+        verdict = PATCH_REQUIRED if current < images else ALREADY_SUFFICIENT
+        return verdict, current
+    if "limit_mm_per_prompt" in source or VLLM_EVIDENCE_PATTERN.search(source):
+        raise ValueError(
+            "classification=unknown: the recognized image-cap literal is absent "
+            "but the evaluator still references limit_mm_per_prompt or vLLM; "
+            "verify the new source shape before evaluating"
+        )
+    return CAP_ABSENT, None
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--image", required=True, help="Pinned Cosmos-RL image URI.")
@@ -126,7 +154,10 @@ def main(argv: list[str] | None = None) -> int:
         source = read_from_image(
             args.image, args.container_path, docker=args.docker
         )
-        patched, current = apply_cap(source, args.images)
+        classification, current = classify_cap(source, args.images)
+        patched = None
+        if classification == PATCH_REQUIRED:
+            patched, _ = apply_cap(source, args.images)
     except (OSError, ValueError) as exc:
         print(f"patch_eval_image_cap: {exc}", file=sys.stderr)
         return 2
@@ -134,27 +165,31 @@ def main(argv: list[str] | None = None) -> int:
     summary = {
         "image": args.image,
         "container_path": args.container_path,
+        "classification": classification,
         "cap_in_image": current,
         "cap_required": args.images,
-        "patch_needed": current < args.images,
+        "patch_needed": classification == PATCH_REQUIRED,
     }
     if args.probe:
         # Read-only: preflight has to report this number before the approval
         # gate, and that gate forbids writing anything.
         summary["mount_argument"] = None
         print(
-            f"patch_eval_image_cap: cap_in_image={current} "
+            f"patch_eval_image_cap: classification={classification} "
+            f"cap_in_image={current if current is not None else 'none'} "
             f"cap_required={args.images} patch_needed={summary['patch_needed']}"
         )
-    elif current >= args.images:
-        # The image was fixed upstream. Emit no mount so the caller stops
-        # overriding a file it no longer needs to touch.
+    elif classification != PATCH_REQUIRED:
+        # No override is needed. Emit no mount so the caller does not replace
+        # a file whose source is already sufficient or not applicable.
         summary["mount_argument"] = None
-        print(
-            f"patch_eval_image_cap: {args.image} already allows {current} "
-            f"image(s) per prompt; no patch needed"
-        )
+        if classification == ALREADY_SUFFICIENT:
+            detail = f"already allows {current} image(s) per prompt"
+        else:
+            detail = "contains no image-cap literal or vLLM engine construction"
+        print(f"patch_eval_image_cap: {args.image} {detail}; no patch needed")
     else:
+        assert patched is not None
         args.output_dir.mkdir(parents=True, exist_ok=True)
         out = (args.output_dir / "base.py").resolve()
         out.write_text(patched)

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_eval_image_cap_compat.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_eval_image_cap_compat.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+
+import patch_eval_image_cap  # noqa: E402
+
+
+FRAMEWORK_EVALUATOR = """\
+from cosmos_rl.framework import checkpoints
+from cosmos_rl.framework import runtime
+
+def evaluate(config):
+    return runtime.evaluate(config)
+"""
+
+
+class EvalImageCapCompatibilityTests(unittest.TestCase):
+    def test_absent_cap_is_source_driven_for_current_and_future_tags(self) -> None:
+        images = (
+            "nvcr.io/nvstaging/tao/cosmos-rl:"
+            "enhanced-hooks-custom-loggers-20260816-direct-cache-fast-v7",
+            "registry.example:5000/tao/cosmos-rl:future-build-20270101-v2",
+            "registry.example/tao/cosmos-rl@sha256:" + "a" * 64,
+        )
+        for image in images:
+            with self.subTest(image=image), mock.patch.object(
+                patch_eval_image_cap,
+                "read_from_image",
+                return_value=FRAMEWORK_EVALUATOR,
+            ), contextlib.redirect_stdout(io.StringIO()) as stdout:
+                result = patch_eval_image_cap.main(
+                    ["--image", image, "--probe", "--images", "2"]
+                )
+            self.assertEqual(result, 0)
+            self.assertIn("classification=cap_absent", stdout.getvalue())
+            self.assertIn("cap_in_image=none", stdout.getvalue())
+            self.assertIn("patch_needed=False", stdout.getvalue())
+
+    def test_absent_cap_writes_explicit_no_patch_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            output_dir = root / "patch"
+            summary = root / "summary.json"
+            with mock.patch.object(
+                patch_eval_image_cap,
+                "read_from_image",
+                return_value=FRAMEWORK_EVALUATOR,
+            ), contextlib.redirect_stdout(io.StringIO()) as stdout:
+                result = patch_eval_image_cap.main(
+                    [
+                        "--image",
+                        "example/cosmos-rl:future-tag",
+                        "--output-dir",
+                        str(output_dir),
+                        "--summary",
+                        str(summary),
+                    ]
+                )
+            self.assertEqual(result, 0)
+            self.assertFalse((output_dir / "base.py").exists())
+            payload = json.loads(summary.read_text())
+            self.assertEqual(payload["classification"], "cap_absent")
+            self.assertIsNone(payload["cap_in_image"])
+            self.assertFalse(payload["patch_needed"])
+            self.assertIsNone(payload["mount_argument"])
+            self.assertIn("no patch needed", stdout.getvalue())
+
+    def test_changed_vllm_shape_fails_with_unknown_verdict(self) -> None:
+        changed = """\
+from vllm import LLM
+
+engine = LLM(model=checkpoint, limit_mm_per_prompt=limits_from_config())
+"""
+        with self.assertRaisesRegex(
+            ValueError,
+            "classification=unknown.*verify the new source shape",
+        ):
+            patch_eval_image_cap.classify_cap(changed, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_sdg_path_compat.py
+++ b/skills/applications/tao-run-deft-aoi-cosmos3/tests/test_sdg_path_compat.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import csv
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT / "scripts"))
+
+import emit_sdg_sharegpt  # noqa: E402
+
+
+PROMPT = "Compare the AOI image with the golden reference."
+STEM = "IC+bridge_00000.png"
+
+
+def _image(path: pathlib.Path) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    return path.resolve()
+
+
+def _csv(
+    path: pathlib.Path, fieldnames: list[str], row: dict[str, str]
+) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow(row)
+    return path
+
+
+class SdgPathCompatibilityTests(unittest.TestCase):
+    def test_paidf_101_repo_relative_output_and_image_filename_resolve(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo_root = pathlib.Path(temporary) / "paidf-anomalygen"
+            relative_output = pathlib.Path("results/nvpcb_qa/original")
+            sdg_dir = repo_root / relative_output
+            generated = _image(sdg_dir / "reconstructed_image" / STEM)
+            source = _image(
+                repo_root / "data/nvpcb/IC/clean_image/source_board.jpg"
+            )
+            sdg_csv = _csv(
+                sdg_dir / "SDG_result.csv",
+                ["output_filename", "image_filename", "guardrail_pass"],
+                {
+                    "output_filename": str(
+                        relative_output / "reconstructed_image" / STEM
+                    ),
+                    "image_filename": str(source),
+                    "guardrail_pass": "1",
+                },
+            )
+
+            records, _ = emit_sdg_sharegpt.emit_records(
+                sdg_csv,
+                media_root=repo_root,
+                prompt=PROMPT,
+                relative=False,
+            )
+
+            self.assertEqual(records[0]["images"], [str(generated), str(source)])
+
+    def test_documented_output_relative_pair_resolves(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            sdg_dir = pathlib.Path(temporary) / "sdg"
+            generated = _image(sdg_dir / "reconstructed_image" / STEM)
+            clean = _image(sdg_dir / "original_image" / STEM)
+            sdg_csv = _csv(
+                sdg_dir / "SDG_result.csv",
+                ["reconstructed_image", "original_image"],
+                {
+                    "reconstructed_image": f"reconstructed_image/{STEM}",
+                    "original_image": f"original_image/{STEM}",
+                },
+            )
+
+            records, _ = emit_sdg_sharegpt.emit_records(
+                sdg_csv,
+                media_root=sdg_dir,
+                prompt=PROMPT,
+                relative=False,
+            )
+
+            self.assertEqual(records[0]["images"], [str(generated), str(clean)])
+
+    def test_missing_101_source_uses_resolved_pair_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo_root = pathlib.Path(temporary) / "paidf-anomalygen"
+            relative_output = pathlib.Path("results/nvpcb_qa/original")
+            sdg_dir = repo_root / relative_output
+            generated = _image(sdg_dir / "reconstructed_image" / STEM)
+            clean = _image(sdg_dir / "original_image" / STEM)
+            sdg_csv = _csv(
+                sdg_dir / "SDG_result.csv",
+                ["output_filename", "image_filename"],
+                {
+                    "output_filename": str(
+                        relative_output / "reconstructed_image" / STEM
+                    ),
+                    "image_filename": "/container/data/missing-source.jpg",
+                },
+            )
+
+            records, _ = emit_sdg_sharegpt.emit_records(
+                sdg_csv,
+                media_root=repo_root,
+                prompt=PROMPT,
+                relative=False,
+            )
+
+            self.assertEqual(records[0]["images"], [str(generated), str(clean)])
+
+    def test_explicit_sdg_root_resolves_a_moved_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            repo_root = root / "paidf-anomalygen"
+            relative_output = pathlib.Path("results/nvpcb_qa/original")
+            generated = _image(
+                repo_root / relative_output / "reconstructed_image" / STEM
+            )
+            source = _image(repo_root / "data/clean/source.jpg")
+            sdg_csv = _csv(
+                root / "staged/SDG_result.csv",
+                ["output_filename", "image_filename"],
+                {
+                    "output_filename": str(
+                        relative_output / "reconstructed_image" / STEM
+                    ),
+                    "image_filename": str(source),
+                },
+            )
+
+            records, summary = emit_sdg_sharegpt.emit_records(
+                sdg_csv,
+                media_root=repo_root,
+                prompt=PROMPT,
+                relative=False,
+                sdg_root=repo_root.resolve(),
+            )
+
+            self.assertEqual(records[0]["images"][0], str(generated))
+            self.assertEqual(summary["sdg_root"], str(repo_root.resolve()))
+
+    def test_failure_lists_every_attempted_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            repo_root = root / "paidf-anomalygen"
+            relative_output = pathlib.Path("results/nvpcb_qa/original")
+            sdg_dir = repo_root / relative_output
+            override = root / "override"
+            raw = relative_output / "reconstructed_image" / STEM
+            sdg_csv = _csv(
+                sdg_dir / "SDG_result.csv",
+                ["output_filename", "image_filename"],
+                {
+                    "output_filename": str(raw),
+                    "image_filename": "/container/data/missing-source.jpg",
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "attempted paths:") as raised:
+                emit_sdg_sharegpt.emit_records(
+                    sdg_csv,
+                    media_root=repo_root,
+                    prompt=PROMPT,
+                    relative=False,
+                    sdg_root=override.resolve(),
+                )
+
+            message = str(raised.exception)
+            expected = (
+                (sdg_dir / raw).resolve(),
+                (repo_root / raw).resolve(),
+                (override / raw).resolve(),
+            )
+            for attempted in expected:
+                self.assertIn(str(attempted), message)
+
+    def test_missing_clean_lists_source_and_pair_attempts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            sdg_dir = pathlib.Path(temporary) / "sdg"
+            _image(sdg_dir / "reconstructed_image" / STEM)
+            source = pathlib.Path(temporary) / "missing-source.jpg"
+            sdg_csv = _csv(
+                sdg_dir / "SDG_result.csv",
+                ["output_filename", "image_filename"],
+                {
+                    "output_filename": f"reconstructed_image/{STEM}",
+                    "image_filename": str(source),
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "attempted paths:") as raised:
+                emit_sdg_sharegpt.emit_records(
+                    sdg_csv,
+                    media_root=sdg_dir,
+                    prompt=PROMPT,
+                    relative=False,
+                )
+
+            message = str(raised.exception)
+            self.assertIn(str(source.resolve()), message)
+            self.assertIn(
+                str((sdg_dir / "original_image" / STEM).resolve()), message
+            )
+
+    def test_future_schema_failure_names_available_columns(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "available columns:.*future_output_path.*attempted paths: none",
+        ):
+            emit_sdg_sharegpt._resolve_pair(
+                {"future_output_path": "new/location.png"},
+                sdg_dir=pathlib.Path("/tmp/sdg"),
+                row_number=2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
NVBugs: [6642020](https://nvbugspro.nvidia.com/bug/6642020), [6642025](https://nvbugspro.nvidia.com/bug/6642025)

## Summary

- **NVBug 6642020** — `patch_eval_image_cap.py` now classifies the selected image's evaluator source instead of pattern-matching the tag, so the pinned `cosmos_rl` image is handled correctly; behaviors covered: cap-below-request patched, sufficient cap no-op, cap-absent explicit, unrecognized evidence exits 2 with an actionable message.
- **NVBug 6642025** — `emit_sdg_sharegpt.py` pair resolution is version-agnostic: both the PAIDF 1.0.1 repo-root-relative `output_filename` form and the documented output-dir-relative form resolve; the original/clean image derives from the columns the producer actually writes; failures list every attempted path (a future PAIDF 1.1 schema change fails actionably, not mysteriously).

## Validation

- Fixtures reproduce the real 1.0.1 CSV form and the documented form (both resolve); bad CSVs fail with the attempted-paths message; real-workspace inspection grounded the fixtures; both variants' suites pass.
- App-layer only (9 files, single squashed commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
