### PR TITLE
[TAO-2550][Bugfix] DEFT CR ITS Bugfix 6630438: specify host dependencies

### DIFF
--- a/skills/applications/tao-run-deft-cr-its-mining/SKILL.md
+++ b/skills/applications/tao-run-deft-cr-its-mining/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   focused on the non-reasoning classification/evaluation path. Use when the user asks for a
   DEFT CR ITS mining workflow, traffic-camera Cosmos Reason improvement loop, collision-identification workflow with data mining, or iterative Cosmos-RL refinement driven by gap analysis.
 license: Apache-2.0
-compatibility: Requires docker + nvidia-container-toolkit. Workflows declare additional requirements.
+compatibility: Requires Docker with NVIDIA Container Toolkit, Python 3.11 with pandas, pyarrow, PyYAML, and huggingface_hub, plus the selected platform CLI.
 metadata:
   author: NVIDIA Corporation
   version: "0.1.0"
@@ -22,9 +22,13 @@ tags:
 
 # Skill: TAO Run DEFT CR ITS Mining
 
+## Prerequisites
+
+Before preflight, follow `references/host-prerequisites.md`; use its selected `DEFT_PYTHON` for every bundled helper and stop if the dependency probe fails.
+
 ## Bundled Resources
 
-Resolve `DEFT_SKILL_ROOT` to the absolute directory containing this installed `SKILL.md`. The agent or plugin runtime resolves this path; it is not a user input. Run bundled helpers with `run_script("scripts/<name>.py", ...)` when the runtime provides it. Otherwise invoke them directly with `python3 "$DEFT_SKILL_ROOT/scripts/<name>.py"`. Never require a `tao-skills-external` checkout or change the user's working directory to a repository root.
+Resolve `DEFT_SKILL_ROOT` to the absolute directory containing this installed `SKILL.md`. The agent or plugin runtime resolves this path; it is not a user input. Invoke bundled helpers with `"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/<name>.py" ...`. Never require a skill-bank checkout or change the user's working directory to a repository root.
 
 This workflow invokes `tao-finetune-cosmos-embed`, `tao-analyze-gaps-vlm-bcq`, `tao-mine-nearest-neighbors`, and the selected platform skill by registered skill name. Those skills own their credentials, actions, and bundled assets. Cosmos Reason is workflow-owned: resolve `images.tao_toolkit.deft_cosmos_reason`, generate TOMLs with this workflow's helpers and configured base templates, and submit the exact train/evaluate commands in `references/mining-loop.md` through the selected platform. Do not invoke `tao-finetune-cosmos-reason` for planning, templates, action bundles, commands, or hook resolution.
 
@@ -118,12 +122,12 @@ mining:
 
 `run`, `kpi_dataset`, `train_dataset`, `cosmos_reason`, and `mining` are required; configured paths must be absolute inside `<deft_workspace>`. `cosmos_reason.baseline_model_path` must be a Cosmos Reasoner checkpoint. Convert a native Omni checkpoint first with `tao-finetune-cosmos-reason`. The optional `continual_model` defaults to `false`, which starts every iteration from the baseline. `embeddings_modality` selects KPI targets; train/source embeddings always include text and video. The optional `mine_unique_only` defaults to `true` and filters previously mined train/source paths from later iterations.
 
-All workflow outputs go under `<deft_workspace>/results`; do not add a separate output root to `workflow.yaml`. `run.name` is not just a display label: if it is set, use `<deft_workspace>/results/<run.name>` as the run directory and explain that all stage outputs, including `baseline/`, `cosmos_embed_output/`, `embedding_parquets/`, and `iter_<N>/`, are nested under that run directory. If `run.name` is `null`, create `<deft_workspace>/results/run_<YYYYMMDD_HHMMSS>` and record the resolved run directory in `deft_state.json` so resume never recomputes it.
+Write all workflow outputs under `<deft_workspace>/results`; do not add another output root. When `run.name` is set, use `<deft_workspace>/results/<run.name>` and explain that `baseline/`, `cosmos_embed_output/`, `embedding_parquets/`, and `iter_<N>/` are nested there. When it is `null`, create `<deft_workspace>/results/run_<YYYYMMDD_HHMMSS>` and record that path in `deft_state.json` so resume never recomputes it.
 
 Before running any workflow stage, validate the config:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/verify_workflow_yaml.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/verify_workflow_yaml.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml"
 ```
@@ -137,14 +141,14 @@ If the user does not provide custom Cosmos Reason or Cosmos Embed templates, cop
 Initialize a run once after validation:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/initialize_workflow.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/initialize_workflow.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml"
 ```
 
 Use the printed `run_dir` as `RUN_DIR` for every later command. If `run.name` is `null`, never ask another preparation script to derive the run directory again; pass `--run-dir "$RUN_DIR"` so all stages write into the initialized run.
 
-Do not use `--force` for an ordinary resume. It rewrites the state/config snapshot but intentionally leaves `loop_log.jsonl` and all stage artifacts in place. Use it only to repair the snapshot for the same run; choose a new `run.name` for a clean restart. Before resuming, run `$DEFT_SKILL_ROOT/scripts/resume_position.py --run-dir "$RUN_DIR"` and continue from the reported stage.
+Do not use `--force` for an ordinary resume. It rewrites the state/config snapshot but intentionally leaves `loop_log.jsonl` and all stage artifacts in place. Use it only to repair the snapshot for the same run; choose a new `run.name` for a clean restart. Before resuming, run `"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/resume_position.py" --run-dir "$RUN_DIR"` and continue from the reported stage.
 
 ## Baseline Evaluation
 
@@ -161,7 +165,7 @@ The script downloads remote HF checkpoints before Cosmos Embed runs because Cosm
 Use `scripts/prepare_cosmos_embed_inference.py` once. It prepares both the KPI dataset and the train dataset:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_embed_inference.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_embed_inference.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml" \
   --run-dir "$RUN_DIR"

--- a/skills/applications/tao-run-deft-cr-its-mining/references/host-prerequisites.md
+++ b/skills/applications/tao-run-deft-cr-its-mining/references/host-prerequisites.md
@@ -1,0 +1,28 @@
+# Host Prerequisites
+
+Read this reference before workflow preflight and whenever `deft_python.sh`
+cannot select an interpreter.
+
+The host-side helpers require Python 3.11 with `pandas`, `pyarrow`, `PyYAML`,
+and `huggingface_hub`. Resolve `DEFT_SKILL_ROOT` to the installed
+`tao-run-deft-cr-its-mining` skill directory, then export the workspace and
+select one dependency-complete interpreter:
+
+```bash
+export WORKSPACE_DIR="$WORKSPACE"
+DEFT_PYTHON="$("$DEFT_SKILL_ROOT/scripts/deft_python.sh")"
+```
+
+The selector prefers `<deft_workspace>/.venv`, checks every required import,
+and never installs packages. If it fails, show its exact commands and obtain
+user approval before provisioning the workspace-local environment:
+
+```bash
+python3 -m venv "<deft_workspace>/.venv"
+"<deft_workspace>/.venv/bin/python" -m pip install pandas pyarrow pyyaml huggingface_hub
+```
+
+Rerun the selector after installation. Use `DEFT_PYTHON` for every bundled
+Python helper. Do not install these packages into an arbitrary system Python.
+The selected platform must also provide its native CLI, GPU access, status and
+log operations, and writable shared storage.

--- a/skills/applications/tao-run-deft-cr-its-mining/references/mining-loop.md
+++ b/skills/applications/tao-run-deft-cr-its-mining/references/mining-loop.md
@@ -2,7 +2,7 @@
 
 Use this reference when running the iteration loop after the DEFT workspace and `workflow.yaml` have been validated.
 
-Resolve `DEFT_SKILL_ROOT` to the absolute directory containing the installed `tao-run-deft-cr-its-mining/SKILL.md`. The plugin runtime or agent resolves it; never ask the user for this path. Use `run_script()` for bundled helpers when available, otherwise use the direct `python3 "$DEFT_SKILL_ROOT/scripts/<name>.py"` commands below. The user's working directory does not need to be the plugin or repository root.
+Resolve `DEFT_SKILL_ROOT` to the absolute directory containing the installed `tao-run-deft-cr-its-mining/SKILL.md`; never ask the user for it. Export `WORKSPACE_DIR="$WORKSPACE"`, select `DEFT_PYTHON` with `scripts/deft_python.sh`, and invoke every bundled helper with that interpreter. The user's working directory does not need to be the plugin or repository root.
 
 ## Stage Skills
 
@@ -23,7 +23,7 @@ If the user does not provide custom Cosmos Reason or Cosmos Embed templates, cop
 Initialize a run once:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/initialize_workflow.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/initialize_workflow.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml"
 ```
@@ -36,7 +36,7 @@ An orchestrator that resolves the run directory before initialization may also p
 Append one stage event after each completed, skipped, or failed stage:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/log_stage.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/log_stage.py" \
   --log-path "$RUN_DIR/loop_log.jsonl" \
   --iter-label "iter_${ITER}" \
   --stage mine_nearest_neighbors \
@@ -49,7 +49,7 @@ python3 "$DEFT_SKILL_ROOT/scripts/log_stage.py" \
 Each append rebuilds `deft_state.json` atomically from valid log events. A truncated or otherwise malformed log line is ignored without blocking later appends. Before resuming, refresh state and ask the helper for the next unfinished stage:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/resume_position.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/resume_position.py" \
   --run-dir "$RUN_DIR"
 ```
 
@@ -97,7 +97,7 @@ Confirm the submitted job contains the mount and all three environment variables
 Generate the baseline evaluate TOML:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_evaluate.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_evaluate.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml" \
   --run-dir "$RUN_DIR"
@@ -106,7 +106,7 @@ python3 "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_evaluate.py" \
 Run the pinned `cosmos-rl-evaluate --config` command with `$RUN_DIR/baseline/evaluate/specs/evaluate.toml`. After the job exits successfully, restore host write access before result discovery:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
   --path "$RUN_DIR/baseline/evaluate" \
   --docker-image "$DEFT_COSMOS_REASON_IMAGE"
 ```
@@ -114,10 +114,10 @@ python3 "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
 The helper exits without changing anything when the directory is already writable. Do not continue unless it succeeds. Then locate the result and compute the authoritative binary metrics:
 
 ```bash
-BASELINE_RESULTS_JSON="$(python3 "$DEFT_SKILL_ROOT/scripts/find_cosmos_reason_results.py" \
+BASELINE_RESULTS_JSON="$("$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/find_cosmos_reason_results.py" \
   --evaluate-dir "$RUN_DIR/baseline/evaluate")"
 
-python3 "$DEFT_SKILL_ROOT/scripts/compute_bcq_accuracy_metrics.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/compute_bcq_accuracy_metrics.py" \
   --results-json "$BASELINE_RESULTS_JSON" \
   --output-json "$RUN_DIR/baseline/evaluate/bcq_accuracy_metrics.json"
 ```
@@ -129,7 +129,7 @@ The metrics script reads `response`/`gt` and also accepts `answer`/`ground_truth
 Prepare fixed KPI/train Cosmos Embed inputs once:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_embed_inference.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_embed_inference.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml" \
   --run-dir "$RUN_DIR"
@@ -149,7 +149,7 @@ Read `inference.num_gpus` from each generated spec and request exactly that many
 Keep the exact container image selected by `tao-finetune-cosmos-embed` as `COSMOS_EMBED_IMAGE`. After each Cosmos Embed container exits, restore host write access if needed with that same image:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
   --path "$RUN_DIR/cosmos_embed_output/kpi" \
   --docker-image "$COSMOS_EMBED_IMAGE"
 ```
@@ -157,12 +157,12 @@ python3 "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
 Convert completed outputs only for datasets that generated inference specs:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/cosmos_embed_outputs_to_parquet.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/cosmos_embed_outputs_to_parquet.py" \
   --output-dir "$RUN_DIR/cosmos_embed_output/kpi" \
   --parquet-dir "$RUN_DIR/embedding_parquets/kpi" \
   --embedding-modality "$EMBEDDING_MODALITY"
 
-python3 "$DEFT_SKILL_ROOT/scripts/cosmos_embed_outputs_to_parquet.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/cosmos_embed_outputs_to_parquet.py" \
   --output-dir "$RUN_DIR/cosmos_embed_output/train" \
   --parquet-dir "$RUN_DIR/embedding_parquets/train" \
   --embedding-modality both
@@ -181,7 +181,7 @@ Run iterations `1..run.max_iterations`. Before each stage, run `resume_position.
 ```bash
 PREDICTIONS_JSON="$RUN_DIR/iter_${ITER}/gaps/predictions.json"
 
-python3 "$DEFT_SKILL_ROOT/scripts/prepare_gap_analysis_predictions.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/prepare_gap_analysis_predictions.py" \
   --results-json "$PREVIOUS_RESULTS_JSON" \
   --annotations-json "$KPI_ANNOTATIONS_JSON" \
   --media-dir "$KPI_MEDIA_DIR" \
@@ -195,7 +195,7 @@ Invoke `tao-analyze-gaps-vlm-bcq` with `predictions_json=$PREDICTIONS_JSON`, no 
 2. **Prepare nearest-neighbor mining**:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/prepare_nearest_neighbor_mining.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/prepare_nearest_neighbor_mining.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml" \
   --run-dir "$RUN_DIR" \
@@ -210,7 +210,7 @@ The command writes one `$RUN_DIR/iter_<N>/mining/target.parquet`. Gap-analysis `
 4. **Record mined paths**: when `mining.mine_unique_only` is true or omitted, update the cumulative mined-path log after the nearest-neighbor run completes.
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/record_mined_paths.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/record_mined_paths.py" \
   --mined-neighbors-parquet "$RUN_DIR/iter_${ITER}/mining/mined_neighbors.parquet" \
   --mined-log-parquet "$RUN_DIR/mining/mined_paths_log.parquet"
 ```
@@ -222,7 +222,7 @@ When `mining.mine_unique_only` is false, do not run the command; append a `recor
 5. **Prepare Cosmos Reason training**:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_train.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_train.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml" \
   --run-dir "$RUN_DIR" \
@@ -236,7 +236,7 @@ Iteration 1 trains on mined annotations only; `train_dataset.annotations_path` r
 6. **Train Cosmos Reason**: run the pinned `cosmos-rl --config <train.toml> /opt/cosmos_rl/tao_sft_example.py` command with `$RUN_DIR/iter_<N>/train/specs/train.toml`. Keep monitoring the submitted job until it reaches terminal success. Do not infer completion from checkpoint files appearing during training. After terminal success, require the final structured status or training log to report at least one completed optimizer step. If it reports zero, stop before checkpoint discovery or evaluation, tell the user the parameters likely need tuning, and ask how to proceed. Then restore host write access before checkpoint discovery or evaluation preparation:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
   --path "$RUN_DIR/iter_${ITER}/train" \
   --docker-image "$DEFT_COSMOS_REASON_IMAGE"
 ```
@@ -246,7 +246,7 @@ Do not continue unless the helper succeeds.
 7. **Prepare and run evaluation**: after the training job reaches terminal success, prepare evaluation:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_evaluate.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_evaluate.py" \
   --workspace "$WORKSPACE" \
   --workflow-yaml "$WORKSPACE/specs/workflow.yaml" \
   --run-dir "$RUN_DIR" \
@@ -256,7 +256,7 @@ python3 "$DEFT_SKILL_ROOT/scripts/prepare_cosmos_reason_evaluate.py" \
 The preparation command finds the latest `epoch_<N>` safetensors checkpoint under this iteration's completed train directory, prints the selected path, and writes it into `$RUN_DIR/iter_<N>/evaluate/specs/evaluate.toml`. If no checkpoint exists, stop before launching evaluation. Run the pinned `cosmos-rl-evaluate --config` command with that TOML. After the job exits successfully, restore host write access before result discovery:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
   --path "$RUN_DIR/iter_${ITER}/evaluate" \
   --docker-image "$DEFT_COSMOS_REASON_IMAGE"
 ```
@@ -264,10 +264,10 @@ python3 "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
 Do not continue unless the helper succeeds. Then locate the result and compute that iteration's metrics:
 
 ```bash
-ITERATION_RESULTS_JSON="$(python3 "$DEFT_SKILL_ROOT/scripts/find_cosmos_reason_results.py" \
+ITERATION_RESULTS_JSON="$("$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/find_cosmos_reason_results.py" \
   --evaluate-dir "$RUN_DIR/iter_${ITER}/evaluate")"
 
-python3 "$DEFT_SKILL_ROOT/scripts/compute_bcq_accuracy_metrics.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/compute_bcq_accuracy_metrics.py" \
   --results-json "$ITERATION_RESULTS_JSON" \
   --output-json "$RUN_DIR/iter_${ITER}/evaluate/bcq_accuracy_metrics.json"
 ```
@@ -277,7 +277,7 @@ Report the printed accuracy, balanced accuracy, false-positive count, false-nega
 8. **Clean Cosmos Reason training checkpoints**: after evaluation and metric computation complete, remove the large resumable Cosmos-RL checkpoints while retaining the exported safetensors used by later iterations:
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/cleanup_cosmos_reason_training.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/cleanup_cosmos_reason_training.py" \
   --train-dir "$RUN_DIR/iter_${ITER}/train"
 ```
 
@@ -288,7 +288,7 @@ The command removes only each `<timestamp>/checkpoints/` directory and the train
 After the loop stops because it reached `max_iterations` or found no weak samples, generate the baseline/iteration report. Also generate it after a failed run when baseline metrics are available, so completed evaluations are not lost from the final account.
 
 ```bash
-python3 "$DEFT_SKILL_ROOT/scripts/summarize_bcq_accuracy_metrics.py" \
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/summarize_bcq_accuracy_metrics.py" \
   --run-dir "$RUN_DIR"
 ```
 

--- a/skills/applications/tao-run-deft-cr-its-mining/scripts/deft_python.sh
+++ b/skills/applications/tao-run-deft-cr-its-mining/scripts/deft_python.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Select an already-provisioned Python for the workflow's host-side helpers.
+# Installation remains an explicit, user-approved preflight action.
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+skill_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+workspace=${WORKSPACE_DIR:-${WORKSPACE:-}}
+probe='import sys,pandas,pyarrow,yaml,huggingface_hub; assert sys.version_info >= (3, 11)'
+
+candidates=(
+  "${DEFT_PYTHON:-}"
+  "${workspace:+$workspace/.venv/bin/python}"
+  "${workspace:+$workspace/.venv/bin/python3}"
+  "$skill_dir/.venv/bin/python"
+  "$skill_dir/.venv/bin/python3"
+  "$(command -v python3 2>/dev/null || true)"
+)
+
+for candidate in "${candidates[@]}"; do
+  [ -n "$candidate" ] || continue
+  [ -x "$candidate" ] || continue
+  if "$candidate" -c "$probe" >/dev/null 2>&1; then
+    if [ "$#" -eq 0 ]; then
+      printf '%s\n' "$candidate"
+    else
+      exec "$candidate" "$@"
+    fi
+    exit 0
+  fi
+done
+
+workspace_display=${workspace:-/absolute/path/to/deft_workspace}
+cat >&2 <<EOF
+deft_python: no Python 3.11+ interpreter provides pandas, pyarrow, yaml, and huggingface_hub
+deft_python: after user approval, provision the workspace environment with:
+  python3 -m venv "$workspace_display/.venv"
+  "$workspace_display/.venv/bin/python" -m pip install pandas pyarrow pyyaml huggingface_hub
+deft_python: rerun preflight after installation; this selector never installs packages itself
+EOF
+exit 2

--- a/skills/applications/tao-run-deft-cr-its-mining/tests/test_host_dependencies.py
+++ b/skills/applications/tao-run-deft-cr-its-mining/tests/test_host_dependencies.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the DEFT workflow host-Python prerequisite contract."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+
+
+class PythonSelectorTests(unittest.TestCase):
+    """Verify selection and failure guidance without installing packages."""
+
+    def test_prefers_workspace_virtualenv(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = pathlib.Path(temporary)
+            interpreter = workspace / ".venv/bin/python"
+            interpreter.parent.mkdir(parents=True)
+            interpreter.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            interpreter.chmod(0o755)
+
+            result = subprocess.run(
+                ["/bin/bash", str(SCRIPTS / "deft_python.sh")],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "WORKSPACE_DIR": str(workspace), "DEFT_PYTHON": ""},
+            )
+
+            self.assertEqual(result.stdout.strip(), str(interpreter))
+
+    def test_missing_dependencies_prints_workspace_install(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            workspace = root / "workspace"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            for name in ("dirname", "cat"):
+                source = shutil.which(name)
+                self.assertIsNotNone(source)
+                os.symlink(source, bin_dir / name)
+            failing_python = bin_dir / "python3"
+            failing_python.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            failing_python.chmod(0o755)
+
+            result = subprocess.run(
+                ["/bin/bash", str(SCRIPTS / "deft_python.sh")],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    "PATH": str(bin_dir),
+                    "WORKSPACE_DIR": str(workspace),
+                    "DEFT_PYTHON": str(failing_python),
+                },
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn(f'python3 -m venv "{workspace}/.venv"', result.stderr)
+            self.assertIn(
+                "-m pip install pandas pyarrow pyyaml huggingface_hub",
+                result.stderr,
+            )
+            self.assertNotIn("requirements.txt", result.stderr)
+
+
+class DocumentationTests(unittest.TestCase):
+    """Keep documented helper invocations on the selected interpreter."""
+
+    def test_documented_helpers_use_selected_python(self) -> None:
+        documentation = "\n".join(
+            (SKILL_ROOT / path).read_text(encoding="utf-8")
+            for path in (
+                "SKILL.md",
+                "references/host-prerequisites.md",
+                "references/mining-loop.md",
+            )
+        )
+        self.assertNotIn('python3 "$DEFT_SKILL_ROOT/scripts/', documentation)
+        self.assertIn('"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/', documentation)
+
+    def test_host_dependencies_do_not_use_a_skill_manifest(self) -> None:
+        self.assertFalse((SKILL_ROOT / "requirements.txt").exists())
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        prerequisites = (SKILL_ROOT / "references/host-prerequisites.md").read_text(
+            encoding="utf-8"
+        )
+        documentation = skill + prerequisites
+        self.assertNotIn("requirements.txt", documentation)
+        self.assertIn("pip install pandas pyarrow pyyaml huggingface_hub", documentation)
+        self.assertIn("references/host-prerequisites.md", skill)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->
This PR addresses **bug 6630438**. The agent now checks that the necessary packages are installed, and if not it has the agent inform the user and then asks the user's permission to install the packages. It uses a hierarchy of Python environments to find the right python package location.

### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->
This is for a bug fix for the TAO 7.2 release

### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->
Yes, for the DEFT CR ITS skill for TAO 7.2

### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->

Asked the agent to fine-tune Cosmos Reason for DEFT for ITS using the ~/deft_workspace and text only workflow yaml (with embeddings already generated).

Case 1: packages installed
On my machine, the packages are installed. The workflow verified that the packages are installed and continued.

Case 2: no packages installed (in a sandbox environment)
I had the agent create a sandbox environment where no packages were installed.

It verified that:
*  the deft_python.sh script failed
* the agent is instructed to ask to install the packages
* once I gave permission to install the packages, it verified that the packages were available and the scripts requiring them could run

Case 3: one package is installed but not the others (sandbox environment with only PyYaml installed)
It verified that:
* the deft_python.sh script failed
* the agent is instructed to ask to install the packages
 

### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

-->
Generated-by: Codex 5.6 Sol (Extra High reasoning)

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Fixed a bug in which workflow silently fails when the host environment does not have the necessary Python packages.
```


### Checklist

- [ ] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [ ] I have read the contributing guidelines
- [ ] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [ ] All tests pass locally
- [ ] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [ ] No secrets, credentials, proprietary data, or customer data are included in this PR
- [ ] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->
