### PR TITLE
[TAO-000][Bugfix] Correct the Cosmos-RL warmup schedule and request the PEFT spike guard

### DIFF
--- a/skills/models/tao-finetune-cosmos-reason/references/spec_template_train.yaml
+++ b/skills/models/tao-finetune-cosmos-reason/references/spec_template_train.yaml
@@ -9,6 +9,7 @@ train:
   optm_weight_decay: 0.01
   optm_min_lr_factor: 0.0
   optm_grad_norm_clip: 1.0
+  optm_loss_spike_rollback: 0.0
   epsilon: 1.0e-08
   optm_name: AdamW
   optm_betas:

--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -1695,6 +1695,7 @@ def _rl_spec(
     train_batch_per_replica = (
         getattr(args, "rl_train_batch_per_replica", 0) or args.rl_mini_batch
     )
+    requested_loss_spike_rollback = getattr(args, "loss_spike_rollback", None)
     if train_batch_per_replica % args.rl_mini_batch:
         raise WorkflowError(
             "rl_train_batch_per_replica must be divisible by rl_mini_batch"
@@ -1744,8 +1745,8 @@ def _rl_spec(
             # trainable tensor, which is ~1.2GB for a LoRA adapter but ~350GB
             # for a dense 8.8B model, so request it for PEFT only.
             "optm_loss_spike_rollback": (
-                args.loss_spike_rollback
-                if args.loss_spike_rollback is not None
+                requested_loss_spike_rollback
+                if requested_loss_spike_rollback is not None
                 else (10.0 if args.training_mode == "peft" else 0.0)
             ),
             "param_dtype": args.precision,

--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -1725,7 +1725,15 @@ def _rl_spec(
             "epsilon": args.optimizer_epsilon,
             # Cosmos-RL names a constant schedule "none"; the common parity
             # contract and Framework continue to expose it as "constant".
-            "optm_warmup_epochs": args.warmup,
+            # Cosmos-RL reads a FLOAT <= 1.0 as a fraction of the whole run, so
+            # a plain 1.0 becomes "warm up across every epoch" (epochs *
+            # steps_per_epoch steps) instead of one epoch. Emit an int whenever
+            # the request is a whole number of epochs.
+            "optm_warmup_epochs": (
+                int(args.warmup)
+                if float(args.warmup).is_integer()
+                else args.warmup
+            ),
             "optm_decay_type": "none"
             if args.scheduler == "constant"
             else args.scheduler,

--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -1738,6 +1738,16 @@ def _rl_spec(
             if args.scheduler == "constant"
             else args.scheduler,
             "optm_grad_norm_clip": args.gradient_clip,
+            # PEFT SFT on this stack spikes often enough to lose roughly half of
+            # all runs; the backend's guard rewinds parameters and optimizer
+            # moments past the spike. It retains four snapshots of every
+            # trainable tensor, which is ~1.2GB for a LoRA adapter but ~350GB
+            # for a dense 8.8B model, so request it for PEFT only.
+            "optm_loss_spike_rollback": (
+                args.loss_spike_rollback
+                if args.loss_spike_rollback is not None
+                else (10.0 if args.training_mode == "peft" else 0.0)
+            ),
             "param_dtype": args.precision,
             # Preserve Cosmos-RL's full reproducibility contract in addition to
             # the DataLoader-specific seed below.
@@ -5556,6 +5566,17 @@ def add_arguments(parser: argparse.ArgumentParser, *, require_inputs: bool) -> N
     parser.add_argument("--minimum-lr-factor", type=float, default=None)
     parser.add_argument("--weight-decay", type=float, default=0.01)
     parser.add_argument("--gradient-clip", type=float, default=1.0)
+    parser.add_argument(
+        "--loss-spike-rollback",
+        type=float,
+        default=None,
+        help=(
+            "Rewind to the last healthy step when the gradient norm or loss "
+            "exceeds this multiple of its rolling median. Omit to enable it at "
+            "10.0 for PEFT and leave it off for dense training, where the "
+            "snapshots would not fit."
+        ),
+    )
     parser.add_argument("--precision", default="bfloat16")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--sequence-length", type=int, default=0)


### PR DESCRIPTION
Two planner fixes found while running Cosmos3-Nano LoRA SFT on a single GB300 (aarch64). Both are Cosmos-RL specific and touch only `cosmos_workflow.py` plus its train template.

## 1. Whole-epoch warmup reached the TOML as a float

`--warmup` is a float argument, so a one-epoch warmup was emitted as `optm_warmup_epochs = 1.0`. Cosmos-RL's scheduler treats a float `<= 1.0` as a *fraction of the entire run*:

```python
warmup_steps = int(warmup_epochs * total_epochs * steps_per_epoch)
```

Over a 3-epoch run that produced **540 warmup steps instead of 180** - the learning rate ramps across the whole run and only reaches its target on the final step. The integer branch of the same scheduler does the intended `warmup_epochs * steps_per_epoch`, so emit an int whenever the request is a whole number of epochs and leave genuine fractions alone.

Caught live: the run logged `converted to 540 warmup steps` before the fix and `converted to 180 warmup steps` after.

## 2. Request `train.optm_loss_spike_rollback` for PEFT

PEFT SFT on this backend loses roughly half of all runs to a training spike. Measured `train/avg_loss` across four unguarded runs: `0.136 (ok)`, `0.593 (diverged)`, `2.071 (diverged)`, `0.127 (ok)`, with validation loss reaching 6.36 on the worst.

The backend gained `train.optm_loss_spike_rollback` (default `0.0`, disabled), which detects a spike on the pre-clip gradient norm against a rolling median, rewinds parameters *and* optimizer moments past it, and backs the step size off. With it enabled, **ten consecutive runs completed with no failures** and `train/avg_loss` spanning `0.1223-0.1351` (stdev `0.0046`), every one beating the 0.1479 reference. Evaluation accuracy across those ten averaged 0.8750 (best 722/803).

Emit `10.0` for PEFT and `0.0` for dense, overridable with `--loss-spike-rollback`.

**The PEFT/dense split is a hard constraint, not a preference.** Rewinding retains four snapshots of every trainable tensor plus its AdamW moments:

| training mode | trainable | per snapshot | 4-deep ring |
|---|---|---|---|
| LoRA (peft) | 30.7M | 0.31 GB | **1.2 GB** |
| dense | 8797.8M | 87.98 GB | **351.9 GB** |

Defaulting it on would OOM every dense run, which is why the backend default stays `0.0` and the decision lives in the planner.

## Verification

```
peft   optm_loss_spike_rollback=10.0   optm_warmup_epochs=1 (int)
dense  optm_loss_spike_rollback=0.0    optm_warmup_epochs=1 (int)
explicit override -> 5.0
```

## Dependency

`optm_loss_spike_rollback` requires the backend change on `cosmos-reason@feature/enhanced-hooks-and-custom-loggers` (`f369c5c`). Against an older backend the field is simply unknown to the config schema, so this should merge after that reaches the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)