### PR TITLE
[TAO-0000][Bugfix] NVBug 6641988: fix gap cfg introspection

### DIFF
--- a/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
+++ b/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
@@ -31,7 +31,7 @@ docker run --rm -v "$SPEC_DIR:/w:ro" "$DS_IMAGE" gap_analysis vcn_aoi \
     -e /w/vcn_aoi_spec.yaml --cfg=job
 ```
 
-The `-e` path must resolve inside the container, so the spec must live under the directory mounted at `/w`. Reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`. Current data-services builds reject bare-override invocation with `requires the following argument: -e/--experiment_spec_file` — the entrypoint requires `-e` for every subtask before any Hydra override is parsed (an entrypoint contract at tao-data-services HEAD, not a build-specific quirk; verified on both `7.1.0-data-services` and the pinned 7.2 build); keep path values as trailing Hydra overrides during the real run.
+The `-e` path must resolve inside the container, so the spec must live under the directory mounted at `/w`. Reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`. Current data-services builds reject bare-override invocation with `requires the following argument: -e/--experiment_spec_file` — the entrypoint requires `-e` for every subtask before any Hydra override is parsed; keep path values as trailing Hydra overrides during the real run.
 
 ---
 

--- a/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
+++ b/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
@@ -31,7 +31,7 @@ docker run --rm -v "$SPEC_DIR:/w:ro" "$DS_IMAGE" gap_analysis vcn_aoi \
     -e /w/vcn_aoi_spec.yaml --cfg=job
 ```
 
-The `-e` path must resolve inside the container, so the spec must live under the directory mounted at `/w`. Reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`. Current data-services builds reject bare-override invocation with `requires the following argument: -e/--experiment_spec_file` — the entrypoint requires `-e` for every subtask before any Hydra override is parsed; keep path values as trailing Hydra overrides during the real run.
+The `-e` path must resolve inside the container, so the spec must live under the directory mounted at `/w`. Reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`.
 
 ---
 

--- a/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
+++ b/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
@@ -31,7 +31,7 @@ docker run --rm -v "$SPEC_DIR:/w:ro" "$DS_IMAGE" gap_analysis vcn_aoi \
     -e /w/vcn_aoi_spec.yaml --cfg=job
 ```
 
-The `-e` path must resolve inside the container, so the spec must live under the directory mounted at `/w`. Reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`. The `7.1.0-data-services` build rejects bare-override invocation with `requires the following argument: -e/--experiment_spec_file`; keep path values as trailing Hydra overrides during the real run.
+The `-e` path must resolve inside the container, so the spec must live under the directory mounted at `/w`. Reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`. Current data-services builds reject bare-override invocation with `requires the following argument: -e/--experiment_spec_file` — the entrypoint requires `-e` for every subtask before any Hydra override is parsed (an entrypoint contract at tao-data-services HEAD, not a build-specific quirk; verified on both `7.1.0-data-services` and the pinned 7.2 build); keep path values as trailing Hydra overrides during the real run.
 
 ---
 

--- a/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
+++ b/skills/data/tao-analyze-gaps-visual-changenet/SKILL.md
@@ -20,9 +20,18 @@ tags:
 
 You are an analyst for NVIDIA TAO VCN Classify (Visual Component Net) inference results. Your job is to identify the **weakest samples per ground-truth label** by measuring signed distance from the decision threshold *in the wrong direction*, then surface them for downstream augmentation or relabeling.
 
-This skill is intentionally lightweight. VCN's classify head is a single-score binary boundary (PASS vs NO_PASS by `siamese_score`), so the analysis is computational, not investigative. The whole computation lives behind one direct `docker run` invocation against the pinned TAO data-services image (see Setup). The container's entrypoint takes `<category> <action> [hydra overrides...]`; we pass `gap_analysis vcn_aoi key=value …`. Each override is a bare Hydra `key=value` that selectively overrides the script's `GapAnalysisConfig` schema (defaults are baked into the container; introspect with `docker run ... gap_analysis vcn_aoi --cfg=job`). (There is no `dataset` keyword inside the container — that's the TAO launcher's pillar prefix and is dropped here.) You do **not** need delegated analysis, multi-phase image audits, or component-type clustering — VCN does not expose those dimensions. View only a small set of representative weak samples to qualify the gaps after the container returns.
+This skill is intentionally lightweight. VCN's classify head is a single-score binary boundary (PASS vs NO_PASS by `siamese_score`), so the analysis is computational, not investigative. The whole computation lives behind one direct `docker run` invocation against the pinned TAO data-services image (see Setup). The container's entrypoint takes `<category> <action> [hydra overrides...]`; we pass `gap_analysis vcn_aoi key=value …`. Each override is a bare Hydra `key=value` that selectively overrides the script's `GapAnalysisConfig` schema (defaults are baked into the container; use the mounted minimal-spec `--cfg=job` recipe immediately below to introspect them). (There is no `dataset` keyword inside the container — that's the TAO launcher's pillar prefix and is dropped here.) You do **not** need delegated analysis, multi-phase image audits, or component-type clustering — VCN does not expose those dimensions. View only a small set of representative weak samples to qualify the gaps after the container returns.
 
-CLI surface can shift between data-services container builds. If a `gap_analysis vcn_aoi` invocation fails on argument parsing, introspect the actual schema once per image with `docker run --rm "$DS_IMAGE" gap_analysis vcn_aoi --cfg=job` and reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`. Known case: the `7.1.0-data-services` build rejects bare-override invocation with `requires the following argument: -e/--experiment_spec_file` — pass a minimal spec via `-e` (e.g. `min_recall`/`top_k_per_label`) and keep the path values as trailing Hydra overrides.
+CLI surface can shift between data-services container builds. If a `gap_analysis vcn_aoi` invocation fails on argument parsing, introspect the actual schema once per image with a minimal spec on a bind-mounted host path:
+
+```bash
+SPEC_DIR="$(mktemp -d)"
+printf '%s\n' 'min_recall: 0.99' 'top_k_per_label: 5' > "$SPEC_DIR/vcn_aoi_spec.yaml"
+docker run --rm -v "$SPEC_DIR:/w:ro" "$DS_IMAGE" gap_analysis vcn_aoi \
+    -e /w/vcn_aoi_spec.yaml --cfg=job
+```
+
+The `-e` path must resolve inside the container, so the spec must live under the directory mounted at `/w`. Reconcile any renamed keys (e.g. `inference_csv` vs `inference_results_dir`, `output_dir` vs `results_dir`) before retrying. Output parquet name is `kpi_gaps.parquet`. The `7.1.0-data-services` build rejects bare-override invocation with `requires the following argument: -e/--experiment_spec_file`; keep path values as trailing Hydra overrides during the real run.
 
 ---
 


### PR DESCRIPTION
## Summary

- replace the impossible bare `gap_analysis vcn_aoi --cfg=job` guidance with a mounted minimal-spec recipe
- make the entrypoint's required `-e/--experiment_spec_file` contract explicit
- keep the fix documentation-only and scoped to the VCN gap-analysis skill

## Validation

- verified the bare command fails with the expected missing `-e` error on the pinned `7.1.0-data-services` image
- verified the documented mounted two-key spec prints the resolved config and exits 0
- `./scripts/validate-skills.sh`
- `python3 -m pytest -q scripts/tests/test_skill_command_hygiene.py`
- `bash -n` for all bundled skill hooks
- JSON validation for `evals/evals.json`
- `git diff --check`
