### PR TITLE
[TAO-0000][Docs] Document the branching strategy and the nvstaging image gap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing! This guide covers **how we work** — trunk-based devel
 
 ## Trunk-based development and backports
 
-We practice **trunk-based development**: all changes land on **`main`** first, then are backported to release branches as needed.
+We practice **trunk-based development**: all changes land on **`main`** first, then are backported to release branches as needed. `main` is the source of truth for every feature, which also means it is **not** the branch users install from — it can carry work in progress and references to pre-release container builds. Releases are cut onto **`release/X.Y.Z`** branches, which are QA'd and tagged, and that tag is what the [install instructions](README.md#install) point users at. This trunk-plus-release-branch model is the one most large open-source projects use (Kubernetes, Linux, LLVM, Apache Spark, and others).
 
 - **Open your PR against `main`**, not against a `release/*` branch.
 - If a fix should also ship in a release, add a **`release/X.Y.Z`** label to the PR — the label name matches the release branch (e.g. `release/7.1.0`). Add several labels to backport to multiple releases.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Portable agent skills for training, evaluating, and running inference on NVIDIA TAO models. Works with Claude Code, Codex, Gemini CLI, or any coding agent that speaks the [Agent Skills open standard](https://agentskills.io). Most local Docker model/data actions need only Docker plus NVIDIA Container Toolkit; application workflows may declare small host-Python requirements for deterministic state and analysis adapters. Advanced features—job tracking, multi-node, S3 I/O—are built in, not bolted on: platform skills implement a four-verb execution contract over their native CLI with no `nvidia-tao-sdk`. See [Execution: no SDK required](#execution-no-sdk-required).
 
+## Branching strategy
+
+`main` is our **development trunk**, not a stable branch — it moves
+continuously and can reference pre-release container builds. Each release is
+cut onto a **`release/X.Y.Z`** branch, QA'd there, and published as a matching
+Git tag on the [Releases page](https://github.com/NVIDIA-TAO/tao-skill-bank/releases).
+**Install from the latest published tag** — that is what every command below
+pins to — and treat both `main` and an unpublished `release/*` branch as
+work in progress. Contributors: see
+[CONTRIBUTING.md](CONTRIBUTING.md#trunk-based-development-and-backports) for how
+changes flow from `main` into a release.
+
+> **Known issue — internal image gating.** Skills on `main` (and on a
+> `release/*` branch before its tag is published) may pin release-candidate
+> container images under `nvcr.io/nvstaging/*`. Those are internal builds:
+> an external NGC account cannot pull them, however valid its `NGC_KEY`.
+> Publishing a release rewrites those pins to public `nvcr.io/nvidia/tao`
+> images, so **no published tag pins an `nvstaging` image**. We are working on a
+> way to host dev and nightly images publicly; until then, install from the
+> latest published tag.
+
 ## Install
 
 The skill bank works with both Claude Code and Codex. Pick the runtime you use.


### PR DESCRIPTION
## Why

Users have been installing from `main` and hitting release-candidate `nvcr.io/nvstaging/*` container pins they cannot pull — raised on the "TAO Skills using nvstaging containers" thread while prepping a DLI course. Nothing in the README said which branch is meant for consumption, so `main` looked like the supported surface.

## What

- **README — new "Branching strategy" section** above Install: `main` is the development trunk; each release is cut onto `release/X.Y.Z`, QA'd there, and published as a matching Git tag; install from the latest published tag. Both `main` and an unpublished `release/*` branch are work in progress.
- **README — "Known issue — internal image gating" callout**: `main` and unpublished release branches may pin `nvcr.io/nvstaging/*` images that external NGC accounts cannot pull; publishing a release rewrites those pins to public `nvcr.io/nvidia/tao` images; publicly hosted dev/nightly images are being worked on.
- **CONTRIBUTING** — the existing trunk-based development section now states why `main` is not the branch users install from, and where releases get tagged.

## Checked against the repo

| Ref | `nvcr.io/nvstaging/*` pins in `versions.yaml` / `skill_info.yaml` |
|---|---|
| tags `7.1.0`, `7.0.1`, `7.0.0-EA` | none |
| `main` | 9 |
| `release/7.2.0` (not yet published) | 10 |

That is the gap the callout describes, and it is why the "no published tag pins an `nvstaging` image" claim is safe to make.

`pytest scripts/tests` → 342 passed / 2 skipped; `scripts/validate-skills.sh` passes.

The `TAO-0000` placeholder in the title can be swapped for a real ticket if one is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)