### PR TITLE
[TAO-6662913][Bugfix] Preserve AutoML session identity on resume

### DIFF
--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -340,20 +340,14 @@ result = runner.run(
 )
 ```
 
-Every fresh run must set `automl_settings["session_id"]` explicitly. Generate
-it once with `scripts/resolve_automl_session.py new` and retain it in the sealed
-runner configuration. Never rely on the wheel's random per-process default.
-
-Only resume an existing workspace when the user explicitly asks to resume,
-continue, recover, or inspect an existing experiment. Treat a plain "run
-AutoML" request as a fresh run. Before `resume=True`, recover the session with
-`scripts/resolve_automl_session.py resolve --workspace <full-run-path>` and put
-that value in `automl_settings["session_id"]`. The helper deliberately fails
-when state is missing or multiple controller files make the workspace
-ambiguous; do not launch until the intended state is proven. Read the resume
-section of `references/automl-advanced-monitoring.md` for the complete pattern.
-The `validate_session_settings` call above is mandatory for both fresh and
-resumed runs; a prose reminder is not a substitute for that executable gate.
+Set `automl_settings["session_id"]` explicitly and call
+`validate_session_settings` before every run. Generate a fresh ID once with
+`scripts/resolve_automl_session.py new`. Resume only when explicitly requested;
+resolve its controller with
+`scripts/resolve_automl_session.py resolve --workspace <full-run-path>`.
+Missing or ambiguous state is a blocker. See the
+resume section of `references/automl-advanced-monitoring.md` for the complete
+fresh/resume pattern.
 
 ## Monitoring
 

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -316,7 +316,7 @@ runner = AutoMLRunner(
 
 result = runner.run(
     workspace_path="<automl_workspace>",   # timestamp it to avoid collisions
-    automl_settings=automl_settings,
+    automl_settings=automl_settings,       # must contain an explicit session_id
     spec_overrides=spec_overrides,
     automl_hyperparameters=automl_hyperparameters,
     custom_param_ranges=custom_param_ranges,
@@ -326,9 +326,18 @@ result = runner.run(
 )
 ```
 
+Every fresh run must set `automl_settings["session_id"]` explicitly. Generate
+it once with `scripts/resolve_automl_session.py new` and retain it in the sealed
+runner configuration. Never rely on the wheel's random per-process default.
+
 Only resume an existing workspace when the user explicitly asks to resume,
 continue, recover, or inspect an existing experiment. Treat a plain "run
-AutoML" request as a fresh run.
+AutoML" request as a fresh run. Before `resume=True`, recover the session with
+`scripts/resolve_automl_session.py resolve --workspace <full-run-path>` and put
+that value in `automl_settings["session_id"]`. The helper deliberately fails
+when state is missing or multiple controller files make the workspace
+ambiguous; do not launch until the intended state is proven. Read the resume
+section of `references/automl-advanced-monitoring.md` for the complete pattern.
 
 ## Monitoring
 

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -301,12 +301,17 @@ Use the selected platform SDK only after its preflight passes. Construct SDKs
 without embedding credentials in code.
 
 ```python
+import sys
 from pathlib import Path
 from tao_automl.runner import AutoMLRunner
 
 skill_bank = Path("<absolute-tao-skill-bank>")
 model_skill = "<resolved-model-skill-directory>"
 skill_dir = skill_bank / "skills" / "models" / model_skill
+sys.path.insert(
+    0, str(skill_bank / "skills/applications/tao-run-automl/scripts")
+)
+from resolve_automl_session import validate_session_settings
 
 runner = AutoMLRunner(
     sdk=sdk,
@@ -314,8 +319,16 @@ runner = AutoMLRunner(
     action=action,                      # train, distill, prune, quantize, ...
 )
 
+workspace_path = Path("<automl_workspace>")
+resume = False
+# Mandatory fail-closed gate from this skill's bundled scripts directory.
+validate_session_settings(
+    automl_settings,
+    resume=resume,
+    workspace=workspace_path if resume else None,
+)
 result = runner.run(
-    workspace_path="<automl_workspace>",   # timestamp it to avoid collisions
+    workspace_path=str(workspace_path),    # timestamp it to avoid collisions
     automl_settings=automl_settings,       # must contain an explicit session_id
     spec_overrides=spec_overrides,
     automl_hyperparameters=automl_hyperparameters,
@@ -323,6 +336,7 @@ result = runner.run(
     metric_extractor=metric_extractor,  # optional
     eval_fn=eval_fn,                    # optional
     final_eval_fn=final_eval_fn,        # optional but required when final eval is runnable
+    resume=resume,
 )
 ```
 
@@ -338,6 +352,8 @@ that value in `automl_settings["session_id"]`. The helper deliberately fails
 when state is missing or multiple controller files make the workspace
 ambiguous; do not launch until the intended state is proven. Read the resume
 section of `references/automl-advanced-monitoring.md` for the complete pattern.
+The `validate_session_settings` call above is mandatory for both fresh and
+resumed runs; a prose reminder is not a substitute for that executable gate.
 
 ## Monitoring
 

--- a/skills/applications/tao-run-automl/references/automl-advanced-monitoring.md
+++ b/skills/applications/tao-run-automl/references/automl-advanced-monitoring.md
@@ -184,7 +184,12 @@ def eval_on_held_out(rec, train_job_id):
 
 runner.run(
     ...,
-    automl_settings={"metric": task_metric, "direction": direction, ...},
+    automl_settings={
+        "metric": task_metric,
+        "direction": direction,
+        "session_id": session_id,
+        ...,
+    },
     eval_fn=eval_on_held_out,
 )
 ```
@@ -316,6 +321,17 @@ SESSION_ID=$(python "$TAO_SKILL_BANK_PATH/skills/applications/tao-run-automl/scr
 Place that literal value in the sealed `automl_settings`. The resulting
 `.automl/controller/<session_id>.json` is the durable binding used by later
 resume invocations.
+
+Before either fresh or resumed `runner.run(...)`, call the bundled
+`validate_session_settings(automl_settings, resume=..., workspace=...)` gate
+shown in `SKILL.md`. Missing identities fail before the wheel can apply its
+random default; resumed identities must resolve to an existing controller.
+
+This is a skill-boundary safeguard. The currently packaged
+`nvidia-tao-automl` wheel still permits `resume=True` without a matching
+`session_id` and may silently create a fresh controller for callers outside
+this skill. NVBug 6662913 tracks that upstream fail-loud behavior; until the
+wheel changes, non-skill callers must apply the same explicit identity gate.
 
 Behaviour on resume:
 1. **Brain state** is reloaded from `<workspace>/.automl/*` for the explicit

--- a/skills/applications/tao-run-automl/references/automl-advanced-monitoring.md
+++ b/skills/applications/tao-run-automl/references/automl-advanced-monitoring.md
@@ -282,18 +282,47 @@ resume. An uncatchable process termination or host loss can also leave an
 in-flight backend job; recover that run with `resume=True` and the **full
 suffixed path** (including the `run_<timestamp>` directory):
 
+Resolve the controller identity before constructing the resumed runner:
+
+```bash
+SESSION_ID=$(python "$TAO_SKILL_BANK_PATH/skills/applications/tao-run-automl/scripts/resolve_automl_session.py" \
+  resolve --workspace ./my_experiment/run_20260423_183015)
+```
+
+The command fails closed if no controller state exists. It also refuses to
+choose arbitrarily when a workspace contains multiple controller files. For a
+workspace contaminated by an older failed resume, inspect the controller
+states and rerun with `--session-id <intended-id>`; never select the first file
+returned by the filesystem.
+
 ```python
 result = runner.run(
     ...,
     workspace_path="./my_experiment/run_20260423_183015",   # full suffixed path
+    automl_settings={**automl_settings, "session_id": "<resolved-session-id>"},
     resume=True,
 )
 ```
 
 When `resume=True`, the runner does NOT append a new timestamp suffix — it reuses the path as-is.
 
+For the original run, create the identity once after launch approval and before
+calling the runner:
+
+```bash
+SESSION_ID=$(python "$TAO_SKILL_BANK_PATH/skills/applications/tao-run-automl/scripts/resolve_automl_session.py" new)
+```
+
+Place that literal value in the sealed `automl_settings`. The resulting
+`.automl/controller/<session_id>.json` is the durable binding used by later
+resume invocations.
+
 Behaviour on resume:
-1. **Brain state** is reloaded from `<workspace>/.automl/*` — all completed rec results are already registered.
+1. **Brain state** is reloaded from `<workspace>/.automl/*` for the explicit
+   `session_id` — all completed rec results are already registered. Treat
+   `Loaded controller state: 0 recommendations` as an error when the selected
+   controller file contains completed recommendations; cancel before a new
+   recommendation is submitted.
 2. **Any in-flight jobs** recorded in `<workspace>/active_jobs.json` (persisted after each submission) are polled to terminal, their recovered backend job IDs are restored on the recommendation, their metrics extracted, and reported to the brain — *before* the main propose-new-rec loop starts. No duplicate submissions or orphaned trial artifacts.
 3. After recovery, the loop continues normally until `automl.is_complete()`.
 
@@ -373,7 +402,7 @@ Model-specific notes do not belong in this AutoML skill. For every requested mod
 5. **Using a weak proxy metric.** The brain can optimize a metric that does not reflect real task quality. Use the metric recommended by the model skill or provide `eval_fn`.
 6. **Implicit direction trap.** If the metric name does not imply the desired direction, set `direction` explicitly.
 7. **Spec-override typos.** `save_freq_in_epochs` (plural) used to silently do nothing; now raises `ValueError` with suggestion. If you see that error, it's the fix working.
-8. **Orchestrator dies mid-sweep.** Relaunch with the same `workspace_path` and `resume=True`. In-flight jobs are recovered from `active_jobs.json`.
+8. **Orchestrator dies mid-sweep.** Resolve the existing `session_id`, then relaunch with the same full `workspace_path`, that session id in `automl_settings`, and `resume=True`. In-flight jobs are recovered from `active_jobs.json`. Missing or ambiguous controller state is a blocker, not permission to start a new search.
 9. **Rec never reports a metric.** Check the model skill's metric-emission requirements and custom extractor guidance.
 10. **Parallel Bayesian arms.** Bayesian is inherently sequential. If you want parallelism, use `asha`. If you use multiple `AutoMLRunner` instances, give each its own `<SDK>(state_file=...)` (e.g., `BrevSDK(state_file=...)`, `KubernetesSDK(state_file=...)`) to avoid SQLite write races on the SDK's job store.
 11. **LLM brain returning random configs.** If every LLM recommendation looks random, the LLM endpoint is probably failing silently. Check the logs for "LLM call failed" warnings. Verify your API key and endpoint are correct. Common cause: using the wrong endpoint URL (see pitfall #2).

--- a/skills/applications/tao-run-automl/references/automl-examples.md
+++ b/skills/applications/tao-run-automl/references/automl-examples.md
@@ -61,6 +61,7 @@ User: confirmed
     "llm_endpoint": "https://inference-api.nvidia.com",
     "llm_model": "gcp/google/gemini-3.1-pro-preview",
     "llm_api_key": os.environ["AUTOML_LLM_API_KEY"],
+    "session_id": session_id,
     ...
 })]
 ```
@@ -90,6 +91,7 @@ User: confirmed
     "llm_endpoint": "https://inference-api.nvidia.com",
     "llm_model": "gcp/google/gemini-3.1-pro-preview",
     "llm_api_key": os.environ["AUTOML_LLM_API_KEY"],
+    "session_id": session_id,
     ...
 })]
 ```
@@ -100,7 +102,12 @@ User: confirmed
 Agent: Resuming. The runner will poll any jobs that were in flight when we stopped, report their results, then show a resume review before submitting any new recommendation jobs.
 [shows resume review with completed/failed/in-flight recs, remaining budget, metric state, image/platform/data checks, and ETA]
 User: confirmed
-[executes runner.run(..., workspace_path="./my_experiment", resume=True)]
+[executes runner.run(
+    ...,
+    workspace_path="./my_experiment/run_<timestamp>",
+    automl_settings={**automl_settings, "session_id": resolved_session_id},
+    resume=True,
+)]
 ```
 
 ### User: "Switch to ASHA with 30 trials and track in WandB"
@@ -110,7 +117,12 @@ Agent: Switching to ASHA — parallel + early-stopping. I’ll first check the m
 [shows launch review with ASHA rungs, max concurrent jobs, WandB project, search bounds, and estimated runtime]
 User: confirmed
 [executes runner.run(
-    automl_settings={"algorithm": "asha", "automl_max_epochs": 9, ...},
+    automl_settings={
+        "algorithm": "asha",
+        "automl_max_epochs": 9,
+        "session_id": session_id,
+        ...,
+    },
     wandb_config={"enabled": True, "project": "tao-hpo"},
 )]
 ```

--- a/skills/applications/tao-run-automl/references/automl-intent-algorithms.md
+++ b/skills/applications/tao-run-automl/references/automl-intent-algorithms.md
@@ -172,6 +172,7 @@ result = runner.run(
         "algorithm": "bayesian",
         "metric": metric,
         "automl_max_recommendations": 10,
+        "session_id": session_id,
     },
     automl_hyperparameters=None,  # use schema params marked automl_enabled=true
     custom_param_ranges=None,     # use schema ranges/options/defaults

--- a/skills/applications/tao-run-automl/references/automl-runner-configuration.md
+++ b/skills/applications/tao-run-automl/references/automl-runner-configuration.md
@@ -170,6 +170,7 @@ print("Best:", automl.get_best().specs)
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `algorithm` | str | **required** | `bayesian`, `hyperband`, `bohb`, `asha`, `bfbo`, `dehb`, `pbt`, `hyperband_es`, `llm`, `hybrid`, `autoresearch` |
+| `session_id` | str | **required by this skill** | Stable controller identity. Generate it once for a fresh run with `scripts/resolve_automl_session.py new`; on resume recover it from the full run workspace. Never rely on the wheel's random default. |
 | `metric` | str | `"loss"` | Metric name. The implicit rule for direction is "contains `'loss'` → minimize, else maximize". Override with `direction`. |
 | `direction` | `"minimize"` \| `"maximize"` | inferred | Explicit direction. Required only when it disagrees with the implicit rule. The runner transparently inverts reported values so callers always see their metric in its original scale. |
 | `automl_max_recommendations` | int | 20 | Max trials (bayesian, bfbo, llm) |

--- a/skills/applications/tao-run-automl/references/automl-runner-configuration.md
+++ b/skills/applications/tao-run-automl/references/automl-runner-configuration.md
@@ -62,6 +62,7 @@ result = runner.run(
         "algorithm": algorithm,
         "metric": metric,
         "automl_max_recommendations": max_recommendations,
+        "session_id": session_id,                     # explicit, generated once
     },
     workspace_path=f"./automl_workspace/{TIMESTAMP}",  # timestamped to avoid collisions
     # Platform-specific create_job kwargs go here as **platform_kwargs.
@@ -97,6 +98,7 @@ result = runner.run(
         "metric": metric,
         "direction": direction,                       # explicit when needed
         "automl_max_recommendations": max_recommendations,
+        "session_id": session_id,                     # explicit, generated/resolved once
     },
     automl_hyperparameters=automl_hyperparameters,    # from model skill / schema
     custom_param_ranges=custom_param_ranges,          # from model skill / user constraints

--- a/skills/applications/tao-run-automl/scripts/resolve_automl_session.py
+++ b/skills/applications/tao-run-automl/scripts/resolve_automl_session.py
@@ -17,7 +17,9 @@ import json
 import re
 import secrets
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 
 SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -94,6 +96,33 @@ def resolve_session_id(workspace: Path, requested: str | None = None) -> str:
         )
     _validate_controller(selected)
     return selected.stem
+
+
+def validate_session_settings(
+    automl_settings: Mapping[str, Any],
+    *,
+    resume: bool,
+    workspace: Path | None = None,
+) -> str:
+    """Fail before runner construction when session identity is not durable."""
+    if not isinstance(automl_settings, Mapping):
+        raise SessionResolutionError("automl_settings must be a mapping")
+    session_id = automl_settings.get("session_id")
+    if not isinstance(session_id, str) or not SESSION_ID_RE.fullmatch(session_id):
+        raise SessionResolutionError(
+            "automl_settings.session_id must be an explicit valid session id"
+        )
+    if resume:
+        if workspace is None:
+            raise SessionResolutionError(
+                "resume=True requires the full existing workspace path"
+            )
+        resolved = resolve_session_id(workspace, session_id)
+        if resolved != session_id:  # defensive: requested resolution must be exact
+            raise SessionResolutionError(
+                f"resolved session {resolved!r} does not match settings {session_id!r}"
+            )
+    return session_id
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/skills/applications/tao-run-automl/scripts/resolve_automl_session.py
+++ b/skills/applications/tao-run-automl/scripts/resolve_automl_session.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Create or recover the explicit session identity used by TAO AutoML.
+
+The AutoML wheel otherwise generates a new random identity on each invocation,
+which makes ``resume=True`` silently start a second controller in the same
+workspace. This helper is deliberately read-only: the runner persists the
+identity in ``.automl/controller/<session_id>.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import secrets
+import sys
+from pathlib import Path
+
+
+SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class SessionResolutionError(ValueError):
+    """Raised when an AutoML workspace cannot be resumed unambiguously."""
+
+
+def new_session_id() -> str:
+    """Return a wheel-compatible 12-character session identity."""
+
+    return secrets.token_hex(6)
+
+
+def _controller_files(workspace: Path) -> list[Path]:
+    controller_dir = workspace / ".automl" / "controller"
+    if not controller_dir.is_dir():
+        raise SessionResolutionError(
+            f"resume state is missing: {controller_dir} does not exist; "
+            "refuse to start a fresh search with resume=True"
+        )
+    return sorted(controller_dir.glob("*.json"))
+
+
+def _validate_controller(path: Path) -> None:
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SessionResolutionError(
+            f"controller state is unreadable: {path}: {exc}"
+        ) from exc
+    if not isinstance(state, list):
+        raise SessionResolutionError(
+            f"controller state has unexpected shape: {path} must contain a JSON list"
+        )
+
+
+def resolve_session_id(workspace: Path, requested: str | None = None) -> str:
+    """Resolve exactly one existing controller identity for a resumed run."""
+
+    workspace = workspace.expanduser().resolve()
+    files = _controller_files(workspace)
+
+    if requested is not None:
+        if not SESSION_ID_RE.fullmatch(requested):
+            raise SessionResolutionError(f"invalid session id: {requested!r}")
+        selected = workspace / ".automl" / "controller" / f"{requested}.json"
+        if selected not in files:
+            available = ", ".join(path.stem for path in files) or "none"
+            raise SessionResolutionError(
+                f"session {requested!r} has no controller state in {workspace}; "
+                f"available sessions: {available}"
+            )
+    else:
+        if not files:
+            raise SessionResolutionError(
+                f"resume state is missing: no controller JSON exists in "
+                f"{workspace / '.automl' / 'controller'}; refuse to start a fresh "
+                "search with resume=True"
+            )
+        if len(files) != 1:
+            available = ", ".join(path.stem for path in files)
+            raise SessionResolutionError(
+                f"resume state is ambiguous: found {len(files)} controller sessions "
+                f"in {workspace}: {available}; select the intended session explicitly "
+                "with --session-id after inspecting its state"
+            )
+        selected = files[0]
+
+    if not SESSION_ID_RE.fullmatch(selected.stem):
+        raise SessionResolutionError(
+            f"controller filename is not a valid session id: {selected.name}"
+        )
+    _validate_controller(selected)
+    return selected.stem
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("new", help="emit a new explicit session id")
+    resume = subparsers.add_parser(
+        "resolve", help="recover the session id from an existing run workspace"
+    )
+    resume.add_argument("--workspace", required=True, type=Path)
+    resume.add_argument(
+        "--session-id",
+        help="select an existing session when a previously broken workspace is ambiguous",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "new":
+            session_id = new_session_id()
+        else:
+            session_id = resolve_session_id(args.workspace, args.session_id)
+    except SessionResolutionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(session_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-automl/tests/test_resolve_automl_session.py
+++ b/skills/applications/tao-run-automl/tests/test_resolve_automl_session.py
@@ -64,6 +64,37 @@ def test_malformed_controller_state_is_rejected(tmp_path):
         MODULE.resolve_session_id(tmp_path)
 
 
+def test_runner_settings_without_explicit_session_fail_before_launch():
+    with pytest.raises(
+        MODULE.SessionResolutionError,
+        match="automl_settings.session_id",
+    ):
+        MODULE.validate_session_settings(
+            {"algorithm": "bayesian"},
+            resume=False,
+        )
+
+
+def test_resume_settings_must_bind_existing_controller(tmp_path):
+    _write_controller(tmp_path, "abc123def456")
+
+    with pytest.raises(MODULE.SessionResolutionError, match="has no controller state"):
+        MODULE.validate_session_settings(
+            {"algorithm": "bayesian", "session_id": "different123"},
+            resume=True,
+            workspace=tmp_path,
+        )
+
+    assert (
+        MODULE.validate_session_settings(
+            {"algorithm": "bayesian", "session_id": "abc123def456"},
+            resume=True,
+            workspace=tmp_path,
+        )
+        == "abc123def456"
+    )
+
+
 def test_cli_returns_nonzero_instead_of_silently_starting_fresh(tmp_path):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "resolve", "--workspace", str(tmp_path)],
@@ -92,6 +123,7 @@ def test_explicit_identity_resumes_real_automl_controller(tmp_path):
         "automl_max_recommendations": 1,
         "session_id": session_id,
     }
+    assert MODULE.validate_session_settings(settings, resume=False) == session_id
     fresh = tao_automl.AutoML(
         workspace=str(workspace),
         network="nv_tesseract_forecasting",
@@ -105,6 +137,14 @@ def test_explicit_identity_resumes_real_automl_controller(tmp_path):
     fresh.finish()
 
     assert MODULE.resolve_session_id(workspace) == session_id
+    assert (
+        MODULE.validate_session_settings(
+            settings,
+            resume=True,
+            workspace=workspace,
+        )
+        == session_id
+    )
     resumed = tao_automl.AutoML(
         workspace=str(workspace),
         network="nv_tesseract_forecasting",

--- a/skills/applications/tao-run-automl/tests/test_resolve_automl_session.py
+++ b/skills/applications/tao-run-automl/tests/test_resolve_automl_session.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "resolve_automl_session.py"
+SPEC = importlib.util.spec_from_file_location("resolve_automl_session", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _write_controller(workspace: Path, session_id: str, state=None) -> Path:
+    path = workspace / ".automl" / "controller" / f"{session_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps([] if state is None else state), encoding="utf-8")
+    return path
+
+
+def test_new_session_id_matches_wheel_default_shape():
+    first = MODULE.new_session_id()
+    second = MODULE.new_session_id()
+    assert first != second
+    assert len(first) == 12
+    assert MODULE.SESSION_ID_RE.fullmatch(first)
+
+
+def test_resolve_unique_controller(tmp_path):
+    _write_controller(tmp_path, "abc123def456", [{"id": 0, "status": "success"}])
+    assert MODULE.resolve_session_id(tmp_path) == "abc123def456"
+
+
+def test_missing_controller_state_fails_closed(tmp_path):
+    with pytest.raises(MODULE.SessionResolutionError, match="resume state is missing"):
+        MODULE.resolve_session_id(tmp_path)
+
+
+def test_ambiguous_controller_state_fails_closed(tmp_path):
+    _write_controller(tmp_path, "111111111111")
+    _write_controller(tmp_path, "222222222222")
+    with pytest.raises(MODULE.SessionResolutionError, match="resume state is ambiguous"):
+        MODULE.resolve_session_id(tmp_path)
+
+
+def test_explicit_session_resolves_legacy_ambiguous_workspace(tmp_path):
+    _write_controller(tmp_path, "111111111111")
+    _write_controller(tmp_path, "222222222222")
+    assert MODULE.resolve_session_id(tmp_path, "222222222222") == "222222222222"
+
+
+def test_malformed_controller_state_is_rejected(tmp_path):
+    path = _write_controller(tmp_path, "abc123def456")
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(MODULE.SessionResolutionError, match="unexpected shape"):
+        MODULE.resolve_session_id(tmp_path)
+
+
+def test_cli_returns_nonzero_instead_of_silently_starting_fresh(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "resolve", "--workspace", str(tmp_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "refuse to start a fresh search with resume=True" in result.stderr
+    assert result.stdout == ""
+
+
+def test_explicit_identity_resumes_real_automl_controller(tmp_path):
+    tao_automl = pytest.importorskip("tao_automl")
+    schema_path = (
+        Path(__file__).resolve().parents[3]
+        / "models/tao-finetune-nv-tesseract-forecasting/schemas/train.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    session_id = MODULE.new_session_id()
+    workspace = tmp_path / "run_resume"
+    settings = {
+        "algorithm": "bayesian",
+        "metric": "val_mse",
+        "direction": "minimize",
+        "automl_max_recommendations": 1,
+        "session_id": session_id,
+    }
+    fresh = tao_automl.AutoML(
+        workspace=str(workspace),
+        network="nv_tesseract_forecasting",
+        train_specs=schema["default"],
+        settings=settings,
+        action="train",
+        search_schema=schema,
+    )
+    rec = fresh.next_recommendation()[0]
+    fresh.report_result(rec.id, 0.5)
+    fresh.finish()
+
+    assert MODULE.resolve_session_id(workspace) == session_id
+    resumed = tao_automl.AutoML(
+        workspace=str(workspace),
+        network="nv_tesseract_forecasting",
+        train_specs=schema["default"],
+        settings={**settings, "automl_max_recommendations": 2},
+        action="train",
+        search_schema=schema,
+        resume=True,
+    )
+    assert resumed.get_status()["progress"]["completed"] == 1
+    assert [item.id for item in resumed.next_recommendation()] == [1]
+    assert [path.name for path in (workspace / ".automl/controller").glob("*.json")] == [
+        f"{session_id}.json"
+    ]


### PR DESCRIPTION
## Summary

- bind every fresh AutoML run to an explicit `session_id`
- resolve the existing controller identity before `resume=True`
- fail closed when resume state is missing or ambiguous
- enforce the explicit identity immediately before `runner.run`, not only in prose
- document the safe fresh/resume flow and add regression coverage

## Why this is a root-cause fix

The failure begins when the controller is constructed without a durable
identity: the wheel chooses a new random session and `resume=True` then has no
way to select the original state. The skill now creates or resolves exactly one
identity, seals it into `automl_settings`, and calls the bundled
`validate_session_settings` gate before runner execution. Resume validation
also proves that the requested controller file exists and is structurally
valid. This prevents the silent fresh-controller path rather than detecting a
duplicate search after launch.

I intentionally avoided selecting the first controller file, deriving identity
from directory order, or treating a missing controller as a fresh run. Those
shortcuts reproduce the ambiguity and silent-restart hazards in the bug.

## Reproduction on unmodified main

Baseline: `01e5ae02c7d17d7157dc59e4339a5c19ee4c07d9`

With the repository-pinned `nvidia-tao-automl 7.1.0`, a two-recommendation run used controller `ec3b5de6a36b`. Resuming the same workspace without `session_id` generated `88d76bbde48c`, logged `Loaded controller state: 0 recommendations, next_id=0`, proposed recommendation 0 again, and left two controller files.

## Validation

- `96 passed in 2.78s`
- focused review update: `10 passed in 1.24s`
- `scripts/validate-skills.sh --all` passed
- `git diff --check` passed
- installed-plugin AutoMLRunner + VirtualEnvSDK controller-resume integration passed:
  - fresh run completed recommendations 0 and 1
  - resumed process logged `Loaded controller state: 2 recommendations, next_id=2`
  - resumed run launched only recommendations 2 and 3
  - final progress was 4/4 with one controller file for the original session

### Workload scope

The integration used the repository-pinned AutoML package, the NV-Tesseract Forecasting skill schema/search space, a 500-row synthetic time-series CSV, and a deterministic CPU trial script submitted through `VirtualEnvSDK`. It validated controller identity, persisted recommendation history, separate-process resume, spec materialization, subprocess submission, and metric ingestion. It did **not** execute the real NV-Tesseract model or GPU training stack, so model-level end-to-end validation has not been performed.

### Residual upstream risk

This PR enforces the contract for the `tao-run-automl` skill. The currently
packaged `nvidia-tao-automl` wheel still permits callers outside this skill to
invoke `resume=True` without a matching `session_id` and silently start a new
controller. NVBug 6662913 tracks the corresponding wheel-side fail-loud change.
Until that lands, external wheel callers must apply the same explicit identity
gate; this PR does not claim otherwise.

Fixes NVBug 6662913 / TLT-5949.