### PR TITLE
[TAO-0000][Bugfix] NVBug 6662919: rename inference_hpo spec block to avoid AutoML action-scoped pruning

### DIFF
--- a/skills/models/tao-finetune-nv-tesseract-ad-diffusion/references/automl.md
+++ b/skills/models/tao-finetune-nv-tesseract-ad-diffusion/references/automl.md
@@ -46,12 +46,12 @@ VirtualEnvSDK with no container required:
 
 | Parameter | Spec key | Default | Search range | Effect |
 |---|---|---|---|---|
-| Diffusion samples | `inference.nsample` | `15` | `[5, 30]` | More samples → better MAE estimate, slower per trial |
+| Diffusion samples | `hpo.nsample` | `15` | `[5, 30]` | More samples → better MAE estimate, slower per trial |
 
 **`threshold_strategy`** (`scs` or `macs`) is fixed per AutoML run — run once
 per strategy and compare F1 to pick the winner.
 
-**Fixed:** `inference.model_path`, `inference.config_path` — set these in
+**Fixed:** `hpo.model_path`, `hpo.config_path` — set these in
 `spec_overrides`, not the search space.
 
 ### AutoML artifacts
@@ -182,7 +182,7 @@ def main():
 
     cfg = yaml.safe_load(Path(args.run_config).read_text())
     ds  = cfg["dataset"]
-    inf = cfg["inference"]
+    inf = cfg["hpo"]
     out = Path(cfg.get("train", {}).get("output_dir", "artifacts/inference_hpo"))
     out.mkdir(parents=True, exist_ok=True)
 
@@ -227,8 +227,8 @@ for strategy in ["scs", "macs"]:
         # spec_overrides MUST use dotted keys — see fine-tuning section for why.
         spec_overrides={
             "dataset.csv":                  "/path/to/labeled_data.csv",
-            "inference.threshold_strategy": strategy,
-            "inference.model_path":         None,   # None → pretrained HF weights; or path to fine-tuned .pth
+            "hpo.threshold_strategy": strategy,
+            "hpo.model_path":         None,   # None → pretrained HF weights; or path to fine-tuned .pth
             "train.output_dir":             f"automl_workspace/inference_hpo_{strategy}/trials",
         },
         workspace_path=f"automl_workspace/inference_hpo_{strategy}",
@@ -243,10 +243,10 @@ for strategy in ["scs", "macs"]:
     best = result["best"]
     results_by_strategy[strategy] = best
     # best["specs"] uses the same dotted keys as spec_overrides
-    print(f"{strategy:4s}  F1={best['metric_value']:.4f}  nsample={best['specs']['inference.nsample']}")
+    print(f"{strategy:4s}  F1={best['metric_value']:.4f}  nsample={best['specs']['hpo.nsample']}")
 
 winner = max(results_by_strategy, key=lambda s: results_by_strategy[s]["metric_value"])
-print(f"\nBest: strategy={winner}  nsample={results_by_strategy[winner]['specs']['inference.nsample']}")
+print(f"\nBest: strategy={winner}  nsample={results_by_strategy[winner]['specs']['hpo.nsample']}")
 ```
 
 **Timestamp / label columns:** drop them before passing to the inference function — the template above does this via `errors="ignore"`.

--- a/skills/models/tao-finetune-nv-tesseract-ad-diffusion/references/spec_template_inference_hpo.yaml
+++ b/skills/models/tao-finetune-nv-tesseract-ad-diffusion/references/spec_template_inference_hpo.yaml
@@ -2,7 +2,7 @@ dataset:
   csv: ""
   label_col: label
   eval_rows: 2000
-inference:
+hpo:
   nsample: 15
   threshold_strategy: scs
   model_path: ""

--- a/skills/models/tao-finetune-nv-tesseract-ad-diffusion/schemas/inference_hpo.schema.json
+++ b/skills/models/tao-finetune-nv-tesseract-ad-diffusion/schemas/inference_hpo.schema.json
@@ -1,14 +1,14 @@
 {
   "automl_default_parameters": [
-    "inference.nsample"
+    "hpo.nsample"
   ],
   "automl_disabled_parameters": [
     "dataset.csv",
     "dataset.label_col",
     "dataset.eval_rows",
-    "inference.threshold_strategy",
-    "inference.model_path",
-    "inference.config_path",
+    "hpo.threshold_strategy",
+    "hpo.model_path",
+    "hpo.config_path",
     "train.output_dir"
   ],
   "default": {
@@ -17,7 +17,7 @@
       "label_col": "label",
       "eval_rows": 2000
     },
-    "inference": {
+    "hpo": {
       "nsample": 15,
       "threshold_strategy": "scs",
       "model_path": "",
@@ -64,12 +64,12 @@
         }
       }
     },
-    "inference": {
-      "automl_default_parameters": ["inference.nsample"],
+    "hpo": {
+      "automl_default_parameters": ["hpo.nsample"],
       "automl_disabled_parameters": [
-        "inference.threshold_strategy",
-        "inference.model_path",
-        "inference.config_path"
+        "hpo.threshold_strategy",
+        "hpo.model_path",
+        "hpo.config_path"
       ],
       "automl_enabled": false,
       "description": "Inference hyperparameters to tune.",

--- a/skills/models/tao-finetune-nv-tesseract-forecasting/references/automl.md
+++ b/skills/models/tao-finetune-nv-tesseract-forecasting/references/automl.md
@@ -112,10 +112,10 @@ direct forecast quality.
 
 | Parameter | Spec key | Default | Search range |
 |---|---|---|---|
-| Context length | `inference.seq_len` | `512` | `[128, 256, 512]` ordered_int |
-| Cross-channel | `inference.use_cross_channel` | `false` | `[true, false]` categorical |
-| Attention heads | `inference.cross_channel_heads` | `8` | `[4, 8, 16]` ordered_int |
-| Head dropout | `inference.cross_channel_dropout` | `0.1` | `[0.0, 0.1, 0.2]` |
+| Context length | `hpo.seq_len` | `512` | `[128, 256, 512]` ordered_int |
+| Cross-channel | `hpo.use_cross_channel` | `false` | `[true, false]` categorical |
+| Attention heads | `hpo.cross_channel_heads` | `8` | `[4, 8, 16]` ordered_int |
+| Head dropout | `hpo.cross_channel_dropout` | `0.1` | `[0.0, 0.1, 0.2]` |
 
 **Trial script template (basic):**
 
@@ -138,22 +138,23 @@ def main():
 
     cfg = yaml.safe_load(Path(args.run_config).read_text())
     ds  = cfg["dataset"]
-    inf = cfg["inference"]
+    inf = cfg["hpo"]
     out = Path(cfg.get("train", {}).get("output_dir", "artifacts/inference_hpo"))
     out.mkdir(parents=True, exist_ok=True)
 
-    df = pd.read_csv(ds["csv"], parse_dates=[ds.get("timestamp_col", "timestamp")])
-    df = df.set_index(ds.get("timestamp_col", "timestamp"))
+    ts_col = ds.get("timestamp_col", "timestamp")
+    df = pd.read_csv(ds["csv"], parse_dates=[ts_col])
     target_cols = [c.strip() for c in ds["target_cols"].split(",")] if ds.get("target_cols") else None
 
     horizon = inf["forecast_horizon"]
     if horizon <= 0 or horizon >= len(df):
-        raise ValueError(f"inference.forecast_horizon must be in [1, {len(df) - 1}], got {horizon}")
+        raise ValueError(f"hpo.forecast_horizon must be in [1, {len(df) - 1}], got {horizon}")
     df_input  = df.iloc[:-horizon]
     df_actual = df.iloc[-horizon:]
 
     result = perform_forecasting(
         df=df_input,
+        timestamp_column=ts_col,
         forecast_horizon=horizon,
         seq_len=inf.get("seq_len", 512),
         ckpt=inf.get("ckpt") or None,
@@ -203,14 +204,14 @@ result = runner.run(
         "dataset.csv":                "/path/to/eval_data.csv",
         "dataset.timestamp_col":      "timestamp",
         "dataset.target_cols":        "target",
-        "inference.forecast_horizon": 72,
+        "hpo.forecast_horizon": 72,
         "train.output_dir":           "automl_workspace/basic_hpo/trials",
     },
     hyperparameters={
-        "inference.seq_len":               {"type": "ordered_int", "values": [128, 256, 512]},
-        "inference.use_cross_channel":     {"type": "categorical", "values": [True, False]},
-        "inference.cross_channel_heads":   {"type": "ordered_int", "values": [4, 8, 16]},
-        "inference.cross_channel_dropout": {"type": "uniform",     "min": 0.0, "max": 0.2},
+        "hpo.seq_len":               {"type": "ordered_int", "values": [128, 256, 512]},
+        "hpo.use_cross_channel":     {"type": "categorical", "values": [True, False]},
+        "hpo.cross_channel_heads":   {"type": "ordered_int", "values": [4, 8, 16]},
+        "hpo.cross_channel_dropout": {"type": "uniform",     "min": 0.0, "max": 0.2},
     },
     workspace_path="automl_workspace/basic_hpo",
     execution={
@@ -224,9 +225,9 @@ result = runner.run(
 
 best = result["best"]
 print(f"Best val_mse: {best['metric_value']}")
-print(f"Best params: seq_len={best['specs']['inference.seq_len']}  "
-      f"use_cross_channel={best['specs']['inference.use_cross_channel']}  "
-      f"cross_channel_heads={best['specs']['inference.cross_channel_heads']}")
+print(f"Best params: seq_len={best['specs']['hpo.seq_len']}  "
+      f"use_cross_channel={best['specs']['hpo.use_cross_channel']}  "
+      f"cross_channel_heads={best['specs']['hpo.cross_channel_heads']}")
 ```
 
 #### DARR mode (tune blending parameters)
@@ -236,9 +237,9 @@ how much weight the retrieval signal gets versus the model's direct forecast.
 
 | Parameter | Spec key | Default | Search range |
 |---|---|---|---|
-| Blend weight | `inference.alpha` | `0.01` | `[0.001, 0.5]` |
-| kNN count | `inference.k` | `64` | `[8, 16, 32, 64, 128]` ordered_int |
-| Temperature | `inference.temperature` | `0.05` | `[0.01, 0.5]` |
+| Blend weight | `hpo.alpha` | `0.01` | `[0.001, 0.5]` |
+| kNN count | `hpo.k` | `64` | `[8, 16, 32, 64, 128]` ordered_int |
+| Temperature | `hpo.temperature` | `0.05` | `[0.01, 0.5]` |
 
 **Trial script template (DARR):**
 
@@ -261,25 +262,25 @@ def main():
 
     cfg = yaml.safe_load(Path(args.run_config).read_text())
     ds  = cfg["dataset"]
-    inf = cfg["inference"]
+    inf = cfg["hpo"]
     out = Path(cfg.get("train", {}).get("output_dir", "artifacts/inference_hpo"))
     out.mkdir(parents=True, exist_ok=True)
 
-    df = pd.read_csv(ds["csv"], parse_dates=[ds.get("timestamp_col", "timestamp")])
-    df = df.set_index(ds.get("timestamp_col", "timestamp"))
+    ts_col = ds.get("timestamp_col", "timestamp")
+    df = pd.read_csv(ds["csv"], parse_dates=[ts_col])
     target_cols = [c.strip() for c in ds["target_cols"].split(",")] if ds.get("target_cols") else None
 
     horizon = inf["forecast_horizon"]
     if horizon <= 0 or horizon >= len(df):
-        raise ValueError(f"inference.forecast_horizon must be in [1, {len(df) - 1}], got {horizon}")
+        raise ValueError(f"hpo.forecast_horizon must be in [1, {len(df) - 1}], got {horizon}")
     df_input  = df.iloc[:-horizon]
     df_actual = df.iloc[-horizon:]
 
-    context_df = pd.read_csv(ds["context_csv"], parse_dates=[ds.get("timestamp_col", "timestamp")])
-    context_df = context_df.set_index(ds.get("timestamp_col", "timestamp"))
+    context_df = pd.read_csv(ds["context_csv"], parse_dates=[ts_col])
 
     result = perform_forecasting(
         df=df_input,
+        timestamp_column=ts_col,
         context_df=context_df,
         forecast_horizon=horizon,
         seq_len=inf.get("seq_len", 512),
@@ -332,15 +333,15 @@ result = runner.run(
         "dataset.context_csv":        "/path/to/context_history.csv",
         "dataset.timestamp_col":      "timestamp",
         "dataset.target_cols":        "target",
-        "inference.forecast_horizon": 72,
-        "inference.seq_len":          512,
-        "inference.use_cross_channel": False,
+        "hpo.forecast_horizon": 72,
+        "hpo.seq_len":          512,
+        "hpo.use_cross_channel": False,
         "train.output_dir":           "automl_workspace/darr_hpo/trials",
     },
     hyperparameters={
-        "inference.alpha":       {"type": "uniform",     "min": 0.001, "max": 0.5},
-        "inference.k":           {"type": "ordered_int", "values": [8, 16, 32, 64, 128]},
-        "inference.temperature": {"type": "uniform",     "min": 0.01,  "max": 0.5},
+        "hpo.alpha":       {"type": "uniform",     "min": 0.001, "max": 0.5},
+        "hpo.k":           {"type": "ordered_int", "values": [8, 16, 32, 64, 128]},
+        "hpo.temperature": {"type": "uniform",     "min": 0.01,  "max": 0.5},
     },
     workspace_path="automl_workspace/darr_hpo",
     execution={
@@ -354,6 +355,6 @@ result = runner.run(
 
 best = result["best"]
 print(f"Best val_mse: {best['metric_value']}")
-print(f"Best DARR params: alpha={best['specs']['inference.alpha']}  "
-      f"k={best['specs']['inference.k']}  temp={best['specs']['inference.temperature']}")
+print(f"Best DARR params: alpha={best['specs']['hpo.alpha']}  "
+      f"k={best['specs']['hpo.k']}  temp={best['specs']['hpo.temperature']}")
 ```

--- a/skills/models/tao-finetune-nv-tesseract-forecasting/references/spec_template_inference_hpo.yaml
+++ b/skills/models/tao-finetune-nv-tesseract-forecasting/references/spec_template_inference_hpo.yaml
@@ -4,7 +4,7 @@ dataset:
   timestamp_col: timestamp
   target_cols: ""
   label_horizon: 72   # how many future rows to hold back as ground truth
-inference:
+hpo:
   alpha: 0.01
   k: 64
   temperature: 0.05

--- a/skills/models/tao-finetune-nv-tesseract-forecasting/schemas/inference_hpo.schema.json
+++ b/skills/models/tao-finetune-nv-tesseract-forecasting/schemas/inference_hpo.schema.json
@@ -1,8 +1,8 @@
 {
   "automl_default_parameters": [
-    "inference.alpha",
-    "inference.k",
-    "inference.temperature"
+    "hpo.alpha",
+    "hpo.k",
+    "hpo.temperature"
   ],
   "automl_disabled_parameters": [
     "dataset.csv",
@@ -10,12 +10,12 @@
     "dataset.timestamp_col",
     "dataset.target_cols",
     "dataset.label_horizon",
-    "inference.forecast_horizon",
-    "inference.seq_len",
-    "inference.ckpt",
-    "inference.standardizer_pkl",
-    "inference.use_cross_channel",
-    "inference.context_stride",
+    "hpo.forecast_horizon",
+    "hpo.seq_len",
+    "hpo.ckpt",
+    "hpo.standardizer_pkl",
+    "hpo.use_cross_channel",
+    "hpo.context_stride",
     "train.output_dir"
   ],
   "default": {
@@ -26,7 +26,7 @@
       "target_cols": "",
       "label_horizon": 72
     },
-    "inference": {
+    "hpo": {
       "alpha": 0.01,
       "k": 64,
       "temperature": 0.05,
@@ -87,19 +87,19 @@
         }
       }
     },
-    "inference": {
+    "hpo": {
       "automl_default_parameters": [
-        "inference.alpha",
-        "inference.k",
-        "inference.temperature"
+        "hpo.alpha",
+        "hpo.k",
+        "hpo.temperature"
       ],
       "automl_disabled_parameters": [
-        "inference.forecast_horizon",
-        "inference.seq_len",
-        "inference.ckpt",
-        "inference.standardizer_pkl",
-        "inference.use_cross_channel",
-        "inference.context_stride"
+        "hpo.forecast_horizon",
+        "hpo.seq_len",
+        "hpo.ckpt",
+        "hpo.standardizer_pkl",
+        "hpo.use_cross_channel",
+        "hpo.context_stride"
       ],
       "automl_enabled": false,
       "description": "DARR inference hyperparameters.",


### PR DESCRIPTION
## Summary
- Fixes NVBug 6662919: both NV-Tesseract skills' `inference_hpo` action puts its tunable params under an `inference:` spec block, which collides with nvidia-tao-automl's reserved action-name exclusion list — the runner silently pruned every param and aborted with "No searchable parameters found" before any trial launched. Renamed the block to `hpo:` in both skills' schema, spec template, and trial-script docs.
- Fixes NVBug 6591509: the forecasting skill's basic/DARR trial-script templates called `df.set_index(timestamp_col)` then `perform_forecasting(df=df_input, ...)` without `timestamp_column=`, so every trial failed with `Timestamp column 'timestamp' not found in DataFrame`. Fixed both templates to keep timestamp as a column and pass `timestamp_column=` explicitly.

## Test plan
- [x] Verified against a real `nvidia-tao-automl==7.1.0` install (not the `7.2.0rc25` prerelease from the original bug report's repro — that prerelease isn't on public PyPI and no internal package index was reachable in the test sandbox; `7.1.0` is what this repo's `versions.yaml` actually pins) + cloned NV-Tesseract forecasting model: `Automl params enabled` went from `[]` (search-space exclusion) to `['hpo.alpha', 'hpo.k', 'hpo.temperature']`, and a real Bayesian recommendation launched and sampled values.
- [x] Confirmed the timestamp-column fix: trial run progressed past `df.set_index`/`perform_forecasting` into actual DARR inference (`Using DARR mode... alpha=0.329...`) with no `Timestamp column 'timestamp' not found` error.
- [ ] Full end-to-end trial success (real `metrics.json` written) not reached — blocked by an unrelated checkpoint/standardizer auto-download issue (missing `HF_TOKEN`/local checkpoint path in the test sandbox), out of scope for this fix.
- [x] JSON/YAML validity and schema/spec-template structural consistency checked for both skills (`properties` keys match spec-template top-level keys, `hpo` block present, no stale `inference.*` param names, every `automl_default_parameters` entry has `automl_enabled: true`).