### PR TITLE
[TAO-0000][Bugfix] Align VCN dataset validator with the shared OI dataloader

### DIFF
--- a/skills/models/tao-train-visual-changenet/references/data-formats.md
+++ b/skills/models/tao-train-visual-changenet/references/data-formats.md
@@ -17,6 +17,11 @@ The model needs two things from the dataset: a CSV file and an images directory.
 
 ## Classify CSV Format
 
+> The classify task shares its dataloader (`OIDataModule`) with the TAO
+> Optical Inspection network, so this CSV contract is identical to the one
+> documented in the `tao-train-optical-inspection` skill; keep the two in
+> sync when either changes.
+
 ```csv
 input_path,golden_path,label,object_name
 data/defect,data/golden,bridge,bridge_PCB+solder_00000

--- a/skills/models/tao-train-visual-changenet/scripts/validate_vcn_dataset.py
+++ b/skills/models/tao-train-visual-changenet/scripts/validate_vcn_dataset.py
@@ -57,7 +57,7 @@ def validate(
     csv_path: pathlib.Path,
     images_dir: pathlib.Path | None,
     mode: str = "train",
-    light: str = "SolderLight",
+    lights: list[str] | None = None,
     image_ext: str = ".jpg",
     batch_size: int | None = None,
     num_gpus: int = 1,
@@ -67,6 +67,8 @@ def validate(
     Uses stdlib csv so the script runs on bare hosts without pandas.
     """
     errors: list[str] = []
+    lights = list(lights) if lights else ["SolderLight"]
+    light = lights[0]  # representative suffix for message templates
 
     if not csv_path.is_file():
         return [f"CSV not found: {csv_path}"]
@@ -139,9 +141,10 @@ def validate(
                 if not obj:
                     missing.append((i, "<empty object_name>"))
                     continue
-                resolved = images_dir / raw / f"{obj}_{light}{image_ext}"
-                if not resolved.is_file():
-                    missing.append((i, f"{raw} -> {resolved}"))
+                for suffix in lights:
+                    resolved = images_dir / raw / f"{obj}_{suffix}{image_ext}"
+                    if not resolved.is_file():
+                        missing.append((i, f"{raw} -> {resolved}"))
             if missing:
                 sample = ", ".join(f"row {i}: {p}" for i, p in missing[:5])
                 errors.append(
@@ -149,6 +152,24 @@ def validate(
                     f"(expected <images_dir>/<{col}>/<object_name>_{light}{image_ext}); "
                     f"first: {sample}"
                 )
+
+    # 3.5 Label hygiene (all modes): the loader computes
+    #     int(label != 'PASS') without stripping or casefolding, so 'pass',
+    #     'Pass' or ' PASS ' silently become DEFECT rows.
+    for i, row in enumerate(rows):
+        raw_label = row.get("label") or ""
+        if raw_label and raw_label != raw_label.strip():
+            errors.append(
+                f"row {i}: label {raw_label!r} has surrounding whitespace; the "
+                "loader compares against exact 'PASS' and would silently score "
+                "this row as a defect"
+            )
+        elif raw_label.strip().casefold() == "pass" and raw_label.strip() != "PASS":
+            errors.append(
+                f"row {i}: invalid label {raw_label!r}; non-defective rows must "
+                "use exact case-sensitive 'PASS' (the loader computes "
+                "int(label != 'PASS'), so this row would silently become a defect)"
+            )
 
     # 4. Single-class training set -> ZeroDivisionError in the classify loader.
     if mode == "train":
@@ -222,8 +243,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Dataset role. 'train' additionally enforces a two-class label set.",
     )
     parser.add_argument(
-        "--light", default="SolderLight",
-        help="Lighting suffix for siamese resolution. Default: SolderLight.",
+        "--light", action="append", default=None,
+        help=(
+            "Lighting suffix for siamese resolution; repeat once per entry in "
+            "dataset.classify input_map (e.g. --light SolderLight --light "
+            "WhiteLight). Default: SolderLight."
+        ),
     )
     parser.add_argument(
         "--image-ext", default=".jpg",
@@ -248,7 +273,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     errors = validate(
         args.csv, args.images_dir, mode=args.mode,
-        light=args.light, image_ext=args.image_ext,
+        lights=args.light, image_ext=args.image_ext,
         batch_size=args.batch_size, num_gpus=args.num_gpus,
     )
     if errors:

--- a/skills/models/tao-train-visual-changenet/tests/test_validate_vcn_dataset.py
+++ b/skills/models/tao-train-visual-changenet/tests/test_validate_vcn_dataset.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the Visual ChangeNet dataset validator.
+
+Fixtures are generated in a temp directory at test time: the validator only
+checks file existence, so empty placeholder files stand in for images and no
+binaries need to live in the repository.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "scripts/validate_vcn_dataset.py"
+LIGHTS = ("SolderLight", "WhiteLight")
+
+
+class ValidateVcnDatasetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = pathlib.Path(self._tmp.name)
+        self.images_dir = self.root / "images"
+        for sample, obj in (("sample_001", "R821@1"), ("golden/boardBOT", "R821@1")):
+            directory = self.images_dir / sample
+            directory.mkdir(parents=True)
+            for light in LIGHTS:
+                (directory / f"{obj}_{light}.jpg").touch()
+
+    def _write_csv(self, *rows: str) -> pathlib.Path:
+        csv_path = self.root / "dataset.csv"
+        header = "input_path,golden_path,label,object_name"
+        csv_path.write_text("\n".join((header, *rows)) + "\n")
+        return csv_path
+
+    def _run(self, csv_path: pathlib.Path, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--csv",
+                str(csv_path),
+                "--images-dir",
+                str(self.images_dir),
+                *extra,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_multi_light_dataset_passes_with_repeated_light(self) -> None:
+        csv_path = self._write_csv(
+            "sample_001,golden/boardBOT,PASS,R821@1",
+            "sample_001,golden/boardBOT,missing,R821@1",
+        )
+        result = self._run(
+            csv_path, "--light", "SolderLight", "--light", "WhiteLight"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_missing_second_light_is_flagged(self) -> None:
+        for path in self.images_dir.rglob("*_WhiteLight.jpg"):
+            path.unlink()
+        csv_path = self._write_csv(
+            "sample_001,golden/boardBOT,PASS,R821@1",
+            "sample_001,golden/boardBOT,missing,R821@1",
+        )
+        result = self._run(
+            csv_path, "--light", "SolderLight", "--light", "WhiteLight"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("_WhiteLight.jpg", result.stderr)
+        single = self._run(csv_path, "--light", "SolderLight")
+        self.assertEqual(single.returncode, 0, single.stderr)
+
+    def test_lowercase_pass_label_is_flagged(self) -> None:
+        csv_path = self._write_csv(
+            "sample_001,golden/boardBOT,pass,R821@1",
+            "sample_001,golden/boardBOT,missing,R821@1",
+        )
+        result = self._run(csv_path, "--light", "SolderLight")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid label 'pass'", result.stderr)
+        self.assertIn("exact case-sensitive 'PASS'", result.stderr)
+
+    def test_label_whitespace_is_flagged(self) -> None:
+        csv_path = self._write_csv(
+            "sample_001,golden/boardBOT, PASS,R821@1",
+            "sample_001,golden/boardBOT,missing,R821@1",
+        )
+        result = self._run(csv_path, "--light", "SolderLight")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("surrounding whitespace", result.stderr)
+
+    def test_default_light_remains_solderlight(self) -> None:
+        csv_path = self._write_csv(
+            "sample_001,golden/boardBOT,PASS,R821@1",
+            "sample_001,golden/boardBOT,missing,R821@1",
+        )
+        result = self._run(csv_path)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes: https://nvbugspro.nvidia.com/bug/6568064 (same NVBug as #199 — shared dataset contract, two validators)

Follow-up to #199 (NVBug 6568064). Visual ChangeNet classify shares its dataloader (`OIDataModule`, `changenet=True`) with the optical-inspection network — verified in tao-pytorch: all five VCN classify scripts import `cv/optical_inspection/dataloader/pl_oi_data_module`. The two skills' validators had drifted; #199 ported the VCN-side guards into the OI validator, and this PR ports the OI-side guards back.

- `--light` is now repeatable, and on-disk image checks cover **every** declared lighting suffix (matching `dataset.classify` `input_map`); previously only one suffix was checked. Default behavior (single `SolderLight`) unchanged.
- Label hygiene: rows with surrounding whitespace or wrong-case `pass` are flagged. The loader computes `int(label != 'PASS')` without normalizing, so such rows silently become defects — the validator's help text advertised a "PASS-preserving label case" check that was never implemented.
- New regression tests (5) for the validator; fixtures are generated in a temp dir at test time, so no binary files are committed.
- `references/data-formats.md` now cross-references the shared contract with `tao-train-optical-inspection`.

## Validation
- `python3 -m unittest discover -s tests` → **5 passed** (multi-light pass/fail, lowercase-`pass` flagged, whitespace flagged, single-light default preserved).
- Loader semantics cross-checked against `nvidia_tao_pytorch/cv/optical_inspection/dataloader/oi_dataset.py` (`label != 'PASS'`, `<images_dir>/<path>/<object_name>_<light><ext>`).