### PR TITLE
fix: harden TAO workflow validation and Brev execution

### DIFF
--- a/scripts/check_tao_launch_preflight.py
+++ b/scripts/check_tao_launch_preflight.py
@@ -584,8 +584,23 @@ def check_gpu_resources(
         memory_gb = list(target_memory_gb)
         if target_count and len(memory_gb) == 1:
             memory_gb = memory_gb * target_count
+    elif target_count and not skip_access:
+        detected_memory = detect_local_gpu_memory_gb()
+        if len(detected_memory) < target_count:
+            print(
+                "GPU resource check failed: detected fewer GPUs than "
+                f"--target-gpu-count={target_count}"
+            )
+            return False
+        memory_gb = detected_memory[:target_count]
     elif target_count:
-        memory_gb = [0.0] * target_count
+        if min_memory_gb is not None or min_total_memory_gb is not None:
+            print(
+                "GPU memory requirements cannot be verified from --target-gpu-count alone; "
+                "provide --target-gpu-memory-gb or allow target access."
+            )
+            return False
+        memory_gb = [1.0] * target_count
     elif skip_access:
         print(
             "GPU resource requirement present but target GPU detection was skipped. "

--- a/scripts/tests/test_cosmos_skill_workflow.py
+++ b/scripts/tests/test_cosmos_skill_workflow.py
@@ -2018,7 +2018,7 @@ def test_arbitrary_task_uses_declared_metric_instead_of_dataset_name(tmp_path):
                 "items": [
                     {
                         "id": "item-1",
-                        "video": "clip.mp4",
+                        "video_id": "clip.mp4",
                         "conversations": [
                             {"from": "human", "value": "question"},
                             {"from": "gpt", "value": "safe"},
@@ -3128,3 +3128,128 @@ def test_rl_spec_preserves_top_level_and_dataloader_seed_contract() -> None:
     assert spec["train"]["train_policy"]["dataloader_seed"] == 42
     assert spec["train"]["train_policy"]["dataloader_num_workers"] == 0
     assert "dataloader_prefetch_factor" not in spec["train"]["train_policy"]
+
+
+def test_nvbug_comma_joined_lora_modules_are_normalized():
+    args = workflow.parse_args([
+        "resolve", "--model", "nvidia/Cosmos3-Nano",
+        "--lora-target-modules", "q_proj,k_proj",
+        "--lora-modules-to-save", "lm_head, embed_tokens",
+    ])
+    assert args.lora_target_modules == ["q_proj", "k_proj"]
+    assert args.lora_modules_to_save == ["lm_head", "embed_tokens"]
+
+
+def test_nvbug_conversion_command_has_nonroot_identity_env(tmp_path):
+    args = SimpleNamespace(
+        base_model_path_or_uri="nvidia/Cosmos3-Nano", base_model_revision="a" * 40,
+        vlm_architecture_model_path_or_uri="Qwen/Qwen3-VL-8B-Instruct",
+        vlm_architecture_model_revision="b" * 40, runtime_image="image",
+    )
+    joined = " ".join(checkpoint_preparation.command(args, tmp_path / "out", tmp_path / "cache"))
+    assert "USER=" in joined and "LOGNAME=" in joined
+    assert "HOME=/cache/tao-home" in joined
+    assert "TORCHINDUCTOR_CACHE_DIR=/cache/torchinductor" in joined
+
+
+def test_nvbug_task_aware_alias_media_key_fails_closed(tmp_path):
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "x.mp4").write_bytes(b"x")
+    annotation = tmp_path / "items.json"
+    annotation.write_text(json.dumps({
+        "metadata": {"task": "mcq", "metric": "accuracy"},
+        "items": [{"video": "x.mp4", "question": "Q", "answer": "A"}],
+    }))
+    with pytest.raises(common.WorkflowError, match="canonical video_id or image_id"):
+        common.inspect_dataset(dataset_family="auto", annotations=[str(annotation)], media_roots=[str(media)])
+
+
+def test_nvbug_framework_edge_dimensions_reach_environment(tmp_path):
+    args = args_for(tmp_path, dataset_family="task_aware_video_reasoning", model_name="nvidia/Cosmos3-Edge")
+    plan = workflow.build_plan(args)
+    assert plan["environment"]["TAO_VIDEO_FRAME_WIDTH"] == "1280"
+    assert plan["environment"]["TAO_VIDEO_FRAME_HEIGHT"] == "720"
+
+
+def test_nvbug_local_preflight_rejects_undecodable_media(monkeypatch, tmp_path):
+    args = args_for(tmp_path)
+    plan = workflow.build_plan(args)
+    def fail(path):
+        raise common.WorkflowError(f"cannot decode {path}")
+    monkeypatch.setattr(workflow, "decode_media", fail)
+    result = workflow.local_preflight(args, plan)
+    assert not result["ok"]
+    assert any("cannot decode" in error for error in result["errors"])
+
+
+def test_nvbug_framework_checkpoint_action_normalizes_hf_model_uri(tmp_path):
+    checkpoint, config, base_model = make_framework_dcp(tmp_path)
+    args = framework_action_args(checkpoint, config, base_model)
+    args.base_model_path_or_uri = "hf_model://nvidia/Cosmos3-Nano"
+    argv = framework_action.build_plan(args)["pre_action"]["argv"]
+    assert argv[argv.index("--base-model-path-or-uri") + 1] == "nvidia/Cosmos3-Nano"
+
+
+def test_nvbug_terminal_success_average_does_not_displace_weighted_event():
+    records = [
+        {"status": "RUNNING", "phase": "training_complete", "kpi": {
+            "train/avg_loss": .5, "train/loss_numerator": 5, "train/valid_label_count": 10}},
+        {"status": "RUNNING", "phase": "validation_complete", "kpi": {
+            "val/avg_loss": .4, "val/loss_numerator": 4, "val/valid_label_count": 10}},
+        {"status": "SUCCESS", "kpi": {"train/avg_loss": .5}},
+    ]
+    result = metric.summarize_records(records, require_complete=False)
+    assert result["average_training_loss"]["numerator"] == 5
+
+
+def test_nvbug_brev_and_video_clip_contracts_are_retry_safe():
+    brev = (ROOT / "skills" / "platform" / "tao-run-on-brev" / "SKILL.md").read_text()
+    assert "grep -qx ok" in brev
+    assert "docker inspect '$JOB_ID'" in brev
+    spec = yaml.safe_load((ROOT / "skills" / "models" / "tao-finetune-video-clip" / "references" / "spec_template_export.yaml").read_text())
+    assert spec["export"]["batch_size"] == -1
+
+
+def test_nvbug_framework_export_rejects_tensor_key_drift(tmp_path):
+    checkpoint, config, base_model = make_framework_dcp(tmp_path)
+    export = tmp_path / "exports" / "epoch_1"
+    write_framework_export(export, checkpoint, config, base_model)
+    (base_model / "model.safetensors.index.json").write_text(json.dumps({
+        "weight_map": {"base.layer.weight": "model.safetensors"}
+    }))
+    (export / "model.safetensors.index.json").write_text(json.dumps({
+        "weight_map": {"export.layer.weight": "model.safetensors"}
+    }))
+    manifest = json.loads((export / "export_manifest.json").read_text())
+    manifest["base_model_fingerprint"]["sha256"] = framework_action._base_model_fingerprint(base_model)
+    (export / "export_manifest.json").write_text(json.dumps(manifest))
+    with pytest.raises(common.WorkflowError, match="tensor key set differs"):
+        framework_action.verify_export(
+            checkpoint_path=str(checkpoint), config_file=str(config),
+            export_dir=str(export), base_model_path_or_uri=str(base_model),
+            base_model_revision="immutable-test-revision",
+        )
+
+
+def test_nvbug_render_docker_has_identity_and_idempotency_guard(tmp_path):
+    args = SimpleNamespace(
+        tao_job_id="job-123", results_dir=str(tmp_path),
+        container_results_dir="/results", container_mount=[f"{tmp_path}:/results"],
+    )
+    plan = {
+        "compute": {"platform": "docker", "nodes": 1},
+        "image": {"tag": "example.invalid/cosmos:immutable"},
+        "paths": {"results_dir": {"original": str(tmp_path)}},
+        "environment": {"TAO_JOB_ID": "job-123"},
+        "command": "python -m cosmos_framework.scripts.train --sft-toml=/spec.toml",
+    }
+    rendered = workflow.render_docker(args, plan)
+    assert "docker inspect job-123" in rendered
+    assert "HOME=" in rendered and "USER=" in rendered and "LOGNAME=" in rendered
+    assert "TORCHINDUCTOR_CACHE_DIR=" in rendered
+
+
+def test_nvbug_docker_gpu_count_is_not_hardcoded():
+    args = workflow.parse_args(["resolve", "--model", "nvidia/Cosmos3-Nano"])
+    assert args.gpus_per_node == 0

--- a/scripts/tests/test_cosmos_skill_workflow.py
+++ b/scripts/tests/test_cosmos_skill_workflow.py
@@ -54,6 +54,21 @@ framework_image_preflight = load_module(
 )
 
 
+def write_safetensors(path: Path, tensor_keys: list[str]) -> None:
+    offset = 0
+    header = {}
+    for key in tensor_keys:
+        header[key] = {
+            "dtype": "F32",
+            "shape": [1],
+            "data_offsets": [offset, offset + 4],
+        }
+        offset += 4
+    encoded = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    encoded += b" " * (-len(encoded) % 8)
+    path.write_bytes(len(encoded).to_bytes(8, "little") + encoded + bytes(offset))
+
+
 def make_model(tmp_path: Path, model_type: str = "qwen3_vl") -> Path:
     model = tmp_path / "model"
     model.mkdir(parents=True)
@@ -65,7 +80,7 @@ def make_model(tmp_path: Path, model_type: str = "qwen3_vl") -> Path:
             }
         )
     )
-    (model / "model.safetensors").write_bytes(b"weights")
+    write_safetensors(model / "model.safetensors", ["model.layer.weight"])
     (model / "tokenizer.json").write_text("{}")
     (model / "processor_config.json").write_text("{}")
     return model
@@ -661,7 +676,7 @@ def write_framework_export(
 ) -> None:
     output.mkdir(parents=True, exist_ok=True)
     (output / "config.json").write_text(json.dumps({"model_type": "qwen3_vl"}))
-    (output / "model.safetensors").write_bytes(b"exported-weights")
+    write_safetensors(output / "model.safetensors", ["model.layer.weight"])
     metadata = checkpoint / "model" / ".metadata"
     manifest = {
         "format": "cosmos-framework-vlm-dcp",
@@ -3203,12 +3218,10 @@ def test_nvbug_terminal_success_average_does_not_displace_weighted_event():
     assert result["average_training_loss"]["numerator"] == 5
 
 
-def test_nvbug_brev_and_video_clip_contracts_are_retry_safe():
+def test_nvbug_brev_contract_is_retry_safe():
     brev = (ROOT / "skills" / "platform" / "tao-run-on-brev" / "SKILL.md").read_text()
     assert "grep -qx ok" in brev
     assert "docker inspect '$JOB_ID'" in brev
-    spec = yaml.safe_load((ROOT / "skills" / "models" / "tao-finetune-video-clip" / "references" / "spec_template_export.yaml").read_text())
-    assert spec["export"]["batch_size"] == -1
 
 
 def test_nvbug_framework_export_rejects_tensor_key_drift(tmp_path):
@@ -3218,9 +3231,11 @@ def test_nvbug_framework_export_rejects_tensor_key_drift(tmp_path):
     (base_model / "model.safetensors.index.json").write_text(json.dumps({
         "weight_map": {"base.layer.weight": "model.safetensors"}
     }))
+    write_safetensors(base_model / "model.safetensors", ["base.layer.weight"])
     (export / "model.safetensors.index.json").write_text(json.dumps({
         "weight_map": {"export.layer.weight": "model.safetensors"}
     }))
+    write_safetensors(export / "model.safetensors", ["export.layer.weight"])
     manifest = json.loads((export / "export_manifest.json").read_text())
     manifest["base_model_fingerprint"]["sha256"] = framework_action._base_model_fingerprint(base_model)
     (export / "export_manifest.json").write_text(json.dumps(manifest))
@@ -3232,13 +3247,38 @@ def test_nvbug_framework_export_rejects_tensor_key_drift(tmp_path):
         )
 
 
+def test_nvbug_framework_export_rejects_single_file_tensor_key_drift(tmp_path):
+    checkpoint, config, base_model = make_framework_dcp(tmp_path)
+    export = tmp_path / "exports" / "epoch_1"
+    write_framework_export(export, checkpoint, config, base_model)
+    write_safetensors(export / "model.safetensors", ["wrong.layer.weight"])
+    manifest = json.loads((export / "export_manifest.json").read_text())
+    manifest["base_model_fingerprint"]["sha256"] = framework_action._base_model_fingerprint(
+        base_model
+    )
+    (export / "export_manifest.json").write_text(json.dumps(manifest))
+    with pytest.raises(common.WorkflowError, match="tensor key set differs"):
+        framework_action.verify_export(
+            checkpoint_path=str(checkpoint),
+            config_file=str(config),
+            export_dir=str(export),
+            base_model_path_or_uri=str(base_model),
+            base_model_revision="immutable-test-revision",
+        )
+
+
 def test_nvbug_render_docker_has_identity_and_idempotency_guard(tmp_path):
     args = SimpleNamespace(
         tao_job_id="job-123", results_dir=str(tmp_path),
         container_results_dir="/results", container_mount=[f"{tmp_path}:/results"],
     )
     plan = {
-        "compute": {"platform": "docker", "nodes": 1},
+        "compute": {
+            "platform": "docker",
+            "nodes": 1,
+            "gpus_per_node": 2,
+            "host_gpu_ids": ["2", "3"],
+        },
         "image": {"tag": "example.invalid/cosmos:immutable"},
         "paths": {"results_dir": {"original": str(tmp_path)}},
         "environment": {"TAO_JOB_ID": "job-123"},
@@ -3248,8 +3288,57 @@ def test_nvbug_render_docker_has_identity_and_idempotency_guard(tmp_path):
     assert "docker inspect job-123" in rendered
     assert "HOME=" in rendered and "USER=" in rendered and "LOGNAME=" in rendered
     assert "TORCHINDUCTOR_CACHE_DIR=" in rendered
+    assert "--gpus device=2,3" in rendered
 
 
 def test_nvbug_docker_gpu_count_is_not_hardcoded():
     args = workflow.parse_args(["resolve", "--model", "nvidia/Cosmos3-Nano"])
     assert args.gpus_per_node == 0
+
+
+def test_nvbug_docker_gpu_derivation_respects_cuda_visible_devices(
+    monkeypatch, tmp_path
+):
+    inventory = "\n".join(
+        [
+            "0, GPU-aaaa, 24576",
+            "1, GPU-bbbb, 24576",
+            "2, GPU-cccc, 8192",
+            "3, GPU-dddd, 49152",
+        ]
+    )
+
+    def fake_run(command, **kwargs):
+        assert command[:2] == ["nvidia-smi", "--query-gpu=index,uuid,memory.total"]
+        return subprocess.CompletedProcess(command, 0, stdout=inventory, stderr="")
+
+    monkeypatch.setattr(workflow.subprocess, "run", fake_run)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-bbbb,3")
+    args = args_for(tmp_path)
+    args.gpus_per_node = 0
+    plan = workflow.build_plan(args)
+    assert plan["compute"]["gpus_per_node"] == 2
+    assert plan["compute"]["host_gpu_ids"] == ["1", "3"]
+    assert "--gpus device=1,3" in plan["preflight"]["container_runtime"]
+
+
+def test_nvbug_docker_gpu_derivation_rejects_ineligible_visible_subset(
+    monkeypatch, tmp_path
+):
+    command = [
+        "nvidia-smi",
+        "--query-gpu=index,uuid,memory.total",
+        "--format=csv,noheader,nounits",
+    ]
+    monkeypatch.setattr(
+        workflow.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            command, 0, stdout="2, GPU-cccc, 8192\n", stderr=""
+        ),
+    )
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
+    args = args_for(tmp_path)
+    args.gpus_per_node = 0
+    with pytest.raises(common.WorkflowError, match="no CUDA-visible >=16 GiB"):
+        workflow.build_plan(args)

--- a/scripts/tests/test_launch_preflight.py
+++ b/scripts/tests/test_launch_preflight.py
@@ -70,6 +70,12 @@ def test_target_gpu_selection_excludes_unallocated_display_gpu(capsys):
     assert "indices=0,1,4" in capsys.readouterr().out
 
 
+def test_target_count_without_memory_uses_detected_hardware(monkeypatch, capsys):
+    monkeypatch.setattr(preflight, "detect_local_gpu_memory_gb", lambda: [80.0, 80.0])
+    assert preflight.check_gpu_resources(2, 40, None, 2, [], False)
+    assert "detected=0.0GiB" not in capsys.readouterr().out
+
+
 def test_target_gpu_selection_rejects_missing_index(capsys):
     ok, selected = preflight.filter_target_gpus([{"index": "0"}], ["0", "2"])
     assert not ok and selected == []

--- a/scripts/tests/test_platform_contract.py
+++ b/scripts/tests/test_platform_contract.py
@@ -80,6 +80,16 @@ def test_platform_wires_the_job_record(platform):
         f"{platform}/SKILL.md never calls `tao_job_record.py mark` to update state")
 
 
+def test_brev_submit_contract_is_idempotent():
+    """The normative Brev submit verb must guard against CLI command replay."""
+    text = _skill_text("tao-run-on-brev")
+    execution = text.split("## Execution — the four verbs", 1)[1].split(
+        "### `brev exec` argument form", 1
+    )[0]
+    assert "docker inspect '$JOB_ID'" in execution
+    assert "$JOB_ID already submitted" in execution
+
+
 # Shell-assigned paths that point into the bank, e.g.
 #   SETUP_SCRIPT="${TAO_SKILL_BANK_ROOT}/skills/platform/.../setup.sh"
 BANK_PATH_RE = re.compile(

--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_common.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_common.py
@@ -15,7 +15,9 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import statistics
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -27,6 +29,7 @@ MODEL_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 ACCURACY_TASKS = {"bcq", "binary", "mcq", "binary_choice", "multiple_choice"}
 DATASET_FAMILIES = {"auto", "video_conversation", "task_aware_video_reasoning"}
 MEDIA_FIELDS = ("video", "video_id", "image", "image_id", "media", "media_path")
+TAO_VL_MEDIA_FIELDS = ("video_id", "image_id")
 CLASSIFICATION_LABEL_SETS = (
     frozenset({"a", "b", "c", "d"}),
     frozenset({"yes", "no"}),
@@ -222,6 +225,27 @@ def _record_media(record: Mapping[str, Any]) -> list[str]:
     return values
 
 
+def decode_media(path: Path) -> None:
+    """Decode-probe one frame so corrupt video inputs fail before launch."""
+    if path.suffix.casefold() not in {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v"}:
+        return
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        raise WorkflowError(
+            "media decode validation requires ffprobe on the inspection host; "
+            f"cannot validate {path}"
+        )
+    completed = subprocess.run(
+        [ffprobe, "-v", "error", "-select_streams", "v:0", "-read_intervals", "%+#1",
+         "-show_entries", "frame=media_type", "-of", "csv=p=0", str(path)],
+        text=True, capture_output=True, check=False,
+    )
+    if completed.returncode or "video" not in completed.stdout.split():
+        detail = completed.stderr.strip().splitlines()
+        reason = detail[-1] if detail else "no decodable video frame"
+        raise WorkflowError(f"media decode validation failed for {path}: {reason}")
+
+
 def _record_key(record: Mapping[str, Any]) -> str:
     identity = {
         "id": record.get("id") or record.get("sample_id") or record.get("video_id"),
@@ -361,8 +385,17 @@ def inspect_dataset(
                     schema_errors.append(f"{annotation_path}:{index}: task-aware record has no task")
                 if requested_tasks and task not in requested_tasks:
                     continue
-                if not _record_media(record):
-                    schema_errors.append(f"{annotation_path}:{index}: task-aware record has no media field")
+                canonical_media = [
+                    field for field in TAO_VL_MEDIA_FIELDS
+                    if isinstance(record.get(field), str) and record.get(field)
+                ]
+                if len(canonical_media) != 1:
+                    aliases = [field for field in MEDIA_FIELDS if record.get(field)]
+                    schema_errors.append(
+                        f"{annotation_path}:{index}: task-aware tao-vl-reason-v1.0 "
+                        "record requires exactly one canonical video_id or image_id; "
+                        f"found {aliases or 'none'}"
+                    )
                 conversations = record.get("conversations") or record.get("messages")
                 has_conversation_target = isinstance(conversations, list) and len(conversations) >= 2
                 has_question_answer = (

--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -32,6 +32,7 @@ import yaml
 from cosmos_common import (
     WorkflowError,
     assert_no_overlap,
+    decode_media,
     dataset_parity,
     inspect_dataset,
     inspect_model,
@@ -1945,6 +1946,7 @@ def _env(
     val_media: Sequence[str],
     rl_video_runtime: Mapping[str, Any] | None = None,
     framework_video_runtime: Mapping[str, Any] | None = None,
+    model_profile: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
     tao_job_id = args.tao_job_id or args.experiment_id
     status_path = str(Path(args.container_results_dir) / tao_job_id / "status.json")
@@ -1990,6 +1992,10 @@ def _env(
                     "baked container path below /tao-patches-framework-*"
                 )
             common["PYTHONPATH"] = str(overlay)
+        resolved_profile = model_profile or {
+            "frame_width": args.video_resized_width or args.video_frame_width or 1280,
+            "frame_height": args.video_resized_height or args.video_frame_height or 720,
+        }
         common.update(
             {
                 "PYTHONNOUSERSITE": "1",
@@ -2010,6 +2016,8 @@ def _env(
                 "TAO_VIDEO_VAL_MEDIA": val_media[0],
                 "TAO_VIDEO_VAL_MEDIA_ROOTS": json.dumps(framework_val_media),
                 "TAO_VIDEO_NUM_FRAMES": str(args.frames),
+                "TAO_VIDEO_FRAME_WIDTH": str(resolved_profile["frame_width"]),
+                "TAO_VIDEO_FRAME_HEIGHT": str(resolved_profile["frame_height"]),
                 "TAO_VIDEO_SYSTEM_PROMPT": args.system_prompt,
                 "TAO_VIDEO_CACHE_SIZE": str(
                     framework_video_runtime["video_cache_size"]
@@ -3531,6 +3539,30 @@ def build_plan(
         raise WorkflowError(
             "base_model_path_or_uri is required for every Cosmos training request"
         )
+    if args.gpus_per_node <= 0:
+        if args.platform != "docker":
+            raise WorkflowError(
+                "--gpus-per-node is required when the target platform is not docker"
+            )
+        detected = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if detected.returncode:
+            raise WorkflowError(
+                "could not derive --gpus-per-node from the Docker host; specify it explicitly"
+            )
+        eligible = [
+            line for line in detected.stdout.splitlines()
+            if line.strip().isdigit() and int(line.strip()) >= 16 * 1024
+        ]
+        if not eligible:
+            raise WorkflowError(
+                "no eligible >=16 GiB training GPU was detected; specify --gpus-per-node explicitly"
+            )
+        args.gpus_per_node = len(eligible)
     try:
         runtime_model_hint = resolve_model_name(args.model, args.base_model_path_or_uri)
     except WorkflowError:
@@ -3892,6 +3924,7 @@ def build_plan(
         val_media_container,
         rl_video_runtime,
         framework_video_runtime,
+        model_profile,
     )
     command = _command(args, backend)
     if decoder_artifact["enabled"]:
@@ -4456,11 +4489,64 @@ def load_plan_artifact(
     args.plan_artifact = str(path)
     args.render_output = getattr(current_args, "render_output", "")
     args.tao_job_id = str(getattr(current_args, "tao_job_id", "") or "")
-    if args.verb == "render-slurm" and not args.tao_job_id:
+    if args.verb in {"render-slurm", "render-docker"} and not args.tao_job_id:
         raise WorkflowError(
-            "render-slurm requires --tao-job-id from a newly opened job record"
+            f"{args.verb} requires --tao-job-id from a newly opened job record"
         )
     return args, plan
+
+
+def render_docker(args: argparse.Namespace, plan: Mapping[str, Any]) -> str:
+    """Render the reviewed single-node Docker submit command without launching it."""
+    if plan.get("compute", {}).get("platform") != "docker":
+        raise WorkflowError("render-docker requires a Docker plan")
+    if int(plan.get("compute", {}).get("nodes", 0)) != 1:
+        raise WorkflowError("render-docker supports only single-node plans")
+    if not args.tao_job_id:
+        raise WorkflowError("render-docker requires --tao-job-id")
+    image = str(plan.get("image", {}).get("tag") or "")
+    if not image:
+        raise WorkflowError("Docker plan has no resolved image")
+    results_host = str(plan.get("paths", {}).get("results_dir", {}).get("original") or args.results_dir)
+    home = f"{args.container_results_dir.rstrip('/')}/.tao-runtime/home"
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -Eeuo pipefail",
+        'HOST_UID="$(id -u)"',
+        'HOST_GID="$(id -g)"',
+        '[ "$HOST_UID" -ne 0 ] || { echo "Refusing writable Docker launch as UID 0" >&2; exit 1; }',
+        'HOST_USER_NAME="$(id -un)"',
+        'HOST_IDENTITY_ARGS=(--user "$HOST_UID:$HOST_GID")',
+        'for group_id in $(id -G); do [ "$group_id" = "$HOST_GID" ] || HOST_IDENTITY_ARGS+=(--group-add "$group_id"); done',
+        f"mkdir -p {shlex.quote(results_host + '/.tao-runtime/home/.cache/huggingface')} "
+        f"{shlex.quote(results_host + '/.tao-runtime/home/.cache/torchinductor')}",
+        f"docker inspect {shlex.quote(args.tao_job_id)} >/dev/null 2>&1 && "
+        f"{{ echo {shlex.quote(args.tao_job_id + ' already submitted')}; exit 0; }}",
+    ]
+    command = [
+        "docker", "run", "-d", "--name", args.tao_job_id,
+        "--label", f"tao-job={args.tao_job_id}", "--gpus", "all", "--ipc=host",
+        "--shm-size=32g", '"${HOST_IDENTITY_ARGS[@]}"',
+    ]
+    for mount in args.container_mount:
+        command.extend(["-v", mount])
+    identity_env = {
+        "HOME": home,
+        "USER": '"$HOST_USER_NAME"',
+        "LOGNAME": '"$HOST_USER_NAME"',
+        "XDG_CACHE_HOME": f"{home}/.cache",
+        "HF_HOME": f"{home}/.cache/huggingface",
+        "TORCHINDUCTOR_CACHE_DIR": f"{home}/.cache/torchinductor",
+    }
+    for name, value in {**dict(plan.get("environment", {})), **identity_env}.items():
+        command.extend(["-e", f"{name}={value}"])
+    for name in ("HF_TOKEN", "NGC_KEY"):
+        command.extend(["-e", name])
+    command.extend([image, "bash", "-lc", str(plan.get("command") or "")])
+    rendered = shlex.join(command).replace("'\"${HOST_IDENTITY_ARGS[@]}\"'", '"${HOST_IDENTITY_ARGS[@]}"')
+    rendered = rendered.replace("'\"$HOST_USER_NAME\"'", '"$HOST_USER_NAME"')
+    lines.append(rendered)
+    return "\n".join(lines) + "\n"
 
 
 def _retry_identity(value: str, kind: str) -> dict[str, object]:
@@ -5099,6 +5185,13 @@ def local_preflight(
     env = os.environ if env is None else env
     errors: list[str] = []
     warnings: list[str] = []
+    if plan.get("input_frame", {}).get("kind") != "slurm_remote":
+        for split in ("train", "validation"):
+            for media in plan.get("datasets", {}).get(split, {}).get("media_manifest", []):
+                try:
+                    decode_media(Path(media["path"]))
+                except WorkflowError as exc:
+                    errors.append(str(exc))
     decoder_artifact = plan["decoder_artifact"]
     if decoder_artifact["required"] and not decoder_artifact["enabled"]:
         errors.append(
@@ -5670,7 +5763,7 @@ def add_arguments(parser: argparse.ArgumentParser, *, require_inputs: bool) -> N
     parser.add_argument("--container-checkpoint-dir", default="/results/checkpoints")
     parser.add_argument("--container-cache-dir", default="/cache")
     parser.add_argument("--nodes", type=int, default=1)
-    parser.add_argument("--gpus-per-node", type=int, default=8)
+    parser.add_argument("--gpus-per-node", type=int, default=0)
     parser.add_argument("--cpus-per-task", type=int, default=64)
     parser.add_argument("--gpu-architecture", default="")
     parser.add_argument("--slurm-user", default="")
@@ -5715,7 +5808,7 @@ def add_arguments(parser: argparse.ArgumentParser, *, require_inputs: bool) -> N
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     subs = parser.add_subparsers(dest="verb", required=True)
-    for verb in ("resolve", "plan", "preflight", "materialize", "render-slurm"):
+    for verb in ("resolve", "plan", "preflight", "materialize", "render-slurm", "render-docker"):
         child = subs.add_parser(verb)
         add_arguments(child, require_inputs=verb != "resolve")
     child = subs.add_parser("validate-metadata")
@@ -5750,6 +5843,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     child.add_argument("--slurm-node-inventory", type=Path, required=True)
     child.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
+    for name in ("lora_target_modules", "lora_modules_to_save"):
+        if hasattr(args, name):
+            values = []
+            for raw in getattr(args, name):
+                values.extend(part.strip() for part in raw.split(",") if part.strip())
+            setattr(args, name, values)
     if getattr(args, "experiment_id", None) is None:
         args.experiment_id = ""
     if (
@@ -5887,6 +5986,19 @@ def main(argv: list[str] | None = None) -> int:
                         "sha256": sha256_file(rendered),
                         "approved_plan": plan.get("plan_artifact"),
                         "node_exclusions": plan.get("slurm_node_exclusions", {}),
+                    }
+                else:
+                    result = script
+            elif args.verb == "render-docker":
+                verify_materialized_spec(args, plan)
+                script = render_docker(args, plan)
+                if args.render_output:
+                    rendered = _atomic_write_text(Path(args.render_output), script)
+                    result = {
+                        "ok": True,
+                        "output": str(rendered),
+                        "sha256": sha256_file(rendered),
+                        "approved_plan": plan.get("plan_artifact"),
                     }
                 else:
                     result = script

--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import copy
 import hashlib
 import json
@@ -23,6 +24,7 @@ import urllib.parse
 import urllib.request
 import uuid
 from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -3178,7 +3180,16 @@ def _preflight_contract(
         )
     else:
         allocation = path_checks
-        container = f"docker run --rm --gpus all {shlex.quote(plan_image['tag'])} bash -lc {shlex.quote(container_check)}"
+        docker_gpu_ids = list(getattr(args, "docker_gpu_ids", []))
+        gpu_request = (
+            f"device={','.join(docker_gpu_ids)}"
+            if docker_gpu_ids
+            else str(args.gpus_per_node)
+        )
+        container = (
+            f"docker run --rm --gpus {shlex.quote(gpu_request)} "
+            f"{shlex.quote(plan_image['tag'])} bash -lc {shlex.quote(container_check)}"
+        )
     return {
         "submission_host": host,
         "target_compute_node": allocation,
@@ -3523,6 +3534,81 @@ def _slurm_node_exclusion_contract(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def _docker_visible_gpu_inventory(
+    cuda_visibility: str | None,
+) -> list[dict[str, str | int]]:
+    """Return physical Docker GPUs allowed by the CUDA visibility contract."""
+    detected = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=index,uuid,memory.total",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if detected.returncode:
+        raise WorkflowError(
+            "could not inventory Docker host GPUs with nvidia-smi; "
+            "correct host access before resolving GPU resources"
+        )
+    inventory: list[dict[str, str | int]] = []
+    for row in csv.reader(detected.stdout.splitlines()):
+        if len(row) != 3:
+            raise WorkflowError("nvidia-smi returned malformed Docker GPU inventory")
+        index, gpu_uuid, memory = (value.strip() for value in row)
+        try:
+            memory_mib = int(memory)
+        except ValueError as exc:
+            raise WorkflowError(
+                f"nvidia-smi returned invalid GPU memory for index {index!r}: {memory!r}"
+            ) from exc
+        if not index or not gpu_uuid:
+            raise WorkflowError("nvidia-smi returned incomplete Docker GPU inventory")
+        inventory.append(
+            {"index": index, "uuid": gpu_uuid, "memory_mib": memory_mib}
+        )
+    if not inventory:
+        raise WorkflowError("nvidia-smi found no Docker host GPUs")
+    if cuda_visibility is None:
+        return inventory
+
+    raw = cuda_visibility.strip()
+    if not raw or raw == "-1":
+        raise WorkflowError("CUDA_VISIBLE_DEVICES exposes no Docker training GPUs")
+    tokens = [token.strip() for token in raw.split(",")]
+    if any(not token for token in tokens):
+        raise WorkflowError("CUDA_VISIBLE_DEVICES contains an empty device token")
+    by_index = {str(gpu["index"]): gpu for gpu in inventory}
+    visible: list[dict[str, str | int]] = []
+    selected_indices: set[str] = set()
+    for token in tokens:
+        match = by_index.get(token) if token.isdigit() else None
+        if match is None and token.upper().startswith("GPU-"):
+            matches = [
+                gpu
+                for gpu in inventory
+                if str(gpu["uuid"]).upper().startswith(token.upper())
+            ]
+            if len(matches) == 1:
+                match = matches[0]
+        if match is None:
+            raise WorkflowError(
+                "CUDA_VISIBLE_DEVICES cannot be resolved against Docker host "
+                f"inventory: token={token!r}"
+            )
+        index = str(match["index"])
+        if index in selected_indices:
+            raise WorkflowError(
+                "CUDA_VISIBLE_DEVICES selects the same Docker host GPU more than "
+                f"once: index={index}"
+            )
+        selected_indices.add(index)
+        visible.append(match)
+    return visible
+
+
 def build_plan(
     args: argparse.Namespace,
     *,
@@ -3539,30 +3625,33 @@ def build_plan(
         raise WorkflowError(
             "base_model_path_or_uri is required for every Cosmos training request"
         )
-    if args.gpus_per_node <= 0:
+    docker_gpu_ids: list[str] = []
+    cuda_visibility = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if args.platform == "docker" and (
+        args.gpus_per_node <= 0 or cuda_visibility is not None
+    ):
+        visible_gpus = _docker_visible_gpu_inventory(cuda_visibility)
+        eligible = [gpu for gpu in visible_gpus if gpu["memory_mib"] >= 16 * 1024]
+        requested = args.gpus_per_node if args.gpus_per_node > 0 else len(eligible)
+        if len(eligible) < requested:
+            raise WorkflowError(
+                "Docker GPU selection has fewer CUDA-visible >=16 GiB devices "
+                f"than requested: requested={requested}, eligible={len(eligible)}"
+            )
+        selected = eligible[:requested]
+        if not selected:
+            raise WorkflowError(
+                "no CUDA-visible >=16 GiB training GPU was detected; "
+                "specify --gpus-per-node explicitly only after correcting GPU visibility"
+            )
+        args.gpus_per_node = len(selected)
+        docker_gpu_ids = [str(gpu["index"]) for gpu in selected]
+    elif args.gpus_per_node <= 0:
         if args.platform != "docker":
             raise WorkflowError(
                 "--gpus-per-node is required when the target platform is not docker"
             )
-        detected = subprocess.run(
-            ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        if detected.returncode:
-            raise WorkflowError(
-                "could not derive --gpus-per-node from the Docker host; specify it explicitly"
-            )
-        eligible = [
-            line for line in detected.stdout.splitlines()
-            if line.strip().isdigit() and int(line.strip()) >= 16 * 1024
-        ]
-        if not eligible:
-            raise WorkflowError(
-                "no eligible >=16 GiB training GPU was detected; specify --gpus-per-node explicitly"
-            )
-        args.gpus_per_node = len(eligible)
+    args.docker_gpu_ids = docker_gpu_ids
     try:
         runtime_model_hint = resolve_model_name(args.model, args.base_model_path_or_uri)
     except WorkflowError:
@@ -4039,6 +4128,7 @@ def build_plan(
             "gpus_per_node": args.gpus_per_node,
             "total_gpus": total_gpus,
             "cpus_per_task": args.cpus_per_task,
+            "host_gpu_ids": docker_gpu_ids,
         },
         "slurm_node_exclusions": node_exclusions,
         "cache_prewarm": {
@@ -4523,9 +4613,22 @@ def render_docker(args: argparse.Namespace, plan: Mapping[str, Any]) -> str:
         f"docker inspect {shlex.quote(args.tao_job_id)} >/dev/null 2>&1 && "
         f"{{ echo {shlex.quote(args.tao_job_id + ' already submitted')}; exit 0; }}",
     ]
+    compute = plan.get("compute", {})
+    host_gpu_ids = compute.get("host_gpu_ids", [])
+    if not isinstance(host_gpu_ids, list) or not all(
+        isinstance(value, str) and value for value in host_gpu_ids
+    ):
+        raise WorkflowError("Docker plan has invalid compute.host_gpu_ids")
+    gpu_request = (
+        f"device={','.join(host_gpu_ids)}"
+        if host_gpu_ids
+        else str(int(compute.get("gpus_per_node", 0)))
+    )
+    if gpu_request == "0":
+        raise WorkflowError("Docker plan has no resolved GPU allocation")
     command = [
         "docker", "run", "-d", "--name", args.tao_job_id,
-        "--label", f"tao-job={args.tao_job_id}", "--gpus", "all", "--ipc=host",
+        "--label", f"tao-job={args.tao_job_id}", "--gpus", gpu_request, "--ipc=host",
         "--shm-size=32g", '"${HOST_IDENTITY_ARGS[@]}"',
     ]
     for mount in args.container_mount:
@@ -5186,12 +5289,21 @@ def local_preflight(
     errors: list[str] = []
     warnings: list[str] = []
     if plan.get("input_frame", {}).get("kind") != "slurm_remote":
-        for split in ("train", "validation"):
-            for media in plan.get("datasets", {}).get(split, {}).get("media_manifest", []):
-                try:
-                    decode_media(Path(media["path"]))
-                except WorkflowError as exc:
-                    errors.append(str(exc))
+        media_paths = [
+            Path(media["path"])
+            for split in ("train", "validation")
+            for media in plan.get("datasets", {}).get(split, {}).get(
+                "media_manifest", []
+            )
+        ]
+        if media_paths:
+            with ThreadPoolExecutor(max_workers=min(8, len(media_paths))) as executor:
+                futures = [executor.submit(decode_media, path) for path in media_paths]
+                for future in futures:
+                    try:
+                        future.result()
+                    except WorkflowError as exc:
+                        errors.append(str(exc))
     decoder_artifact = plan["decoder_artifact"]
     if decoder_artifact["required"] and not decoder_artifact["enabled"]:
         errors.append(

--- a/skills/models/tao-finetune-cosmos-reason/scripts/extract_cosmos_metrics.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/extract_cosmos_metrics.py
@@ -176,7 +176,10 @@ def summarize_records(records: list[dict[str, Any]], evaluation: Mapping[str, An
         if phase in {"checkpoint_saved", "checkpoint_complete", "checkpoint_submitted"} or checkpoint_path:
             checkpoints.append({"path": checkpoint_path, "phase": phase, "epoch": values.get("epoch", record.get("epoch"))})
         # Step/heartbeat train loss is intentionally never treated as complete-run average.
-        if "train/avg_loss" in values or ("train/loss_numerator" in values and "train/valid_label_count" in values):
+        if (
+            "train/loss_numerator" in values
+            and "train/valid_label_count" in values
+        ):
             train_events.append(_weighted_event(record, "train"))
         # Only a validation-complete event is authoritative.
         if phase == "validation_complete" and ("val/avg_loss" in values or "val/loss_numerator" in values):

--- a/skills/models/tao-finetune-cosmos-reason/scripts/framework_checkpoint_action.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/framework_checkpoint_action.py
@@ -92,15 +92,84 @@ def _normalized_source(value: str) -> str:
     return str(candidate.resolve()) if candidate.exists() else value
 
 
-def _indexed_tensor_keys(root: Path) -> set[str] | None:
+def _safetensors_file_tensor_keys(path: Path) -> set[str]:
+    """Read tensor names from a safetensors header without loading tensor data."""
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as stream:
+            encoded_length = stream.read(8)
+            if len(encoded_length) != 8:
+                raise WorkflowError(f"safetensors file has no complete header: {path}")
+            header_length = int.from_bytes(encoded_length, "little", signed=False)
+            if header_length <= 0 or header_length > min(100 * 1024 * 1024, size - 8):
+                raise WorkflowError(
+                    f"safetensors file has an invalid header length: {path}"
+                )
+            encoded_header = stream.read(header_length)
+    except OSError as exc:
+        raise WorkflowError(f"cannot read safetensors header: {path}: {exc}") from exc
+    try:
+        header = json.loads(encoded_header.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise WorkflowError(f"invalid safetensors header JSON: {path}: {exc}") from exc
+    if not isinstance(header, dict):
+        raise WorkflowError(f"safetensors header must be a JSON object: {path}")
+    tensor_entries = {
+        name: value for name, value in header.items() if name != "__metadata__"
+    }
+    if not tensor_entries or not all(
+        isinstance(name, str) and name and isinstance(value, dict)
+        for name, value in tensor_entries.items()
+    ):
+        raise WorkflowError(f"safetensors header has no valid tensor entries: {path}")
+    return set(tensor_entries)
+
+
+def _safetensors_tensor_keys(root: Path) -> set[str] | None:
+    """Return verified tensor keys for indexed or single-file safetensors."""
     index = root / "model.safetensors.index.json"
-    if not index.is_file():
+    expected_keys: set[str] | None = None
+    if index.is_file():
+        payload = _read_json(index, "safetensors index")
+        weight_map = payload.get("weight_map")
+        if not isinstance(weight_map, dict) or not weight_map or not all(
+            isinstance(name, str)
+            and name
+            and isinstance(filename, str)
+            and filename
+            for name, filename in weight_map.items()
+        ):
+            raise WorkflowError(f"safetensors index has an invalid weight_map: {index}")
+        expected_keys = set(weight_map)
+        weight_files = sorted({root / filename for filename in weight_map.values()})
+    else:
+        weight_files = sorted(root.glob("*.safetensors"))
+    if not weight_files:
         return None
-    payload = _read_json(index, "safetensors index")
-    weight_map = payload.get("weight_map")
-    if not isinstance(weight_map, dict) or not weight_map:
-        raise WorkflowError(f"safetensors index has no weight_map: {index}")
-    return set(weight_map)
+    actual_keys: set[str] = set()
+    for weight_file in weight_files:
+        try:
+            resolved_weight = weight_file.resolve(strict=True)
+            resolved_weight.relative_to(root.resolve())
+        except (OSError, ValueError) as exc:
+            raise WorkflowError(
+                f"safetensors weight path escapes or is missing below {root}: {weight_file}"
+            ) from exc
+        keys = _safetensors_file_tensor_keys(resolved_weight)
+        duplicates = actual_keys & keys
+        if duplicates:
+            raise WorkflowError(
+                "duplicate tensor keys across safetensors files: "
+                f"{sorted(duplicates)[:10]}"
+            )
+        actual_keys.update(keys)
+    if expected_keys is not None and actual_keys != expected_keys:
+        raise WorkflowError(
+            "safetensors index tensor keys disagree with shard headers: "
+            f"missing={sorted(expected_keys - actual_keys)[:10]}, "
+            f"unexpected={sorted(actual_keys - expected_keys)[:10]}"
+        )
+    return actual_keys
 
 
 def _base_model_fingerprint(path: Path) -> str:
@@ -195,9 +264,14 @@ def verify_export(
             recorded_fingerprint = manifest.get("base_model_fingerprint", {}).get("sha256")
             if recorded_fingerprint != _base_model_fingerprint(local_base.resolve()):
                 raise WorkflowError("Framework export base model fingerprint is stale")
-            base_keys = _indexed_tensor_keys(local_base.resolve())
-            export_keys = _indexed_tensor_keys(output)
-            if base_keys is not None and export_keys is not None and base_keys != export_keys:
+            base_keys = _safetensors_tensor_keys(local_base.resolve())
+            export_keys = _safetensors_tensor_keys(output)
+            if base_keys is None or export_keys is None:
+                raise WorkflowError(
+                    "Framework export tensor-key verification requires safetensors "
+                    "weights in both the local base checkpoint and export"
+                )
+            if base_keys != export_keys:
                 missing = sorted(base_keys - export_keys)[:10]
                 unexpected = sorted(export_keys - base_keys)[:10]
                 raise WorkflowError(

--- a/skills/models/tao-finetune-cosmos-reason/scripts/framework_checkpoint_action.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/framework_checkpoint_action.py
@@ -84,8 +84,23 @@ def infer_config_file(checkpoint: Path) -> Path:
 
 
 def _normalized_source(value: str) -> str:
+    if value.startswith("hf_model://"):
+        return value.removeprefix("hf_model://").strip("/")
+    if value.startswith("hf://"):
+        return value.removeprefix("hf://").removeprefix("models/").strip("/")
     candidate = Path(value).expanduser()
     return str(candidate.resolve()) if candidate.exists() else value
+
+
+def _indexed_tensor_keys(root: Path) -> set[str] | None:
+    index = root / "model.safetensors.index.json"
+    if not index.is_file():
+        return None
+    payload = _read_json(index, "safetensors index")
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise WorkflowError(f"safetensors index has no weight_map: {index}")
+    return set(weight_map)
 
 
 def _base_model_fingerprint(path: Path) -> str:
@@ -180,6 +195,15 @@ def verify_export(
             recorded_fingerprint = manifest.get("base_model_fingerprint", {}).get("sha256")
             if recorded_fingerprint != _base_model_fingerprint(local_base.resolve()):
                 raise WorkflowError("Framework export base model fingerprint is stale")
+            base_keys = _indexed_tensor_keys(local_base.resolve())
+            export_keys = _indexed_tensor_keys(output)
+            if base_keys is not None and export_keys is not None and base_keys != export_keys:
+                missing = sorted(base_keys - export_keys)[:10]
+                unexpected = sorted(export_keys - base_keys)[:10]
+                raise WorkflowError(
+                    "Framework export tensor key set differs from the base checkpoint: "
+                    f"missing={missing}, unexpected={unexpected}"
+                )
     if base_model_revision and manifest.get("base_model_revision") != base_model_revision:
         raise WorkflowError("Framework export base model revision does not match the requested revision")
     return {
@@ -263,7 +287,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         args.dtype,
     ]
     if args.base_model_path_or_uri:
-        export_command.extend(["--base-model-path-or-uri", args.base_model_path_or_uri])
+        export_command.extend(
+            ["--base-model-path-or-uri", _normalized_source(args.base_model_path_or_uri)]
+        )
     if args.base_model_revision:
         export_command.extend(["--base-model-revision", args.base_model_revision])
 

--- a/skills/models/tao-finetune-cosmos-reason/scripts/prepare_cosmos3_vlm_checkpoint.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/prepare_cosmos3_vlm_checkpoint.py
@@ -12,6 +12,7 @@ source, runtime, and output checkpoint provenance.
 from __future__ import annotations
 
 import argparse
+import getpass
 import hashlib
 import json
 import os
@@ -138,6 +139,7 @@ python -m cosmos_rl.model_preparation.vlm_safetensors \
   --checkpoint-path "$source_value" --output-path "/output/$OUTPUT_NAME" \
   --vlm-model-name "$architecture_value"
 """
+    runtime_user = os.environ.get("USER") or os.environ.get("LOGNAME") or getpass.getuser() or "tao"
     result = [
         # Run as the invoking user so the host-side validation pass can read
         # the prepared files; the selected backend image keeps its venv readable.
@@ -149,6 +151,16 @@ python -m cosmos_rl.model_preparation.vlm_safetensors \
         "bash",
         "--user",
         f"{os.getuid()}:{os.getgid()}",
+        "-e",
+        f"USER={runtime_user}",
+        "-e",
+        f"LOGNAME={runtime_user}",
+        "-e",
+        "HOME=/cache/tao-home",
+        "-e",
+        "XDG_CACHE_HOME=/cache/tao-home/.cache",
+        "-e",
+        "TORCHINDUCTOR_CACHE_DIR=/cache/torchinductor",
         "-e",
         f"BASE_MODEL={source}",
         "-e",

--- a/skills/models/tao-finetune-video-clip/references/spec_template_export.yaml
+++ b/skills/models/tao-finetune-video-clip/references/spec_template_export.yaml
@@ -26,7 +26,7 @@ export:
   input_height: 224
   input_width: 224
   input_channel: 3
-  batch_size: -1
+  batch_size: 1
   opset_version: 23
   gpu_id: 0
   on_cpu: false

--- a/skills/models/tao-finetune-video-clip/references/spec_template_export.yaml
+++ b/skills/models/tao-finetune-video-clip/references/spec_template_export.yaml
@@ -26,7 +26,7 @@ export:
   input_height: 224
   input_width: 224
   input_channel: 3
-  batch_size: 1
+  batch_size: -1
   opset_version: 23
   gpu_id: 0
   on_cpu: false

--- a/skills/platform/tao-run-on-brev/SKILL.md
+++ b/skills/platform/tao-run-on-brev/SKILL.md
@@ -51,8 +51,8 @@ target instance — poll with a **two-word** command until it succeeds before
 issuing real work (a fresh instance reports `RUNNING` before sshd is up):
 
 ```bash
-for i in $(seq 1 60); do [ "$(brev exec <instance> "echo ok" 2>/dev/null)" = ok ] && break; sleep 5; done
-[ "$(brev exec <instance> "echo ok" 2>/dev/null)" = ok ] || { echo "instance not exec-ready"; exit 1; }
+for i in $(seq 1 60); do brev exec <instance> "echo ok" 2>/dev/null | grep -qx ok && break; sleep 5; done
+brev exec <instance> "echo ok" 2>/dev/null | grep -qx ok || { echo "instance not exec-ready"; exit 1; }
 ```
 
 The probe must be **two words, quoted as one argument**. A single-token probe
@@ -141,7 +141,7 @@ brev exec <instance> "docker manifest inspect $IMG >/dev/null && echo AUTH_OK ||
 brev exec <instance> "docker image inspect $IMG >/dev/null 2>&1 || docker pull $IMG"
 
 # Run a TAO job (the docker `submit` verb, over brev exec)
-brev exec <instance> "docker run -d --name $JOB_ID --gpus all -v ~/data:/data -e NGC_KEY $IMG visual_changenet train -e /data/spec.yaml"
+brev exec <instance> "docker inspect '$JOB_ID' >/dev/null 2>&1 && { echo '$JOB_ID already submitted'; exit 0; }; docker run -d --name '$JOB_ID' --label 'tao-job=$JOB_ID' --gpus all -v ~/data:/data -e NGC_KEY '$IMG' visual_changenet train -e /data/spec.yaml"
 ```
 
 ## Multi-GPU and multi-node

--- a/skills/platform/tao-run-on-brev/SKILL.md
+++ b/skills/platform/tao-run-on-brev/SKILL.md
@@ -90,7 +90,7 @@ instance to stop billing. `$BANK` = `${TAO_SKILL_BANK_PATH}`.
     --platform brev --image "$IMG" \
     --network-arch "$ARCH" --action "$ACTION" \
     --storage-tier "$TIER" --results-root "$RESULTS_ROOT")
-  brev exec <instance> "docker run -d --name $JOB_ID ..."
+  brev exec <instance> "docker inspect '$JOB_ID' >/dev/null 2>&1 && { echo '$JOB_ID already submitted'; exit 0; }; docker run -d --name '$JOB_ID' --label 'tao-job=$JOB_ID' ..."
   "$BANK/scripts/tao_job_record.py" mark "$JOB_ID" --state RUNNING \
     --backend-ref "<instance>/$JOB_ID"       # instance is part of the ref: the
                                              # container is unreachable without it


### PR DESCRIPTION
## Summary

- normalize LoRA target-module inputs and propagate Cosmos runtime identity, dimensions, GPU topology, and sealed-plan Docker launch details
- fail closed for undecodable or non-canonical media, checkpoint tensor-key drift, and incomplete launch hardware data
- harden Framework checkpoint and metric helpers without changing the Video-CLIP template owned by #203
- make Brev readiness tolerant of appended CLI output and make the normative submit contract idempotent

## Root-cause review updates

- Framework checkpoint verification now reads tensor keys from actual safetensors headers for both indexed/sharded and single-file checkpoints. Indexed metadata is also checked against the referenced shard headers. Missing, malformed, duplicate, escaping, or mismatched weights fail closed. This fixes the verification boundary itself; it does not rename files, trust metadata hashes alone, or special-case the reported tensor name.
- Docker GPU resolution now inventories physical index, UUID, and memory, applies `CUDA_VISIBLE_DEVICES` using the same index/UUID-prefix convention as shared launch preflight, filters capacity within that visible set, records the selected host IDs in the sealed plan, and uses the exact device request in preflight and final Docker launch. It does not infer availability from physical `nvidia-smi` count or expose all GPUs after approving a subset.
- Full media decode validation is preserved, but ffprobe work is dispatched through a bounded eight-worker pool. I intentionally avoided sampling because it could let corrupt unsampled clips reach a long-running job.
- The Video-CLIP export-template hunk and its test were removed; #203 remains the single owner of that complete deploy change.

## NVBugs

6671248, 6671239, 6670478, 6670470, 6670461, 6670213, 6670029, 6669930, 6669910, 6669898, 6669893, 6669862, 6669859, 6669829, and duplicate 6669848.

## Validation

- `python -m pytest -q scripts/tests/test_cosmos_skill_workflow.py scripts/tests/test_launch_preflight.py scripts/tests/test_platform_contract.py`: **202 passed**
- focused review cases covering single-file/indexed tensor drift, CUDA-visible index/UUID selection, ineligible visible GPUs, exact Docker device rendering, and media preflight: **14 passed**
- `./scripts/validate-skills.sh`: passed
- Python compilation and `git diff --check`: passed
- live Brev readiness gate exited 0 with the CLI's appended instance-name output
- two identical guarded live submits produced one container; the test container was removed afterward
