### PR TITLE
[TAO-0000][Bugfix] Cherry-pick DEFT CR ITS Fixes from main (commit e91a65c)

### DIFF
--- a/scripts/ci/render_and_validate_templates.py
+++ b/scripts/ci/render_and_validate_templates.py
@@ -46,7 +46,7 @@ COMMON = {
     "NUM_NODES": "2",
     "GPUS_PER_NODE": "8",
     "NUM_GPUS": "8",          # single-node templates spell it this way
-    "IMAGE": "nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-47-multiarch",  # versions-key: images.tao_toolkit.pyt
+    "IMAGE": "nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-53-multiarch",  # versions-key: images.tao_toolkit.pyt
     "COMMAND": "dino train -e /data/specs/spec.yaml",
 }
 K8S_VALS = {

--- a/skills/applications/tao-run-deft-cr-its-mining/SKILL.md
+++ b/skills/applications/tao-run-deft-cr-its-mining/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   focused on the non-reasoning classification/evaluation path. Use when the user asks for a
   DEFT CR ITS mining workflow, traffic-camera Cosmos Reason improvement loop, collision-identification workflow with data mining, or iterative Cosmos-RL refinement driven by gap analysis.
 license: Apache-2.0
-compatibility: Requires Docker with NVIDIA Container Toolkit, Python 3.11 with pandas, pyarrow, PyYAML, and huggingface_hub, plus the selected platform CLI.
+compatibility: Requires Docker with NVIDIA Container Toolkit, Python 3.11 with venv/ensurepip, numpy, pandas, pyarrow, PyYAML, and huggingface_hub, plus the selected platform CLI.
 metadata:
   author: NVIDIA Corporation
   version: "0.1.0"
@@ -184,7 +184,7 @@ The KPI parquet contains only the selected modality or modalities. The train par
 
 ### Run Cosmos Embed Inference
 
-Use the `tao-finetune-cosmos-embed` skill's inference action for each generated inference spec. That model skill owns the Cosmos Embed container image, action command, credentials, and platform-specific mount behavior. This workflow skill owns only the generated specs and the downstream conversion into mining-ready parquet files. Do not run inference or conversion for a dataset whose combined Parquet was supplied and staged during preparation. See `references/mining-loop.md` for exact commands, permission repair, and conversion.
+Use `tao-finetune-cosmos-embed` for each generated inference spec. Follow the mandatory terminal-exit validation, permission repair, and conversion procedure in `references/mining-loop.md`. Do not run inference or conversion for a dataset whose combined Parquet was supplied during preparation.
 
 The generated lookup Parquet uses `annotation_id` for the original LLaVA `id` and `video_path` for resolved media. Do not rename either column to `video_id`; that external field belongs to Cosmos Reason and gap-analysis records.
 
@@ -200,7 +200,7 @@ Run iterations `1..run.max_iterations`. The loop is mining-only: no PAIDF or gen
 | `initialize_workflow` | `$RUN_DIR/workflow.yaml` and `$RUN_DIR/deft_state.json` exist. |
 | `baseline_evaluate` | The evaluate job exits successfully, exactly one baseline `results.json` is found, and `baseline/evaluate/bcq_accuracy_metrics.json` exists. |
 | `prepare_cosmos_embed_inference` | Each dataset has a lookup parquet and either all required Cosmos Embed specs or a staged combined embedding Parquet. |
-| `cosmos_embed` | Every generated Cosmos Embed inference spec has completed successfully through the underlying skill. |
+| `cosmos_embed` | Every generated inference spec has a current `completion_validation.json`; exit `0` is accepted after output validation, while exit `130` additionally records a teardown warning. |
 | `convert_embeddings` | `embedding_parquets/{kpi,train}/embeddings.parquet` exist; train contains both modalities and KPI contains the selected modalities. |
 | `gap_analysis` | `$RUN_DIR/iter_<N>/gaps/predictions.json` exists and the container exits successfully. The workflow counts valid rows directly from `kpi_gaps.jsonl`; missing or empty output after successful completion means zero weak samples. |
 | `prepare_nearest_neighbor_mining` | One target parquet, optional filtered source parquet, and one nearest-neighbor spec exist. |

--- a/skills/applications/tao-run-deft-cr-its-mining/references/host-prerequisites.md
+++ b/skills/applications/tao-run-deft-cr-its-mining/references/host-prerequisites.md
@@ -3,8 +3,10 @@
 Read this reference before workflow preflight and whenever `deft_python.sh`
 cannot select an interpreter.
 
-The host-side helpers require Python 3.11 with `pandas`, `pyarrow`, `PyYAML`,
-and `huggingface_hub`. Resolve `DEFT_SKILL_ROOT` to the installed
+The host-side helpers require Python 3.11 with `numpy`, `pandas`, `pyarrow`,
+`PyYAML`, and `huggingface_hub`. A Python used to provision the workspace must
+also provide `venv` and `ensurepip`; a globally installed `pip` executable is
+not required. Resolve `DEFT_SKILL_ROOT` to the installed
 `tao-run-deft-cr-its-mining` skill directory, then export the workspace and
 select one dependency-complete interpreter:
 
@@ -18,9 +20,18 @@ and never installs packages. If it fails, show its exact commands and obtain
 user approval before provisioning the workspace-local environment:
 
 ```bash
-python3 -m venv "<deft_workspace>/.venv"
-"<deft_workspace>/.venv/bin/python" -m pip install pandas pyarrow pyyaml huggingface_hub
+BOOTSTRAP_PYTHON="$(command -v python3.11 || command -v python3)"
+"$BOOTSTRAP_PYTHON" -c 'import sys; assert sys.version_info >= (3, 11)'
+"$BOOTSTRAP_PYTHON" -m venv "<deft_workspace>/.venv"
+VENV_PYTHON="<deft_workspace>/.venv/bin/python"
+"$VENV_PYTHON" -m pip --version >/dev/null 2>&1 || "$VENV_PYTHON" -m ensurepip --upgrade
+"$VENV_PYTHON" -m pip install numpy pandas pyarrow pyyaml huggingface_hub
 ```
+
+If venv creation or the `ensurepip` fallback fails, stop and tell the user that
+the host Python lacks venv bootstrap support. Ask how they want to provide a
+Python 3.11 installation with `venv`/`ensurepip`; do not install an OS package,
+run `get-pip.py`, or use elevated privileges without explicit user direction.
 
 Rerun the selector after installation. Use `DEFT_PYTHON` for every bundled
 Python helper. Do not install these packages into an arbitrary system Python.

--- a/skills/applications/tao-run-deft-cr-its-mining/references/mining-loop.md
+++ b/skills/applications/tao-run-deft-cr-its-mining/references/mining-loop.md
@@ -122,7 +122,7 @@ BASELINE_RESULTS_JSON="$("$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/find_cosmos_re
   --output-json "$RUN_DIR/baseline/evaluate/bcq_accuracy_metrics.json"
 ```
 
-The metrics script reads `response`/`gt` and also accepts `answer`/`ground_truth`. It extracts `yes` and `no` defensively from capitalization, punctuation, and short free-form answers. An unparseable prediction is reported and counted as incorrect; an unparseable ground truth is a hard error. Report the printed accuracy, balanced accuracy, false-positive count, false-negative count, and unparseable count in the baseline stage update. Log both `results.json` and `bcq_accuracy_metrics.json` as `baseline_evaluate` artifacts. The stage is not complete until the metrics file exists.
+Ignore metrics emitted by Cosmos-RL evaluate; `compute_bcq_accuracy_metrics.py` and its `bcq_accuracy_metrics.json` output are the source of truth for this workflow. The metrics script reads `response`/`gt` and also accepts `answer`/`ground_truth`. It extracts `yes` and `no` defensively from capitalization, punctuation, and short free-form answers. An unparseable prediction is reported and counted as incorrect; an unparseable ground truth is a hard error. Report the printed accuracy, balanced accuracy, false-positive count, false-negative count, and unparseable count in the baseline stage update. Log both `results.json` and `bcq_accuracy_metrics.json` as `baseline_evaluate` artifacts. The stage is not complete until the metrics file exists.
 
 ## Mining Embeddings
 
@@ -146,13 +146,27 @@ Only run specs that exist. KPI specs follow `mining.embeddings_modality`; train 
 
 Read `inference.num_gpus` from each generated spec and request exactly that many GPUs from the selected platform. The bundled template defaults to 8 GPUs. The preparation script prints the count for every generated modality; stop before launch if the platform cannot satisfy it.
 
-Keep the exact container image selected by `tao-finetune-cosmos-embed` as `COSMOS_EMBED_IMAGE`. After each Cosmos Embed container exits, restore host write access if needed with that same image:
+Use the registered inference action exactly as `cosmos-embed1 inference -e <generated-spec>`. Do not append a `results_dir=...` CLI override: OmegaConf would replace the generated spec's modality-specific output path. Before submission, inspect the rendered command and require the selected platform to make the spec's absolute workspace paths visible and writable at those same paths inside the container. Do not infer output location from the container working directory.
+
+Keep the exact container image selected by `tao-finetune-cosmos-embed` as `COSMOS_EMBED_IMAGE`. Handle every generated spec independently. Set `INFERENCE_SPEC` to that spec's absolute path and `DATASET` to its `kpi` or `train` parent dataset. Run the inference action through `tao-finetune-cosmos-embed` and the selected platform. Monitor it to a terminal state and record its exact numeric exit code as `COSMOS_EMBED_EXIT_CODE`, including when the platform classifies the job as failed. After the container exits, restore host write access if needed with the same image and the dataset directory containing that spec:
 
 ```bash
 "$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/restore_docker_mount_permissions.py" \
-  --path "$RUN_DIR/cosmos_embed_output/kpi" \
+  --path "$RUN_DIR/cosmos_embed_output/$DATASET" \
   --docker-image "$COSMOS_EMBED_IMAGE"
 ```
+
+Then validate the terminal result and existing outputs:
+
+```bash
+"$DEFT_PYTHON" "$DEFT_SKILL_ROOT/scripts/validate_cosmos_embed_output.py" \
+  --inference-spec "$INFERENCE_SPEC" \
+  --exit-code "$COSMOS_EMBED_EXIT_CODE"
+```
+
+The validator reads `results_dir` from the generated spec and requires metadata and a finite two-dimensional NPY array there, exact input/output counts and identifiers, and one unique `npy_row` for every embedding. Exit `0` passes only when those checks pass. Exit `130` is the one permitted nonzero code because the affected runtime can return it during `torchrun` teardown after successful output; the validation artifact records `ok_with_teardown_warning`. Every other nonzero exit fails. Existing outputs remain reusable when they still match the unchanged inference spec. If the platform cannot report an exact numeric code, do not infer `130` from logs or files; stop and ask how the user wants to proceed.
+
+After every generated spec passes `check` or `complete`, log one `cosmos_embed` `ok` event with every `completion_validation.json` as an artifact. If there are no generated specs because both combined Parquets were supplied, log the stage as skipped. Do not log this stage complete from platform status alone.
 
 Convert completed outputs only for datasets that generated inference specs:
 
@@ -168,7 +182,7 @@ Convert completed outputs only for datasets that generated inference specs:
   --embedding-modality both
 ```
 
-These commands write `$RUN_DIR/embedding_parquets/kpi/embeddings.parquet` and `$RUN_DIR/embedding_parquets/train/embeddings.parquet`. Skip the corresponding command when preparation already staged a supplied combined Parquet at that path. The KPI file contains the selected modality or modalities. The train file always contains both, and each row records its `modality` alongside `filepath` and `embedding`.
+These commands write `$RUN_DIR/embedding_parquets/kpi/embeddings.parquet` and `$RUN_DIR/embedding_parquets/train/embeddings.parquet`. The converter reads each modality's `results_dir` from its generated spec; it never reconstructs the producer path or searches for misplaced files. Skip the corresponding command when preparation already staged a supplied combined Parquet at that path. The KPI file contains the selected modality or modalities. The train file always contains both, and each row records its `modality` alongside `filepath` and `embedding`.
 
 For text outputs, conversion matches each Cosmos Embed metadata `text` value to the corresponding lookup question. Repeated questions consume their lookup rows in occurrence order. `npy_row` selects only the embedding vector; it is not treated as a lookup-row index. Conversion fails if Cosmos Embed returns missing, extra, or unmatched text occurrences.
 
@@ -302,7 +316,7 @@ This writes `$RUN_DIR/bcq_accuracy_report.md` and `$RUN_DIR/bcq_accuracy_summary
 | `initialize_workflow` | `$RUN_DIR/workflow.yaml` and `$RUN_DIR/deft_state.json` exist. |
 | `baseline_evaluate` | The evaluate job exits successfully, exactly one baseline `results.json` is found, and `baseline/evaluate/bcq_accuracy_metrics.json` exists. |
 | `prepare_cosmos_embed_inference` | Each dataset has a lookup parquet and either all required Cosmos Embed specs or a staged combined embedding Parquet. |
-| `cosmos_embed` | Every generated Cosmos Embed inference spec has completed successfully through the underlying skill. |
+| `cosmos_embed` | Every generated inference spec has a current `completion_validation.json`; validated exit `130` is recorded as a teardown warning, and all other nonzero exits fail. |
 | `convert_embeddings` | `embedding_parquets/{kpi,train}/embeddings.parquet` exist with the required modalities. |
 | `gap_analysis` | `$RUN_DIR/iter_<N>/gaps/predictions.json` exists and the container exits successfully. The workflow counts valid rows directly from `kpi_gaps.jsonl`; missing or empty output after successful completion means zero weak samples. |
 | `prepare_nearest_neighbor_mining` | The target, optional filtered source, and nearest-neighbor spec exist. |

--- a/skills/applications/tao-run-deft-cr-its-mining/scripts/cosmos_embed_outputs_to_parquet.py
+++ b/skills/applications/tao-run-deft-cr-its-mining/scripts/cosmos_embed_outputs_to_parquet.py
@@ -15,7 +15,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from workflow_common import MODALITY_CHOICES, atomic_write_parquet, modality_list
+from workflow_common import MODALITY_CHOICES, atomic_write_parquet, load_yaml, modality_list
 
 
 def load_metadata(path: Path) -> dict[str, Any]:
@@ -60,9 +60,24 @@ def text_filepath_queues(output_dir: Path) -> dict[str, deque[str]] | None:
     return dict(queues)
 
 
+def inference_dir_from_spec(output_dir: Path, mode: str) -> Path:
+    """Return the inference output directory declared by a generated spec."""
+    spec_path = output_dir / "specs" / f"inference_{mode}.yaml"
+    if not spec_path.is_file():
+        raise FileNotFoundError(f"Cosmos Embed inference spec is missing: {spec_path}")
+    spec = load_yaml(spec_path)
+    results_dir = spec.get("results_dir")
+    if not isinstance(results_dir, str) or not results_dir:
+        raise ValueError(f"{spec_path}: results_dir must be a non-empty string")
+    results_path = Path(results_dir).expanduser()
+    if not results_path.is_absolute():
+        raise ValueError(f"{spec_path}: results_dir must be absolute: {results_path}")
+    return results_path / "inference"
+
+
 def raw_embeddings_dataframe(mode: str, output_dir: Path) -> pd.DataFrame:
     """Convert one modality's Cosmos Embed JSON/NPY output to a dataframe."""
-    inference_dir = output_dir / "results" / mode / "inference"
+    inference_dir = inference_dir_from_spec(output_dir, mode)
     metadata_path = inference_dir / f"{mode}_embeddings.json"
     metadata = load_metadata(metadata_path)
     embeddings = np.load(npy_path(inference_dir, metadata))

--- a/skills/applications/tao-run-deft-cr-its-mining/scripts/deft_python.sh
+++ b/skills/applications/tao-run-deft-cr-its-mining/scripts/deft_python.sh
@@ -10,7 +10,7 @@ set -eu
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 skill_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
 workspace=${WORKSPACE_DIR:-${WORKSPACE:-}}
-probe='import sys,pandas,pyarrow,yaml,huggingface_hub; assert sys.version_info >= (3, 11)'
+probe='import sys,numpy,pandas,pyarrow,yaml,huggingface_hub; assert sys.version_info >= (3, 11)'
 
 candidates=(
   "${DEFT_PYTHON:-}"
@@ -36,10 +36,16 @@ done
 
 workspace_display=${workspace:-/absolute/path/to/deft_workspace}
 cat >&2 <<EOF
-deft_python: no Python 3.11+ interpreter provides pandas, pyarrow, yaml, and huggingface_hub
+deft_python: no Python 3.11+ interpreter provides numpy, pandas, pyarrow, yaml, and huggingface_hub
 deft_python: after user approval, provision the workspace environment with:
-  python3 -m venv "$workspace_display/.venv"
-  "$workspace_display/.venv/bin/python" -m pip install pandas pyarrow pyyaml huggingface_hub
+  BOOTSTRAP_PYTHON="\$(command -v python3.11 || command -v python3)"
+  "\$BOOTSTRAP_PYTHON" -c 'import sys; assert sys.version_info >= (3, 11)'
+  "\$BOOTSTRAP_PYTHON" -m venv "$workspace_display/.venv"
+  VENV_PYTHON="$workspace_display/.venv/bin/python"
+  "\$VENV_PYTHON" -m pip --version >/dev/null 2>&1 || "\$VENV_PYTHON" -m ensurepip --upgrade
+  "\$VENV_PYTHON" -m pip install numpy pandas pyarrow pyyaml huggingface_hub
+deft_python: a global pip executable is not required
+deft_python: if venv creation or ensurepip fails, ask the user to provide Python 3.11 with venv/ensurepip; do not make a privileged system change
 deft_python: rerun preflight after installation; this selector never installs packages itself
 EOF
 exit 2

--- a/skills/applications/tao-run-deft-cr-its-mining/scripts/resume_position.py
+++ b/skills/applications/tao-run-deft-cr-its-mining/scripts/resume_position.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from log_stage import read_valid_events, rebuild_state
+from validate_cosmos_embed_output import incomplete_specs
 from workflow_common import absolute_path
 
 
@@ -91,6 +92,16 @@ def resume_position(
     for stage in INITIAL_STAGES:
         candidates = [event for (_, event_stage), event in latest.items() if event_stage == stage]
         event = max(candidates, key=lambda item: item["seq"], default=None)
+        if stage == "cosmos_embed" and stage_is_complete(event) and run_dir is not None:
+            incomplete = incomplete_specs(run_dir)
+            if incomplete:
+                return {
+                    "workflow_status": "running",
+                    "next_iteration": 0,
+                    "next_stage": stage,
+                    "reason": "Cosmos Embed completion validation is missing or stale: "
+                    + "; ".join(incomplete),
+                }
         if not stage_is_complete(event):
             return {
                 "workflow_status": "failed" if event and event.get("status") == "error" else "running",

--- a/skills/applications/tao-run-deft-cr-its-mining/scripts/validate_cosmos_embed_output.py
+++ b/skills/applications/tao-run-deft-cr-its-mining/scripts/validate_cosmos_embed_output.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate one completed Cosmos Embed inference job."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from workflow_common import absolute_path, atomic_write_json, load_yaml
+
+
+ACCEPTED_EXIT_CODES = {0, 130}
+SUCCESS_STATUSES = {"ok", "ok_with_teardown_warning"}
+COMPLETION_FILENAME = "completion_validation.json"
+
+
+def utc_now() -> str:
+    """Return the current UTC time in ISO-8601 format."""
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def require_string(value: Any, label: str) -> str:
+    """Require a non-empty string value."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def spec_context(spec_path: Path) -> dict[str, Any]:
+    """Load one inference spec and derive its expected output contract."""
+    spec = load_yaml(spec_path)
+    inference = spec.get("inference")
+    if not isinstance(inference, dict):
+        raise ValueError(f"{spec_path}: missing object field 'inference'")
+    mode = require_string(inference.get("mode"), f"{spec_path}: inference.mode")
+    if mode not in {"text", "video"}:
+        raise ValueError(f"{spec_path}: inference.mode must be 'text' or 'video', got {mode!r}")
+    query = inference.get("query")
+    if not isinstance(query, dict):
+        raise ValueError(f"{spec_path}: missing object field 'inference.query'")
+    input_key = "input_texts" if mode == "text" else "input_videos"
+    expected = query.get(input_key)
+    if not isinstance(expected, list) or not expected:
+        raise ValueError(f"{spec_path}: inference.query.{input_key} must be a non-empty list")
+    for index, value in enumerate(expected, start=1):
+        require_string(value, f"{spec_path}: inference.query.{input_key}[{index}]")
+
+    results_dir = Path(require_string(spec.get("results_dir"), f"{spec_path}: results_dir")).expanduser()
+    if not results_dir.is_absolute():
+        raise ValueError(f"{spec_path}: results_dir must be absolute: {results_dir}")
+    inference_dir = results_dir / "inference"
+    return {
+        "spec_path": spec_path,
+        "spec_sha256": file_sha256(spec_path),
+        "mode": mode,
+        "expected": expected,
+        "inference_dir": inference_dir,
+        "metadata_path": inference_dir / f"{mode}_embeddings.json",
+        "completion_path": inference_dir / COMPLETION_FILENAME,
+    }
+
+
+def load_json_object(path: Path, label: str) -> dict[str, Any]:
+    """Read a JSON object from a file."""
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must contain a JSON object: {path}")
+    return payload
+
+
+def referenced_npy_path(inference_dir: Path, metadata: dict[str, Any]) -> Path:
+    """Resolve the NPY array path declared by Cosmos Embed metadata."""
+    value = require_string(metadata.get("npy_file"), "Cosmos Embed metadata.npy_file")
+    path = Path(value).expanduser()
+    return path if path.is_absolute() else inference_dir / path
+
+
+def validate_outputs(spec_path: Path) -> dict[str, Any]:
+    """Validate JSON/NPY outputs against every query in an inference spec."""
+    context = spec_context(spec_path)
+    metadata_path = context["metadata_path"]
+    if not metadata_path.is_file():
+        raise FileNotFoundError(f"Cosmos Embed metadata is missing: {metadata_path}")
+    metadata = load_json_object(metadata_path, "Cosmos Embed metadata")
+    npy_path = referenced_npy_path(context["inference_dir"], metadata)
+    if not npy_path.is_file():
+        raise FileNotFoundError(f"Cosmos Embed NPY output is missing: {npy_path}")
+
+    embeddings = np.load(npy_path, allow_pickle=False)
+    expected = context["expected"]
+    if embeddings.ndim != 2:
+        raise ValueError(f"Cosmos Embed array must be two-dimensional, got shape {embeddings.shape}")
+    if embeddings.shape[0] != len(expected) or embeddings.shape[1] < 1:
+        raise ValueError(
+            f"Cosmos Embed array shape {embeddings.shape} does not match "
+            f"{len(expected)} expected {context['mode']} queries"
+        )
+    try:
+        finite = bool(np.isfinite(embeddings).all())
+    except TypeError as exc:
+        raise ValueError(f"Cosmos Embed array must contain numeric values: {npy_path}") from exc
+    if not finite:
+        raise ValueError(f"Cosmos Embed array contains non-finite values: {npy_path}")
+
+    results = metadata.get("results")
+    if not isinstance(results, list) or len(results) != len(expected):
+        observed = len(results) if isinstance(results, list) else "non-list"
+        raise ValueError(f"Cosmos Embed metadata has {observed} results; expected {len(expected)}")
+    identifier_key = "text" if context["mode"] == "text" else "video_path"
+    identifiers: list[str] = []
+    npy_rows: list[int] = []
+    for index, result in enumerate(results, start=1):
+        if not isinstance(result, dict):
+            raise ValueError(f"Cosmos Embed result {index} is not an object")
+        identifiers.append(require_string(result.get(identifier_key), f"result {index}.{identifier_key}"))
+        npy_row = result.get("npy_row")
+        if not isinstance(npy_row, int) or isinstance(npy_row, bool):
+            raise ValueError(f"Cosmos Embed result {index}.npy_row must be an integer")
+        npy_rows.append(npy_row)
+    if sorted(npy_rows) != list(range(len(expected))):
+        raise ValueError(
+            "Cosmos Embed npy_row values must reference every embedding row exactly once; "
+            f"observed {npy_rows}"
+        )
+    if Counter(identifiers) != Counter(expected):
+        missing = list((Counter(expected) - Counter(identifiers)).elements())[:3]
+        unexpected = list((Counter(identifiers) - Counter(expected)).elements())[:3]
+        raise ValueError(
+            f"Cosmos Embed {context['mode']} identifiers do not match the spec; "
+            f"missing={missing!r}, unexpected={unexpected!r}"
+        )
+
+    return {
+        "mode": context["mode"],
+        "expected_count": len(expected),
+        "observed_count": len(results),
+        "embedding_shape": list(embeddings.shape),
+        "metadata_path": str(metadata_path),
+        "npy_path": str(npy_path),
+    }
+
+
+def validate_completion(spec_path: Path, exit_code: int) -> Path:
+    """Validate a terminal job and write its reusable completion artifact."""
+    if exit_code not in ACCEPTED_EXIT_CODES:
+        raise RuntimeError(
+            f"Cosmos Embed exited {exit_code}; only exit 0 or the validated teardown code 130 is accepted"
+        )
+    context = spec_context(spec_path)
+    output = validate_outputs(spec_path)
+    warning = exit_code == 130
+    completion = {
+        "schema_version": 1,
+        "status": "ok_with_teardown_warning" if warning else "ok",
+        "validated_at": utc_now(),
+        "exit_code": exit_code,
+        "accepted_exit_code_130": warning,
+        "spec_path": str(spec_path),
+        "spec_sha256": context["spec_sha256"],
+        **output,
+    }
+    atomic_write_json(context["completion_path"], completion)
+    if warning:
+        print(
+            "WARNING: accepted Cosmos Embed exit 130 only because all outputs matched "
+            "the inference spec"
+        )
+    print(f"validated Cosmos Embed completion: {context['completion_path']}")
+    return context["completion_path"]
+
+
+def check_completion(spec_path: Path) -> dict[str, Any]:
+    """Require a current completion artifact and revalidate its outputs."""
+    context = spec_context(spec_path)
+    completion_path = context["completion_path"]
+    if not completion_path.is_file():
+        raise FileNotFoundError(f"Cosmos Embed completion validation is missing: {completion_path}")
+    completion = load_json_object(completion_path, "Cosmos Embed completion validation")
+    if completion.get("status") not in SUCCESS_STATUSES:
+        raise ValueError(f"Cosmos Embed completion is not successful: {completion_path}")
+    if completion.get("exit_code") not in ACCEPTED_EXIT_CODES:
+        raise ValueError(f"Cosmos Embed completion has an invalid exit code: {completion_path}")
+    if completion.get("spec_sha256") != context["spec_sha256"]:
+        raise ValueError(f"Cosmos Embed completion does not match the current spec: {spec_path}")
+    current = validate_outputs(spec_path)
+    for key in ("mode", "expected_count", "observed_count", "embedding_shape", "metadata_path", "npy_path"):
+        if completion.get(key) != current[key]:
+            raise ValueError(f"Cosmos Embed completion field {key!r} is stale: {completion_path}")
+    return completion
+
+
+def incomplete_specs(run_dir: Path) -> list[str]:
+    """Return generated inference specs without a current validated completion."""
+    incomplete: list[str] = []
+    for spec_path in sorted((run_dir / "cosmos_embed_output").glob("*/specs/inference_*.yaml")):
+        try:
+            check_completion(spec_path)
+        except (FileNotFoundError, OSError, ValueError, RuntimeError) as exc:
+            incomplete.append(f"{spec_path}: {exc}")
+    return incomplete
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inference-spec", required=True, type=Path)
+    parser.add_argument("--exit-code", required=True, type=int)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Validate one completed Cosmos Embed inference job."""
+    args = parse_args()
+    spec_path = absolute_path(args.inference_spec)
+    if not spec_path.is_file():
+        raise FileNotFoundError(f"inference spec does not exist: {spec_path}")
+    validate_completion(spec_path, args.exit_code)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/applications/tao-run-deft-cr-its-mining/tests/test_cosmos_embed_completion.py
+++ b/skills/applications/tao-run-deft-cr-its-mining/tests/test_cosmos_embed_completion.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Cosmos Embed terminal-status and output validation."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+import pandas as pd
+import yaml
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from resume_position import resume_position  # noqa: E402
+from cosmos_embed_outputs_to_parquet import consolidate_embeddings  # noqa: E402
+from validate_cosmos_embed_output import (  # noqa: E402
+    check_completion,
+    validate_completion,
+)
+
+
+class CosmosEmbedCompletionTests(unittest.TestCase):
+    """Exercise accepted teardown and strict output checks."""
+
+    def make_spec(
+        self,
+        root: pathlib.Path,
+        *,
+        dataset: str = "kpi",
+        mode: str = "text",
+        inputs: list[str] | None = None,
+        results_dir: pathlib.Path | None = None,
+    ) -> pathlib.Path:
+        inputs = inputs or (["same question", "same question"] if mode == "text" else ["/data/a.mp4"])
+        dataset_dir = root / "cosmos_embed_output" / dataset
+        spec_path = dataset_dir / "specs" / f"inference_{mode}.yaml"
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        results_dir = results_dir or dataset_dir / "results" / mode
+        query = {
+            "input_texts": inputs if mode == "text" else [],
+            "input_videos": inputs if mode == "video" else [],
+        }
+        spec_path.write_text(
+            yaml.safe_dump(
+                {
+                    "results_dir": str(results_dir),
+                    "inference": {"mode": mode, "query": query},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        return spec_path
+
+    def write_outputs(
+        self,
+        spec_path: pathlib.Path,
+        *,
+        identifiers: list[str],
+        finite: bool = True,
+    ) -> None:
+        spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+        mode = spec["inference"]["mode"]
+        inference_dir = pathlib.Path(spec["results_dir"]) / "inference"
+        inference_dir.mkdir(parents=True, exist_ok=True)
+        embeddings = np.arange(len(identifiers) * 4, dtype=np.float32).reshape(len(identifiers), 4)
+        if not finite:
+            embeddings[0, 0] = np.nan
+        npy_path = inference_dir / f"{mode}_embeddings.npy"
+        np.save(npy_path, embeddings)
+        identifier_key = "text" if mode == "text" else "video_path"
+        metadata = {
+            "npy_file": npy_path.name,
+            "results": [
+                {identifier_key: identifier, "npy_row": index}
+                for index, identifier in enumerate(identifiers)
+            ],
+        }
+        (inference_dir / f"{mode}_embeddings.json").write_text(
+            json.dumps(metadata), encoding="utf-8"
+        )
+
+    def test_exit_zero_accepts_repeated_text_occurrences(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            spec = self.make_spec(pathlib.Path(temporary))
+            self.write_outputs(spec, identifiers=["same question", "same question"])
+            completion_path = validate_completion(spec, 0)
+            completion = check_completion(spec)
+            self.assertEqual(completion["status"], "ok")
+            self.assertEqual(completion["embedding_shape"], [2, 4])
+            self.assertTrue(completion_path.is_file())
+
+    def test_exit_130_is_accepted_only_with_complete_video_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            inputs = ["/data/a.mp4", "/data/b.mp4"]
+            spec = self.make_spec(pathlib.Path(temporary), mode="video", inputs=inputs)
+            self.write_outputs(spec, identifiers=list(reversed(inputs)))
+            validate_completion(spec, 130)
+            completion = check_completion(spec)
+            self.assertEqual(completion["status"], "ok_with_teardown_warning")
+            self.assertTrue(completion["accepted_exit_code_130"])
+
+    def test_other_nonzero_exit_is_rejected_even_with_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            spec = self.make_spec(pathlib.Path(temporary))
+            self.write_outputs(spec, identifiers=["same question", "same question"])
+            with self.assertRaisesRegex(RuntimeError, "only exit 0 or.*130"):
+                validate_completion(spec, 1)
+
+    def test_incomplete_or_nonfinite_outputs_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            spec = self.make_spec(root, inputs=["one", "two"])
+            self.write_outputs(spec, identifiers=["one"])
+            with self.assertRaisesRegex(ValueError, "does not match 2 expected"):
+                validate_completion(spec, 130)
+
+            self.write_outputs(spec, identifiers=["one", "two"], finite=False)
+            with self.assertRaisesRegex(ValueError, "non-finite"):
+                validate_completion(spec, 130)
+
+    def test_identifiers_must_match_the_current_spec(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            spec = self.make_spec(pathlib.Path(temporary), inputs=["one", "two"])
+            self.write_outputs(spec, identifiers=["one", "three"])
+            with self.assertRaisesRegex(ValueError, "identifiers do not match"):
+                validate_completion(spec, 130)
+
+    def test_existing_matching_outputs_are_reusable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            spec = self.make_spec(pathlib.Path(temporary), inputs=["one"])
+            self.write_outputs(spec, identifiers=["one"])
+            validate_completion(spec, 130)
+            self.assertEqual(check_completion(spec)["expected_count"], 1)
+
+    def test_parquet_conversion_uses_results_dir_from_spec(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            custom_results = root / "custom_embed_results"
+            spec = self.make_spec(
+                root,
+                mode="video",
+                inputs=["/data/a.mp4"],
+                results_dir=custom_results,
+            )
+            self.write_outputs(spec, identifiers=["/data/a.mp4"])
+            output_dir = root / "cosmos_embed_output" / "kpi"
+            parquet_dir = root / "embedding_parquets" / "kpi"
+            parquet_path = consolidate_embeddings(output_dir, parquet_dir, "video")
+            converted = pd.read_parquet(parquet_path)
+            self.assertEqual(converted["filepath"].tolist(), ["/data/a.mp4"])
+            self.assertEqual(converted["modality"].tolist(), ["video"])
+
+    def test_workflow_forbids_results_dir_command_override(self) -> None:
+        mining_loop = (SKILL_ROOT / "references/mining-loop.md").read_text(encoding="utf-8")
+        self.assertIn("Do not append a `results_dir=...` CLI override", mining_loop)
+
+    def test_resume_reopens_cosmos_embed_when_validation_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            run_dir = pathlib.Path(temporary)
+            spec = self.make_spec(run_dir, inputs=["one"])
+            state = {"max_iterations": 1, "mine_unique_only": False}
+            events = [
+                {"seq": 1, "iter": "baseline", "stage": "baseline_evaluate", "status": "ok"},
+                {
+                    "seq": 2,
+                    "iter": "initialization",
+                    "stage": "prepare_cosmos_embed_inference",
+                    "status": "ok",
+                },
+                {"seq": 3, "iter": "initialization", "stage": "cosmos_embed", "status": "ok"},
+            ]
+            position = resume_position(state, events, run_dir)
+            self.assertEqual(position["next_stage"], "cosmos_embed")
+
+            self.write_outputs(spec, identifiers=["one"])
+            validate_completion(spec, 130)
+            position = resume_position(state, events, run_dir)
+            self.assertEqual(position["next_stage"], "convert_embeddings")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/applications/tao-run-deft-cr-its-mining/tests/test_host_dependencies.py
+++ b/skills/applications/tao-run-deft-cr-its-mining/tests/test_host_dependencies.py
@@ -5,16 +5,59 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
 
 SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPTS = SKILL_ROOT / "scripts"
+REQUIRED_IMPORT_PACKAGES = {
+    "huggingface_hub": "huggingface_hub",
+    "numpy": "numpy",
+    "pandas": "pandas",
+    "pyarrow": "pyarrow",
+    "yaml": "pyyaml",
+}
+INSTALL_PACKAGES = "numpy pandas pyarrow pyyaml huggingface_hub"
+KNOWN_STDLIB_IMPORTS = {
+    "__future__",
+    "argparse",
+    "collections",
+    "copy",
+    "datetime",
+    "hashlib",
+    "json",
+    "os",
+    "pathlib",
+    "re",
+    "shutil",
+    "subprocess",
+    "sys",
+    "tempfile",
+    "tomllib",
+    "typing",
+}
+
+
+def third_party_script_imports() -> set[str]:
+    """Return non-stdlib imports used by the workflow's Python helpers."""
+    local_modules = {path.stem for path in SCRIPTS.glob("*.py")}
+    imported: set[str] = set()
+    for path in SCRIPTS.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.partition(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.partition(".")[0])
+    stdlib_modules = getattr(sys, "stdlib_module_names", KNOWN_STDLIB_IMPORTS)
+    return imported - stdlib_modules - local_modules - {"tomli"}
 
 
 class PythonSelectorTests(unittest.TestCase):
@@ -65,12 +108,18 @@ class PythonSelectorTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 2)
-            self.assertIn(f'python3 -m venv "{workspace}/.venv"', result.stderr)
-            self.assertIn(
-                "-m pip install pandas pyarrow pyyaml huggingface_hub",
-                result.stderr,
-            )
+            self.assertIn(f'-m venv "{workspace}/.venv"', result.stderr)
+            self.assertIn("-m pip --version", result.stderr)
+            self.assertIn("-m ensurepip --upgrade", result.stderr)
+            self.assertIn(f"-m pip install {INSTALL_PACKAGES}", result.stderr)
+            self.assertIn("a global pip executable is not required", result.stderr)
             self.assertNotIn("requirements.txt", result.stderr)
+
+    def test_probe_covers_every_third_party_script_import(self) -> None:
+        selector = (SCRIPTS / "deft_python.sh").read_text(encoding="utf-8")
+        self.assertEqual(third_party_script_imports(), set(REQUIRED_IMPORT_PACKAGES))
+        for import_name in REQUIRED_IMPORT_PACKAGES:
+            self.assertIn(import_name, selector)
 
 
 class DocumentationTests(unittest.TestCase):
@@ -96,7 +145,11 @@ class DocumentationTests(unittest.TestCase):
         )
         documentation = skill + prerequisites
         self.assertNotIn("requirements.txt", documentation)
-        self.assertIn("pip install pandas pyarrow pyyaml huggingface_hub", documentation)
+        self.assertIn(f"pip install {INSTALL_PACKAGES}", documentation)
+        self.assertIn("ensurepip", documentation)
+        self.assertIn("a globally installed `pip` executable is\nnot required", documentation)
+        for package_name in REQUIRED_IMPORT_PACKAGES.values():
+            self.assertIn(package_name, documentation)
         self.assertIn("references/host-prerequisites.md", skill)
 
 

--- a/skills/applications/tao-run-deft-object-detection/references/preflight.md
+++ b/skills/applications/tao-run-deft-object-detection/references/preflight.md
@@ -50,10 +50,10 @@ Resolve everything you can before asking the user. Parameter precedence is stric
    )
    TAO_DS_IMAGE=$(
      <skill_root>/scripts/deft_python.sh \
-       <skill_bank>/scripts/resolve_versions_key.py images.tao_toolkit.data_services_nightly
+       <skill_bank>/scripts/resolve_versions_key.py images.tao_toolkit.data_services
    )
    : "${TAO_PYT_IMAGE:?versions key images.tao_toolkit.pyt did not resolve}"
-   : "${TAO_DS_IMAGE:?versions key images.tao_toolkit.data_services_nightly did not resolve}"
+   : "${TAO_DS_IMAGE:?versions key images.tao_toolkit.data_services did not resolve}"
    export TAO_PYT_IMAGE TAO_DS_IMAGE
    ```
 
@@ -62,12 +62,7 @@ Resolve everything you can before asking the user. Parameter precedence is stric
    | Env var | versions-key | Used by |
    |---|---|---|
    | `TAO_PYT_IMAGE` | `images.tao_toolkit.pyt` | `train`, `inference` |
-   | `TAO_DS_IMAGE` | `images.tao_toolkit.data_services_nightly` | `gap_analysis`, `embed`, `mine`, `kpi_analyze` |
-
-   The data-services key is `data_services_nightly`, not `data_services`: the release
-   data-services image carries neither `gap_analysis object_detection` nor
-   `tmm unique_neighbor_matching`, so two of this loop's four data-services stages cannot
-   run on it at all. Substituting the release image does not degrade the loop — it stops it.
+   | `TAO_DS_IMAGE` | `images.tao_toolkit.data_services` | `gap_analysis`, `embed`, `mine`, `kpi_analyze` |
 
    `versions.yaml` is the single place either URI is written, and step 4 resolves both from
    it, so a bump lands in one file and no document can drift from it.

--- a/skills/data/tao-analyze-detection-kpi/SKILL.md
+++ b/skills/data/tao-analyze-detection-kpi/SKILL.md
@@ -78,7 +78,7 @@ RUN_ROOT=/absolute/path/that/contains/images/annotations/and/results
 python3 skills/data/tao-analyze-detection-kpi/scripts/verify_kpi_analyze_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus all --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -137,7 +137,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-detection-kpi/SKILL.md
+++ b/skills/data/tao-analyze-detection-kpi/SKILL.md
@@ -78,7 +78,7 @@ RUN_ROOT=/absolute/path/that/contains/images/annotations/and/results
 python3 skills/data/tao-analyze-detection-kpi/scripts/verify_kpi_analyze_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus all --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -137,7 +137,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
+++ b/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-detection-kpi
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
+++ b/skills/data/tao-analyze-detection-kpi/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-detection-kpi
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -87,7 +87,7 @@ SPEC="$RESULTS_DIR/object_detection.yaml"        # spec lives beside its outputs
 RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
 GPU_COUNT=1
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -109,7 +109,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-gaps-od-map/SKILL.md
+++ b/skills/data/tao-analyze-gaps-od-map/SKILL.md
@@ -87,7 +87,7 @@ SPEC="$RESULTS_DIR/object_detection.yaml"        # spec lives beside its outputs
 RUN_ROOT=/absolute/path/that/contains/annotations/images/and/results
 GPU_COUNT=1
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -109,7 +109,7 @@ docker info > /dev/null
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-od-map
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
+++ b/skills/data/tao-analyze-gaps-od-map/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-analyze-gaps-od-map
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-analyze-gaps-vlm-bcq/SKILL.md
+++ b/skills/data/tao-analyze-gaps-vlm-bcq/SKILL.md
@@ -4,7 +4,7 @@ description: Extract false-positive and false-negative gaps from VLM binary-clas
   Use when the user asks to "analyze VLM BCQ gaps", "extract VLM false positives and false negatives", or identify failure
   cases from a predictions JSON for DEFT root-cause analysis on a binary-classification VLM workflow.
 license: Apache-2.0
-compatibility: Requires docker + nvidia-container-toolkit.
+compatibility: Requires Docker, NVIDIA Container Toolkit, and one visible GPU.
 metadata:
   author: NVIDIA Corporation
   version: "0.1.0"
@@ -61,6 +61,11 @@ Invoke the `vlm_bcq` action inside the TAO Toolkit data services container with 
 ```bash
 gap_analysis vlm_bcq -e /path/to/vlm_bcq_spec.yaml
 ```
+
+Request exactly one GPU from the selected platform (`compute_shape.gpus: 1`,
+`compute_shape.nodes: 1`). VLM BCQ gap analysis does not perform GPU compute,
+but the Data Services image always calls `nvidia-smi` and fails when no GPU is
+visible. One is a GPU count, not a device ID; the platform selects the device.
 
 After the run, surface the FP/FN counts from `kpi_gaps_report.txt` and point downstream stages at `kpi_gaps.jsonl`.
 

--- a/skills/data/tao-generate-image-embeddings/SKILL.md
+++ b/skills/data/tao-generate-image-embeddings/SKILL.md
@@ -77,7 +77,7 @@ GPU_COUNT=1
 python3 skills/data/tao-generate-image-embeddings/scripts/verify_image_embeddings_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -144,7 +144,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-generate-image-embeddings/SKILL.md
+++ b/skills/data/tao-generate-image-embeddings/SKILL.md
@@ -77,7 +77,7 @@ GPU_COUNT=1
 python3 skills/data/tao-generate-image-embeddings/scripts/verify_image_embeddings_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -144,7 +144,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
+++ b/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-generate-image-embeddings
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: [NGC_KEY]   # the pinned image is nvstaging/*, which is not public
 actions:

--- a/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
+++ b/skills/data/tao-generate-image-embeddings/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-generate-image-embeddings
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: [NGC_KEY]   # the pinned image is nvstaging/*, which is not public
 actions:

--- a/skills/data/tao-mine-nearest-neighbors/SKILL.md
+++ b/skills/data/tao-mine-nearest-neighbors/SKILL.md
@@ -68,7 +68,7 @@ GPU_COUNT=1
 python3 skills/data/tao-mine-nearest-neighbors/scripts/verify_nearest_neighbors_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services_nightly)"
+DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services)"
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -113,7 +113,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services_nightly)"
+DS_IMAGE="$(scripts/resolve_versions_key.py images.tao_toolkit.data_services)"
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-mine-nearest-neighbors/references/skill_info.yaml
+++ b/skills/data/tao-mine-nearest-neighbors/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-mine-nearest-neighbors
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-mine-nearest-neighbors/references/skill_info.yaml
+++ b/skills/data/tao-mine-nearest-neighbors/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-mine-nearest-neighbors
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-mine-od-images/SKILL.md
+++ b/skills/data/tao-mine-od-images/SKILL.md
@@ -83,7 +83,7 @@ GPU_COUNT=1
 python3 skills/data/tao-mine-od-images/scripts/verify_unique_neighbor_matching_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -147,7 +147,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-mine-od-images/SKILL.md
+++ b/skills/data/tao-mine-od-images/SKILL.md
@@ -83,7 +83,7 @@ GPU_COUNT=1
 python3 skills/data/tao-mine-od-images/scripts/verify_unique_neighbor_matching_spec.py \
   --spec "$SPEC"
 
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 
 docker run --rm --gpus "$GPU_COUNT" --ipc=host --network=host \
   -v "$RUN_ROOT:$RUN_ROOT" \
@@ -147,7 +147,7 @@ nvidia-smi -L
 2. Resolve and pull the data-services image if needed:
 
 ```bash
-DS_IMAGE=nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+DS_IMAGE=nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 docker image inspect "$DS_IMAGE" > /dev/null || docker pull "$DS_IMAGE"
 ```
 

--- a/skills/data/tao-mine-od-images/references/skill_info.yaml
+++ b/skills/data/tao-mine-od-images/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-mine-od-images
 type: data
-container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch  # versions-key: images.tao_toolkit.data_services_nightly
+container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/skills/data/tao-mine-od-images/references/skill_info.yaml
+++ b/skills/data/tao-mine-od-images/references/skill_info.yaml
@@ -1,6 +1,6 @@
 network_arch: tao-mine-od-images
 type: data
-container_image: nvcr.io/nvidia/tao/tao-toolkit:7.1.0-data-services  # versions-key: images.tao_toolkit.data_services
+container_image: nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch  # versions-key: images.tao_toolkit.data_services
 gpu_spec_key: null
 required_credentials: []
 actions:

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,7 +32,6 @@ images:
     pyt:                nvcr.io/nvstaging/tao/tao-toolkit-pyt:7.2.0-rc-53-multiarch
     deploy:             nvcr.io/nvstaging/tao/tao-toolkit-deploy:7.2.0-rc-53-multiarch
     data_services:      nvcr.io/nvstaging/tao/tao-toolkit-ds:7.2.0-rc-52-multiarch
-    data_services_nightly: nvcr.io/nvstaging/tao/tao-toolkit-ds:2026.8.10-rc-26-multiarch
     # TAO 7.1.0 has the Cosmos Reason Conv3d/vLLM import regression (NVBUG 6587006).
     cosmos_framework:   nvcr.io/nvstaging/tao/cosmos_framework:7.2.0-rc-290-multiarch
     cosmos_rl:          nvcr.io/nvstaging/tao/cosmos_rl:7.2.0-rc-290-multiarch


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->
This PR manually cherry-picks a commit from main with bug fixes for DEFT CR ITS workflow, and fixes the conflicts.
**Commit being cherry-picked:** e91a65c87e9c2368b4377bb140a3c3cdf152c2e9
**Relevant PR to main:** https://github.com/NVIDIA-TAO/tao-skill-bank/pull/196

Conflicts came from removing the data_services_nightly reference to versions.yaml (a workflow-specific reference in main to get Data Services main feature). Git got confused by the removal.

**To resolve conflicts:**
- git checkout --ours skills/data/tao-analyze-gaps-vlm-bcq/references/skill_info.yaml
- git checkout --ours versions.yaml
- git add skills/data/tao-analyze-gaps-vlm-bcq/references/skill_info.yaml versions.yaml
- git cherry-pick --continue
- Commit

**Updates specific to PR:**
- Update images based on versions.yaml in this branch: run scripts/stamp_versions.py to update the references for the DEFT CR/OD workflows. This required update to scripts/ci/render_and_validate_templates.py as part of the stamp process.
- Removed data_services_nightly reference versions.yaml to match change on main


### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->
We need this commit on the release branch for QA to test bug fixes.

### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->
This is for the 7.2.0 release branch so likely would be shown to users?

### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->


### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

Generated-by: <tool name and version>
-->
No, all me

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Add DEFT CR ITS bug fixes to release 7.2.0 branch.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->
