### PR TITLE
[TAO-0000][Bugfix] Derive Cosmos Framework Enroot test URI

### DIFF
--- a/scripts/tests/test_cosmos_skill_workflow.py
+++ b/scripts/tests/test_cosmos_skill_workflow.py
@@ -2427,10 +2427,10 @@ def test_omitted_sqsh_uses_packaged_backend_image_and_derived_cache_path(tmp_pat
     assert args.sqsh_path == str(expected_sqsh)
     assert plan["image"]["sqsh"]["conversion_required"] is True
     assert "enroot import" in plan["image"]["sqsh"]["command"]
-    assert (
-        "docker://nvcr.io#nvstaging/tao/cosmos-framework:"
-        in plan["image"]["sqsh"]["command"]
+    expected_enroot_uri = "docker://" + expected_image.replace(
+        "nvcr.io/", "nvcr.io#", 1
     )
+    assert expected_enroot_uri in plan["image"]["sqsh"]["command"]
     preflight = workflow.local_preflight(args, plan, env={"NGC_KEY": "SET"})
     assert not any(
         "source" in error or "repository" in error for error in preflight["errors"]


### PR DESCRIPTION
## Summary

- derive the expected Enroot import URI from the packaged Cosmos Framework image already loaded by the test
- remove the stale hard-coded `cosmos-framework` repository spelling so release stamps using `cosmos_framework` do not fail unrelated CI
- keep production planning behavior unchanged; the generated Enroot command already preserves the packaged image correctly

This lands the correction on `main`; it supersedes the closed release-targeted #172.

## Reproduction

On release-stamped commit `dd0fef31bc3876588af75ed12fd4e07e1d19202d`:

```text
python -m pytest -q scripts/tests/test_cosmos_skill_workflow.py::test_omitted_sqsh_uses_packaged_backend_image_and_derived_cache_path
1 failed
assert 'docker://nvcr.io#nvstaging/tao/cosmos-framework:' in "...docker://nvcr.io#nvstaging/tao/cosmos_framework:7.2.0-rc-290-multiarch"
```

## Validation

```text
# Same reproducer after the fix, using the release-stamped underscore image
1 passed in 0.50s

# Same reproducer using the current main hyphenated image
1 passed in 0.50s

python -m pytest -q scripts/tests/test_cosmos_skill_workflow.py
98 passed in 3.89s

python -m pytest -q scripts/tests/test_resolve_tao_image.py
7 passed in 2.95s

python scripts/stamp_versions.py --check
OK: all versions-key stamps match versions.yaml (3 stray warning(s)).
```
