### PR TITLE
[TAO-0000][Chore] Trim tao-run-automl SKILL.md under the 20000-char signer cap

### DIFF
--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -124,7 +124,7 @@ Collect these before runner construction:
 |---|---|
 | `model_skill` | Resolved model skill directory under `skills/models/`. Resolve user aliases such as `network_arch` to the packaged skill directory first. |
 | `network_arch` | Read from the resolved model skill metadata. |
-| `action` | Action to optimize — `train`, `evaluate`, `inference`, `distill`, `prune`, or `quantize` with a packaged schema/template. |
+| `action` | Action to optimize, usually `train`, `evaluate`, `inference`, `distill`, `prune`, or `quantize` with a packaged schema/template. |
 | `platform` | One of the supported TAO platform skills. |
 | `train_dataset` / `eval_dataset` / action inputs | Use model-specific spec keys and layout. Non-train actions may also need parent/teacher checkpoints, calibration data, or pruned artifacts. |
 | `results_root` | Local, Lustre, or S3 path appropriate for the platform. |
@@ -233,7 +233,7 @@ adjustment in `result["history"][i]["adjustments"]`.
 | `hyperband`, `asha` | Many configs, cheap early rungs; ASHA is parallel-friendly. | `max_epochs`, `reduction_factor`, optional `max_concurrent` |
 | `bohb`, `dehb` | Mixed Bayesian/evolutionary search with multi-fidelity budgets. | same rung budget fields as Hyperband |
 | `pbt` | Long training where schedules should mutate during training. | population and generation budget |
-| `llm`, `hybrid`, `autoresearch` | User explicitly wants LLM-guided search with a configured endpoint. | LLM endpoint config plus budget |
+| `llm`, `hybrid`, `autoresearch` | User explicitly wants LLM-guided search and an endpoint is configured. | LLM endpoint config plus budget |
 
 For `evaluate` or `inference`, default to Bayesian/BFBO-style search over the
 selected action's prompt, decoding, preprocessing, or runtime config knobs.

--- a/skills/applications/tao-run-automl/SKILL.md
+++ b/skills/applications/tao-run-automl/SKILL.md
@@ -25,7 +25,7 @@ tags:
 
 # TAO AutoML
 
-> **Standalone install?** If this session was not initialized by the TAO skill bank plugin, run the `tao-setup` skill first (host preflight, credentials, cross-skill discovery).
+> **Standalone install?** If this session was not initialized by the TAO skill bank plugin, run `tao-setup` first (host preflight, credentials, cross-skill discovery).
 
 Run automated hyperparameter optimization for a TAO model by combining:
 
@@ -122,11 +122,11 @@ Collect these before runner construction:
 
 | Input | Requirement |
 |---|---|
-| `model_skill` | Resolved model skill directory under `skills/models/`. Accept user aliases such as `network_arch` only after resolving them to the packaged skill directory. |
+| `model_skill` | Resolved model skill directory under `skills/models/`. Resolve user aliases such as `network_arch` to the packaged skill directory first. |
 | `network_arch` | Read from the resolved model skill metadata. |
-| `action` | Action to optimize, usually `train`, `evaluate`, `inference`, `distill`, `prune`, or `quantize` when that action has a packaged schema/template. |
+| `action` | Action to optimize — `train`, `evaluate`, `inference`, `distill`, `prune`, or `quantize` with a packaged schema/template. |
 | `platform` | One of the supported TAO platform skills. |
-| `train_dataset` / `eval_dataset` / action inputs | Use model-specific spec keys and dataset layout. Non-train actions often also require parent checkpoints, teacher checkpoints, calibration data, or pruned artifacts. |
+| `train_dataset` / `eval_dataset` / action inputs | Use model-specific spec keys and layout. Non-train actions may also need parent/teacher checkpoints, calibration data, or pruned artifacts. |
 | `results_root` | Local, Lustre, or S3 path appropriate for the platform. |
 | `gpu_count`, `num_nodes` | Respect model and platform limits. |
 | `container_image` | Resolve through model metadata and `versions.yaml`; show it to the user. |
@@ -230,10 +230,10 @@ adjustment in `result["history"][i]["adjustments"]`.
 | Algorithm | Good fit | Required knobs |
 |---|---|---|
 | `bayesian` | Default for small/medium budgets and few parameters. | `num_recommendations`, metric, direction |
-| `hyperband`, `asha` | Many configs with cheap early rungs; ASHA supports parallelism. | `max_epochs`, `reduction_factor`, optional `max_concurrent` |
+| `hyperband`, `asha` | Many configs, cheap early rungs; ASHA is parallel-friendly. | `max_epochs`, `reduction_factor`, optional `max_concurrent` |
 | `bohb`, `dehb` | Mixed Bayesian/evolutionary search with multi-fidelity budgets. | same rung budget fields as Hyperband |
 | `pbt` | Long training where schedules should mutate during training. | population and generation budget |
-| `llm`, `hybrid`, `autoresearch` | User explicitly wants LLM-guided search and has an endpoint configured. | LLM endpoint config plus budget |
+| `llm`, `hybrid`, `autoresearch` | User explicitly wants LLM-guided search with a configured endpoint. | LLM endpoint config plus budget |
 
 For `evaluate` or `inference`, default to Bayesian/BFBO-style search over the
 selected action's prompt, decoding, preprocessing, or runtime config knobs.


### PR DESCRIPTION
Unblocks repo-wide CI: `validate-skills.sh` check 3b currently fails every PR because `skills/applications/tao-run-automl/SKILL.md` is 20,040 chars, over the 20,000-char signer cap (observed on PR #209's blossom-ci and reproducible on plain main).

- Six meaning-preserving condensations (wording only, no semantic change): 19,966 chars, back under the cap.
- Longer-term the AutoML skill owner may want to move detail into `references/` per the validator's guidance — this is the minimal hotfix to turn main green again.

## Validation
- `validate-skills.sh` passes locally on the branch (check 3b no longer errors); `git diff --check` clean; single signed commit.
