### PR TITLE
[TAO-0000][Bugfix] NVBug 6642018: resolve the runtime-image digest instead of a placeholder

### DIFF
--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -2510,6 +2510,59 @@ def _source_build_image_plan(
     }
 
 
+_MODEL_PREPARATION_IMAGE_DIGEST_ENV = "TAO_COSMOS_PREPARATION_IMAGE_DIGEST"
+
+
+def _model_preparation_command_with_digest(command: Sequence[str]) -> str:
+    invocation = shlex.join([*command, "--runtime-image-digest"])
+    error = "runtime image digest was not resolved"
+    return (
+        f'{invocation} "${{{_MODEL_PREPARATION_IMAGE_DIGEST_ENV}:?{error}}}"'
+    )
+
+
+def _docker_model_preparation_command(
+    command: Sequence[str], preparation_image: str
+) -> str:
+    repo_digest_command = shlex.join(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            "{{index .RepoDigests 0}}",
+            preparation_image,
+        ]
+    )
+    image_id_command = shlex.join(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            "{{.Id}}",
+            preparation_image,
+        ]
+    )
+    digest = _MODEL_PREPARATION_IMAGE_DIGEST_ENV
+    error = shlex.quote(
+        f"ERROR: unable to resolve runtime image digest for {preparation_image!r}"
+    )
+    return "\n".join(
+        [
+            f'{digest}="$({repo_digest_command} 2>/dev/null || true)"',
+            f'if [[ -z "${{{digest}}}" || "${{{digest}}}" == "<no value>" ]]; then',
+            f'  {digest}="$({image_id_command} 2>/dev/null || true)"',
+            "fi",
+            f'if [[ -z "${{{digest}}}" || "${{{digest}}}" == "<no value>" ]]; then',
+            f"  echo {error} >&2",
+            "  exit 2",
+            "fi",
+            _model_preparation_command_with_digest(command),
+        ]
+    )
+
+
 def _model_preparation(
     args: argparse.Namespace,
     model: Mapping[str, Any],
@@ -2657,8 +2710,6 @@ def _model_preparation(
         args.cache_dir,
         "--runtime-image",
         preparation_image,
-        "--runtime-image-digest",
-        "<RESOLVE_AFTER_CLEAN_BUILD>",
     ]
     if args.base_model_revision:
         command.extend(["--base-model-revision", args.base_model_revision])
@@ -2667,7 +2718,9 @@ def _model_preparation(
             ["--vlm-architecture-model-revision", args.vlm_architecture_model_revision]
         )
     platform_action: dict[str, Any] | None = None
-    preparation_command: str | None = shlex.join(command)
+    preparation_command: str | None = _docker_model_preparation_command(
+        command, preparation_image
+    )
     if args.platform == "slurm":
         helper_host_path = str(
             Path(args.results_dir).expanduser()
@@ -2709,9 +2762,7 @@ def _model_preparation(
             "--cache-dir",
             args.container_cache_dir,
             "--runtime-image",
-            preparation_image,
-            "--runtime-image-digest",
-            "<RESOLVE_AFTER_CLEAN_BUILD>",
+            preparation_sqsh,
         ]
         if args.base_model_revision:
             container_command.extend(
@@ -2733,7 +2784,9 @@ def _model_preparation(
             "helper_host_path": helper_host_path,
             "helper_container_path": helper_container_path,
             "helper_sha256": sha256_file(script),
-            "container_command": shlex.join(container_command),
+            "container_command": _model_preparation_command_with_digest(
+                container_command
+            ),
             "output_container_path": output_container,
         }
         preparation_command = None
@@ -4860,11 +4913,31 @@ def render_slurm(args: argparse.Namespace, plan: Mapping[str, Any]) -> str:
     )
     preparation_action = plan.get("model_preparation", {}).get("platform_action")
     preparation_srun = ""
+    preparation_digest_lines: list[str] = []
     if isinstance(preparation_action, Mapping):
         preparation_sqsh = str(preparation_action.get("container_image") or "")
         preparation_native = str(preparation_action.get("container_command") or "")
         if not preparation_sqsh or not preparation_native:
             raise WorkflowError("SLURM model-preparation action is incomplete")
+        digest = _MODEL_PREPARATION_IMAGE_DIGEST_ENV
+        digest_error = shlex.quote(
+            f"ERROR: unable to resolve runtime image digest for {preparation_sqsh!r}"
+        )
+        preparation_digest_lines = [
+            (
+                "if ! preparation_image_sha256_output="
+                f'"$(sha256sum -- {shlex.quote(preparation_sqsh)} 2>/dev/null)"; then'
+            ),
+            f"  echo {digest_error} >&2",
+            "  exit 2",
+            "fi",
+            'preparation_image_sha256="${preparation_image_sha256_output%% *}"',
+            'if [[ ! "$preparation_image_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then',
+            f"  echo {digest_error} >&2",
+            "  exit 2",
+            "fi",
+            f'export {digest}="sha256:$preparation_image_sha256"',
+        ]
         preparation_wrapped = "\n".join(
             [
                 "set -Eeuo pipefail",
@@ -4886,7 +4959,10 @@ def render_slurm(args: argparse.Namespace, plan: Mapping[str, Any]) -> str:
                 f"--cpus-per-task={args.cpus_per_task}",
                 "--no-container-remap-root",
                 "--no-container-mount-home",
-                "--container-env=HF_TOKEN,HUGGING_FACE_HUB_TOKEN",
+                (
+                    "--container-env=HF_TOKEN,HUGGING_FACE_HUB_TOKEN,"
+                    f"{_MODEL_PREPARATION_IMAGE_DIGEST_ENV}"
+                ),
                 f"--container-image={shlex.quote(preparation_sqsh)}",
                 mount_args,
                 "bash -lc",
@@ -5025,6 +5101,7 @@ def render_slurm(args: argparse.Namespace, plan: Mapping[str, Any]) -> str:
             env_exports,
             'export MASTER_ADDR="$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)"',
             f"export MASTER_PORT={args.master_port}",
+            *preparation_digest_lines,
             *preparation_lines,
             "child_rc=0",
             "set +e",

--- a/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
+++ b/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -387,6 +388,105 @@ def test_slurm_renderer_creates_writable_mount_roots_before_pyxis() -> None:
     assert (
         "--container-mounts=/inputs:/data:ro,/runs/results:/results,"
         "/runs/checkpoints:/checkpoints,/runs/cache:/cache"
+    ) in script
+
+
+def _omni_preparation_args(platform: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        base_model_format="cosmos3_omni",
+        model="nvidia/Cosmos3-Nano",
+        prepared_checkpoint_path="",
+        base_model_path_or_uri="nvidia/Cosmos3-Nano",
+        base_model_revision="b" * 40,
+        checkpoint_dir="/checkpoints",
+        cache_dir="/cache",
+        container_cache_dir="/cache",
+        vlm_architecture_model_path_or_uri="Qwen/Qwen3-VL-8B-Instruct",
+        vlm_architecture_model_revision="a" * 40,
+        image_tag="registry.example.invalid/cosmos-rl:test",
+        sqsh_path="/images/cosmos-rl.sqsh" if platform == "slurm" else "",
+        platform=platform,
+        results_dir="/results",
+        tao_job_id="cosmos-reason-prepare-test",
+        experiment_id="prepare-test",
+        container_mount=[
+            "/results:/results",
+            "/checkpoints:/checkpoints",
+            "/cache:/cache",
+        ],
+    )
+
+
+def _omni_model() -> dict[str, object]:
+    return {
+        "format": "cosmos3_omni",
+        "source_type": "uri",
+        "fingerprint": "c" * 64,
+        "revision_resolution": {"repo_id": "nvidia/Cosmos3-Nano"},
+        "vlm_architecture_revision_resolution": {
+            "repo_id": "Qwen/Qwen3-VL-8B-Instruct"
+        },
+    }
+
+
+def test_docker_model_preparation_resolves_digest_without_placeholder() -> None:
+    args = _omni_preparation_args("docker")
+    _, preparation = MODULE._model_preparation(args, _omni_model(), "cosmos-rl")
+
+    command = preparation["command"]
+    assert isinstance(command, str)
+    assert "<" + "RESOLVE_AFTER_CLEAN_BUILD" + ">" not in command
+    assert command.count("--runtime-image-digest") == 1
+    assert "docker image inspect --format '{{index .RepoDigests 0}}'" in command
+    assert "docker image inspect --format '{{.Id}}'" in command
+    assert "unable to resolve runtime image digest" in command
+    syntax = subprocess.run(
+        ["bash", "-n"], input=command, text=True, capture_output=True, check=False
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
+def test_slurm_model_preparation_resolves_authoritative_sqsh_digest() -> None:
+    args = _omni_preparation_args("slurm")
+    _, preparation = MODULE._model_preparation(args, _omni_model(), "cosmos-rl")
+    action = preparation["platform_action"]
+    assert isinstance(action, dict)
+
+    container_command = action["container_command"]
+    assert "<" + "RESOLVE_AFTER_CLEAN_BUILD" + ">" not in container_command
+    assert container_command.count("--runtime-image-digest") == 1
+    assert "TAO_COSMOS_PREPARATION_IMAGE_DIGEST" in container_command
+    assert "/images/cosmos-rl.sqsh" in container_command
+
+    args.partition = "polar3"
+    args.account = "tao"
+    args.use_requeue = False
+    args.timeout = "00:10:00"
+    args.nodes = 1
+    args.gpus_per_node = 8
+    args.cpus_per_task = 64
+    args.time_limit = "00:15:00"
+    args.stdout_path = "/results/main.out"
+    args.stderr_path = "/results/main.err"
+    args.qos = ""
+    args.reservation = ""
+    args.exclusive = True
+    args.master_port = 29500
+    script = MODULE.render_slurm(
+        args,
+        {
+            "environment": {},
+            "command": "true",
+            "decoder_artifact": {"required": False, "enabled": False},
+            "model_preparation": preparation,
+        },
+    )
+
+    assert "sha256sum -- /images/cosmos-rl.sqsh" in script
+    assert "unable to resolve runtime image digest" in script
+    assert (
+        "--container-env=HF_TOKEN,HUGGING_FACE_HUB_TOKEN,"
+        "TAO_COSMOS_PREPARATION_IMAGE_DIGEST"
     ) in script
 
 


### PR DESCRIPTION
Fixes: https://nvbugspro.nvidia.com/bug/6642018

**NVBug 6642018** — QA's retest confirmed the doc side was fixed in #178; the last remaining piece is in the model skill's planner: `cosmos_workflow.py` passes the literal placeholder `<RESOLVE_AFTER_CLEAN_BUILD>` as `--runtime-image-digest` at two call sites (~L2651, ~L2704). `prepare_cosmos3_vlm_checkpoint.py` records that value verbatim into `tao_conversion_provenance.json` (`preparation_runtime.image_digest`), so checkpoints prepared through the planner path carry invalid provenance and later fail the converter's own reuse validation.

- Docker path: resolve the preparation image's actual `RepoDigests[0]` at call time (image-ID fallback for locally built images; fail closed if unresolvable).
- enroot/SLURM path: fingerprint the authoritative SQSH as the runtime-artifact digest.
- Contract test: asserts no literal placeholder survives in built commands.

## Validation
- 151 tests passed; `git diff --check` clean; single signed commit.
- `validate-skills.sh`: check 3b currently fails repo-wide on main due to the pre-existing `tao-run-automl` SKILL.md size overage — hotfix in #210; unrelated to this change.
