### PR TITLE
[TAO-0000][Bugfix] NVBug 6669758: gate the validation feature cache on supported model type

### DIFF
--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -76,6 +76,10 @@ SUPPORTED_ACTIONS = {
 PLAN_ARTIFACT_SCHEMA_VERSION = 1
 _PLAN_ARTIFACT_TRANSIENT_ARGS = {"verb", "format", "plan_artifact", "render_output"}
 DEFAULT_NANO_VLM_ARCHITECTURE_MODEL = "Qwen/Qwen3-VL-8B-Instruct"
+# Cosmos Framework implements HFModel._configure_validation_video_feature_cache
+# for these runtime model types only; every other family raises at model
+# construction. Keep this allowlist authoritative for the planner. NVBUG 6669758.
+FRAMEWORK_VALIDATION_FEATURE_CACHE_MODEL_TYPES = frozenset({"qwen3_vl"})
 
 
 def _huggingface_repo_id(value: str) -> str | None:
@@ -1481,8 +1485,14 @@ def _framework_video_runtime(
     args: argparse.Namespace,
     train_data: Mapping[str, Any],
     val_data: Mapping[str, Any],
+    runtime_model_type: str = "unknown",
 ) -> dict[str, Any]:
-    """Resolve the native Framework on-demand TorchCodec throughput profile."""
+    """Resolve the native Framework on-demand TorchCodec throughput profile.
+
+    ``runtime_model_type`` is the config.json ``model_type`` Cosmos Framework
+    will actually instantiate after model preparation. It gates the validation
+    video-feature cache; an unresolved value keeps the cache off.
+    """
     unique_media_capacity = max(
         int(train_data["profile"]["unique_media_count"]),
         int(val_data["profile"]["unique_media_count"]),
@@ -1525,9 +1535,21 @@ def _framework_video_runtime(
         raise WorkflowError(
             "Framework validation video feature cache size must be nonnegative"
         )
+    validation_feature_cache_supported = (
+        runtime_model_type in FRAMEWORK_VALIDATION_FEATURE_CACHE_MODEL_TYPES
+    )
+    if not validation_feature_cache_supported and validation_feature_cache_override:
+        raise WorkflowError(
+            "Cosmos Framework implements the validation video feature cache only "
+            "for model_type in "
+            f"{sorted(FRAMEWORK_VALIDATION_FEATURE_CACHE_MODEL_TYPES)}; the "
+            f"resolved runtime model_type is {runtime_model_type!r}. Re-plan with "
+            "--framework-validation-video-feature-cache-size 0"
+        )
     validation_feature_cache_size = (
         min(unique_media_capacity, 512)
         if validation_feature_cache_override is None
+        and validation_feature_cache_supported
         and repeated_validation_media
         and validation_shard_strategy == "media_grouped"
         else (validation_feature_cache_override or 0)
@@ -1653,6 +1675,8 @@ def _framework_video_runtime(
         ),
         "validation_video_feature_cache_scope": "rank_local_gpu_embeddings",
         "validation_video_feature_cache_population": "on_demand_during_validation",
+        "validation_video_feature_cache_model_type": runtime_model_type,
+        "validation_video_feature_cache_supported": validation_feature_cache_supported,
         "unique_media_capacity_basis": unique_media_capacity,
         "dataset_prewarm": False,
         "actual_device_attestation": "first_successful_decode_per_rank",
@@ -3933,8 +3957,15 @@ def build_plan(
         if backend == "cosmos-rl"
         else None
     )
+    framework_runtime_model_type = (
+        "qwen3_vl"
+        if model_preparation.get("kind") == "cosmos3_omni_to_exact_qwen3_vl"
+        else str(model_preparation.get("selected_input_model_type") or "unknown")
+    )
     framework_video_runtime = (
-        _framework_video_runtime(args, train_data, val_data)
+        _framework_video_runtime(
+            args, train_data, val_data, framework_runtime_model_type
+        )
         if backend == "cosmos-framework"
         else None
     )

--- a/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
+++ b/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 SCRIPT = Path(__file__).parents[1] / "scripts" / "cosmos_workflow.py"
 sys.path.insert(0, str(SCRIPT.parent))
 SPEC = importlib.util.spec_from_file_location("cosmos_workflow", SCRIPT)
@@ -568,6 +570,7 @@ def test_framework_repeated_media_auto_profile_emits_measured_validation_contrac
         args,
         train_data={"record_count": 5555, "profile": {"unique_media_count": 341}},
         val_data={"record_count": 2676, "profile": {"unique_media_count": 171}},
+        runtime_model_type="qwen3_vl",
     )
 
     assert runtime["validation_repeated_media"] is True
@@ -600,6 +603,7 @@ def test_framework_repeated_media_derives_frontload_from_user_batch() -> None:
         args,
         train_data={"record_count": 5555, "profile": {"unique_media_count": 341}},
         val_data={"record_count": 2676, "profile": {"unique_media_count": 171}},
+        runtime_model_type="qwen3_vl",
     )
 
     assert runtime["validation_batch_size"] == 16
@@ -787,3 +791,86 @@ def test_framework_validation_cache_preflight_attests_inherited_and_new_modules(
     startup = preflight["container_startup"]
     assert "/tao-patches-framework-c312482-evalval-lab-v13/modules" in startup
     assert "/tao-patches-framework-c312482-evalval-lab-v21/modules" in startup
+
+
+def test_framework_validation_feature_cache_is_gated_on_supported_model_type() -> None:
+    """NVBUG 6669758: Cosmos Framework supports the cache only for qwen3_vl.
+
+    Enabling it for cosmos3_edge aborts at model construction, so the planner
+    must not seal a nonzero size for unsupported families.
+    """
+    args = SimpleNamespace(
+        dataset_family="video_conversation",
+        run_mode="full",
+        nodes=1,
+        gpus_per_node=4,
+        validation_batch_size=1,
+        framework_validation_shard_strategy="auto",
+        framework_validation_video_feature_cache_size=None,
+        framework_validation_processed_video_cache_size=None,
+        framework_validation_cache_frontload_unique_per_batch=None,
+        framework_baked_overlay_pythonpath="",
+        framework_video_cache_size=None,
+        framework_sft_process_threads=0,
+        framework_video_decoder_threads=0,
+        framework_dataloader_num_workers=None,
+        framework_dataloader_prefetch_factor=None,
+    )
+    train_data = {"record_count": 5555, "profile": {"unique_media_count": 341}}
+    val_data = {"record_count": 2676, "profile": {"unique_media_count": 171}}
+
+    edge = MODULE._framework_video_runtime(
+        args, train_data, val_data, runtime_model_type="cosmos3_edge"
+    )
+    assert edge["validation_video_feature_cache_size"] == 0
+    assert edge["validation_cache_frontload_unique_per_batch"] == 0
+    assert edge["validation_video_feature_cache_supported"] is False
+    assert edge["validation_video_feature_cache_model_type"] == "cosmos3_edge"
+    # The gate disables only the GPU-embedding cache; grouped sharding and the
+    # processed-video cache are unrelated and must survive.
+    assert edge["validation_shard_strategy"] == "media_grouped"
+    assert edge["validation_processed_video_cache_size"] == 341
+
+    supported = MODULE._framework_video_runtime(
+        args, train_data, val_data, runtime_model_type="qwen3_vl"
+    )
+    assert supported["validation_video_feature_cache_size"] == 341
+    assert supported["validation_video_feature_cache_supported"] is True
+
+    # Unresolved family fails safe: cache off, never a model-init abort.
+    unknown = MODULE._framework_video_runtime(args, train_data, val_data)
+    assert unknown["validation_video_feature_cache_size"] == 0
+    assert unknown["validation_video_feature_cache_supported"] is False
+
+
+def test_framework_explicit_feature_cache_rejected_for_unsupported_model_type() -> None:
+    """An explicit request on an unsupported family fails at plan time.
+
+    Silently zeroing a user's explicit size would hide the incompatibility;
+    raising here replaces a post-distributed-init ChildFailedError with an
+    actionable planner error. NVBUG 6669758.
+    """
+    args = SimpleNamespace(
+        dataset_family="video_conversation",
+        run_mode="full",
+        nodes=1,
+        gpus_per_node=4,
+        validation_batch_size=1,
+        framework_validation_shard_strategy="auto",
+        framework_validation_video_feature_cache_size=512,
+        framework_validation_processed_video_cache_size=None,
+        framework_validation_cache_frontload_unique_per_batch=None,
+        framework_baked_overlay_pythonpath="",
+        framework_video_cache_size=None,
+        framework_sft_process_threads=0,
+        framework_video_decoder_threads=0,
+        framework_dataloader_num_workers=None,
+        framework_dataloader_prefetch_factor=None,
+    )
+    with pytest.raises(MODULE.WorkflowError, match="qwen3_vl"):
+        MODULE._framework_video_runtime(
+            args,
+            train_data={"record_count": 5555, "profile": {"unique_media_count": 341}},
+            val_data={"record_count": 2676, "profile": {"unique_media_count": 171}},
+            runtime_model_type="cosmos3_edge",
+        )


### PR DESCRIPTION
## NVBug 6669758

A `cosmos3_edge` fine-tune aborts during validation with a `ChildFailedError` once the planner seals a nonzero `validation_video_feature_cache_size`. The Cosmos Framework backend only implements the cached-embedding validation path for `qwen3_vl`; for other model families the cache is constructed but never populated, and the failure surfaces *after* distributed init — far from the plan that caused it.

The planner previously derived the cache size purely from the data profile (repeated media + `media_grouped` sharding), with no notion of which model family was about to consume it.

## Change

- `_framework_video_runtime()` takes `runtime_model_type`, resolved at the call site from `model_preparation`.
- The auto-derived size is sealed only for families in `FRAMEWORK_VALIDATION_FEATURE_CACHE_MODEL_TYPES` (currently `qwen3_vl`).
- An unresolved model type **fails safe to 0** rather than to the old behaviour, so a new family cannot silently inherit a broken cache.
- An *explicit* `--framework-validation-video-feature-cache-size` on an unsupported family now raises `WorkflowError` at plan time, naming the supported families, instead of being silently zeroed.

The gate is scoped to the GPU-embedding cache only. Grouped sharding and the processed-video cache are separate mechanisms that work on every family and are deliberately left untouched. The RL backend (`_rl_video_runtime`) has a byte-identical-looking block that is a different code path and is **not** modified here.

## Verification

Verified by execution, not inspection:

| case | cache | expected |
|---|---|---|
| `cosmos3_edge` | 0 | 0 |
| `qwen3_vl` | 341 | 341 (no regression) |
| unresolved | 0 | 0 (fail-safe) |

Grouped sharding stays `media_grouped` and the processed-video cache stays 341 for edge; frontload self-disables to 0; an explicit cache request on edge raises `WorkflowError` naming `qwen3_vl`.

Two new regression tests, both confirmed to **fail without the fix**. Two existing tests asserted a nonzero cache without declaring a model type — they now pass `runtime_model_type="qwen3_vl"` so they keep testing the cache derivation rather than passing via the new fail-safe path.

`scripts/validate-skills.sh` passes; 21/21 tests in the file pass, including against a merged tree with #211.