### PR TITLE
[TLT-5991][Bugfix] NVBug 6682592: resolve the NemoClaw sandbox container by label

### DIFF
--- a/integrations/nemoclaw/README.md
+++ b/integrations/nemoclaw/README.md
@@ -158,12 +158,27 @@ input tokens returned HTTP 200, and `thinking` blocks come back signed.
 | Component | Verified | Notes |
 |---|---|---|
 | NemoClaw | **v0.0.97** (`lkg`) | v0.0.97–v0.0.101 were previously blocked by an `npm audit` gate against a live advisory feed (upstream issue #8177) |
-| OpenShell CLI | **0.0.85** | pinned exactly by `nemoclaw-blueprint/blueprint.yaml` (`min == max`), so it is not a floor — 0.0.72 in earlier docs is not reproducible |
+| OpenShell CLI | **0.0.85** | pinned exactly by `nemoclaw-blueprint/blueprint.yaml` (`min == max`), so it is not a floor — 0.0.72 in earlier docs is not reproducible. **This pin is NemoClaw's, not ours, and it moves:** 0.0.72 (07-03) → 0.0.85 (07-17) → 0.0.99 (08-07) → 0.0.101 (08-10) → 0.0.106 (08-20). Upgrading NemoClaw upgrades OpenShell with it, so never assume a version observed here still holds — see the note below |
 | OpenClaw agent | **2026.7.1** (`2d2ddc4`) | the `nemoclaw onboard --agent openclaw` path; Hermes and Deep Agents are untested here |
 | Agent brain | **Claude Opus 5** (`aws/anthropic/bedrock-claude-opus-5`) | supersedes Opus 4.8; see capability note below |
 | Node | **≥ 22.19.0** | declared by `tools/mcp-tool-discovery-runtime/package.json`; the quickstart's "Node 20+" is wrong. The installer bootstraps 22.x itself |
 | Python `mcp` | **< 2** (resolves 1.29.0) | `mcp` 2.x removed `mcp.server.fastmcp`, which `server.py` imports. Pinned in this script |
 | TAO toolkit image | **7.1.0-pyt** | from the bank's `versions.yaml`; also the default `TAO_SHELL_IMAGE` for `tao_exec` |
+
+This table records what was *verified*, not what is *enforced*. Nothing here
+pins anything on our side — the versions an operator actually gets come from
+whichever NemoClaw release they installed.
+
+That distinction has already cost us one P0 (NVBug 6682592). OpenShell v0.0.88
+renamed sandbox containers from `openshell-<name>-<id>` to
+`openshell-<workspace>--<name>-<id>`, and NemoClaw's exact pin jumped 0.0.85 →
+0.0.99 on 2026-08-07, straight over it. Both setup and uninstall were matching
+that name and broke — on newer hosts only, so it looked like a flaky recurrence
+rather than a version boundary. They now resolve the container by its
+`openshell.ai/sandbox-name` label instead, which is stable across the rename.
+
+The lesson generalises: **do not re-derive OpenShell's internal conventions**
+(container names, network names, paths). Ask for them, or key off labels.
 
 ### Custom inference endpoints
 

--- a/integrations/nemoclaw/setup-tao-nemoclaw.sh
+++ b/integrations/nemoclaw/setup-tao-nemoclaw.sh
@@ -73,18 +73,36 @@ _server_arg() {
     | awk -v f="$2" 'p{print;exit} $0==f{p=1}'
 }
 
+# Running container id for a sandbox, by label — never by name.
+#
+# OpenShell stamps every sandbox container with openshell.ai/sandbox-name, and
+# has since well before this integration existed. The container *name* is an
+# internal convention that has already changed under us once: it was
+# 'openshell-<sb>-<id>' through OpenShell v0.0.87 and became
+# 'openshell-<workspace>--<sb>-<id>' in v0.0.88 (the workspace resource model),
+# which silently broke every host whose gateway got redeployed onto the newer
+# image. The label is the supported lookup; use it and stop guessing.
+_sandbox_cid() {
+  docker ps -q --filter "label=openshell.ai/sandbox-name=$1" | head -1
+}
+
+# What docker *did* return, so a lookup miss diagnoses itself instead of
+# sending the operator back to re-check onboarding.
+_sandbox_candidates() {
+  _c=$(docker ps --filter 'label=openshell.ai/sandbox-name' \
+       --format '{{.Names}}' | paste -sd' ' -)
+  printf '%s\n' "${_c:-<none>}"
+}
+
 command -v nemoclaw >/dev/null || die "nemoclaw not on PATH (use a login shell)"
 command -v docker   >/dev/null || die "docker not on PATH"
 command -v uv       >/dev/null || die "uv not on PATH"
 [ -f "$SERVER" ] || die "server.py not found next to this script"
 
 # ── 0. Resolve the sandbox container and its docker-bridge gateway ────────────
-# Name-scope the filter: a bare 'openshell' matches every sandbox's container,
-# and 'openshell-<sb>' can still match 'openshell-<sb>-local' — so match the
-# UUID-suffixed form exactly.
-CID=$(docker ps --format '{{.ID}} {{.Names}}' \
-      | awk -v p="openshell-${SB}-" '$2 ~ "^"p {print $1; exit}')
-[ -n "$CID" ] || die "no running container for sandbox '$SB' (nemoclaw list?)"
+CID=$(_sandbox_cid "$SB")
+[ -n "$CID" ] || die "no running container for sandbox '$SB' (nemoclaw list?)
+  running sandbox containers: $(_sandbox_candidates)"
 # The sandbox reaches the host at this gateway IP (== host.openshell.internal).
 # Binding the server here (not 0.0.0.0) keeps it off the LAN.
 GW=$(docker inspect "$CID" -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}')

--- a/integrations/nemoclaw/uninstall-tao-nemoclaw.sh
+++ b/integrations/nemoclaw/uninstall-tao-nemoclaw.sh
@@ -50,10 +50,13 @@ command -v nemoclaw >/dev/null || die "nemoclaw not on PATH (use a login shell)"
 command -v docker   >/dev/null || die "docker not on PATH"
 
 # ── 0. Resolve the sandbox container, if it still exists ──────────────────────
-# Same UUID-suffixed match as setup. A missing container is not an error: the
-# sandbox may already be destroyed, leaving only the host server to clean up.
-CID=$(docker ps --format '{{.ID}} {{.Names}}' \
-      | awk -v p="openshell-${SB}-" '$2 ~ "^"p {print $1; exit}' || true)
+# Same label lookup as setup — see the rationale on _sandbox_cid there. A
+# missing container is not an error: the sandbox may already be destroyed,
+# leaving only the host server to clean up. It is only *not* an error when the
+# lookup is trustworthy, though: while this matched on the container name, a
+# renamed-by-OpenShell container made uninstall silently skip every
+# sandbox-side step and report success.
+CID=$(docker ps -q --filter "label=openshell.ai/sandbox-name=$SB" | head -1 || true)
 if [ -n "$CID" ]; then
   log "sandbox=$SB container=$CID workspace=$WORKSPACE"
 else


### PR DESCRIPTION
## Problem

`setup-tao-nemoclaw.sh` aborts at step 0 on a healthy, onboarded sandbox:

```
$ ./setup-tao-nemoclaw.sh taotesting ~/workspace --restart-server
[tao-nemoclaw] ERROR: no running container for sandbox 'taotesting' (nemoclaw list?)
```

Both scripts located the sandbox container by matching an anchored name prefix,
`openshell-<sandbox>-`. That was correct when this integration was written
(2026-07-09): OpenShell's docker driver named sandbox containers
`openshell-<name>-<id>`.

[NVIDIA/OpenShell#2243](https://github.com/NVIDIA/OpenShell/pull/2243) (`5952a5a2`)
introduced the workspace resource model and changed `container_name_for_sandbox`:

```diff
-    format!("{CONTAINER_NAME_PREFIX}{truncated_name}-{id_suffix}")
+    format!("{CONTAINER_NAME_PREFIX}{workspace}--{truncated_name}-{id_suffix}")
```

It first shipped in **OpenShell v0.0.88** (v0.0.87 still emits the old form). The
anchored prefix cannot match `openshell-<workspace>--<name>-<id>`, so on any host
whose gateway has been redeployed onto v0.0.88+:

- **setup** aborts in step 0, which runs ahead of every branch — so even the
  narrow `--restart-server` path cannot run. Nothing downstream is reachable:
  no MCP server, no skills in the sandbox, no `openclaw.json` entry, no egress
  policy, so the agent never gets `tao_ls` / `tao_run`.
- **uninstall** (not in the bug report) hits the same line but fails *soft* —
  it warns and skips, so it silently leaves the skills, the `openclaw.json`
  entry and the egress policy in place while reporting success.

## Fix

Resolve by label, not by name. OpenShell stamps `openshell.ai/sandbox-name` on
every sandbox container and has since well before this integration existed —
present in v0.0.71 through `main` — so it is exact, version-portable across the
rename, and not an internal convention we have to keep chasing.

```sh
_sandbox_cid() {
  docker ps -q --filter "label=openshell.ai/sandbox-name=$1" | head -1
}
```

A lookup miss now prints the sandbox containers `docker ps` did return, so the
next mismatch diagnoses itself instead of sending the operator back to re-check
onboarding.

`openshell.ai/managed-by` is deliberately *not* part of the filter: the docker
driver only began applying it after v0.0.71, so requiring it would break the
older gateways this change is meant to keep working.

## Validation

Run on a NemoClaw host (`openshell 0.0.71`, real Docker) against containers
carrying the exact names and labels the driver emits on each side of the rename:

| | |
|---|---|
| post-v0.0.88 name, old pattern | finds nothing — reproduces the reported abort |
| post-v0.0.88 name, new lookup | resolves the correct container |
| post-v0.0.88 name + an `openshell-<sb>-local` neighbour, old pattern | resolves the **wrong** container — a latent mis-resolution the abort was masking |
| same, new lookup | still resolves the correct container |
| pre-v0.0.88 name, new lookup | resolves — no regression on older gateways |
| prefix bleed (`taotest` vs `taotesting`) | no match, as intended |
| unknown sandbox | resolves to nothing, diagnostic lists real candidates |

Both scripts also run end to end past step 0 on that host:

```
[tao-nemoclaw] sandbox=taotesting container=00fe5f00b589 bridge-gateway=172.17.0.1 workspace=/home/ubuntu/tao-workspace
```

setup then proceeds to the credentials check and uninstall to the confirmation
prompt — both unrelated to this change and expected on a bare host. With an
unknown sandbox:

```
[tao-nemoclaw] ERROR: no running container for sandbox 'nosuchsb' (nemoclaw list?)
  running sandbox containers: openshell-default--taotesting-8d3c1f92-...
```

## Notes

- NVBug 6682592 (P0-Stopper), Jira TLT-5991.
- This is a re-file of soft-deleted bug `ed5913e0`, which reported the same
  defect against a different sandbox on a different host. Consistent with the
  root cause: hosts break one at a time, as each gateway gets redeployed onto
  a v0.0.88+ cluster image.
