### PR TITLE
[TAO-1796][Docs] Add fixed CLIP PAS PA reproduction profile

### DIFF
--- a/scripts/tests/test_clip_pas_pa_profile.py
+++ b/scripts/tests/test_clip_pas_pa_profile.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Release-contract tests for the fixed CLIP PAS PA profile."""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).parents[2]
+CLIP_SKILL = REPO_ROOT / "skills/models/tao-finetune-clip"
+
+
+def _load_yaml(path: Path):
+    """Load one checked-in YAML mapping."""
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_pas_pa_profile_is_fixed_plain_training():
+    """Guard the model, method, objective, and no-AutoML boundaries."""
+    profile = _load_yaml(
+        CLIP_SKILL / "references/pas_pa_reproduction.yaml"
+    )
+    spec = profile["spec_overrides"]
+
+    assert profile["automl_policy"] == "off"
+    assert spec["model"]["type"] == "siglip2-so400m-patch16-256"
+    assert spec["peft"]["enabled"] is True
+    assert spec["peft"]["method"] == "lora"
+    assert spec["train"]["num_epochs"] == 20
+    assert spec["train"]["num_gpus"] == 8
+    assert spec["train"]["triplet_loss_weight"] == 0.0
+    assert spec["train"]["pa_loss_weight"] == 0.01232533396889774
+    assert spec["train"]["pa_margin"] == 0.1976525764912367
+    assert spec["train"]["pa_inverse_temperature"] == 1.9850472486080717
+    assert spec["train"]["pa_top_ratio"] == 0.07580481977201999
+    assert spec["train"]["checkpointer"]["monitor"] == (
+        "val/pas/overall_mAP"
+    )
+    assert spec["dataset"]["train"]["include_attribute_metadata"] is True
+    assert spec["dataset"]["val"]["metadata_match_mode"] == (
+        "scalar_plus_accessories"
+    )
+    assert spec["evaluate"]["pas_ground_truth_mode"] == (
+        "scalar_plus_accessories"
+    )
+
+
+def test_pas_pa_reference_pins_implementation_and_runtime_gate():
+    """The human procedure must identify code, image, and source override."""
+    reference = (
+        CLIP_SKILL / "references/pas-pa-reproduction.md"
+    ).read_text(encoding="utf-8")
+    skill = (CLIP_SKILL / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "https://github.com/NVIDIA-TAO/tao-pytorch/pull/118" in reference
+    assert "aed14d5c09ecfa2ad5a79d95930784f4a06658c0" in reference
+    assert "sha256:0db93f4e531c12d01d833eb654255fdfff36ee0f46bee1c6be45be502e36c8e0" in reference
+    assert "PYTHONPATH=/workspace/tao-pytorch" in reference
+    assert "references/pas-pa-reproduction.md" in skill
+
+
+def test_clip_contract_stages_optional_pas_pair_files():
+    """PAS metadata files must be expressible by the model data contract."""
+    info = _load_yaml(CLIP_SKILL / "references/skill_info.yaml")
+    train_inputs = info["actions"]["train"]["inputs"]
+    evaluate_inputs = info["actions"]["evaluate"]["inputs"]
+
+    assert train_inputs[
+        "dataset.train.datasets[0].train_pairs_file"
+    ]["optional"] is True
+    assert train_inputs[
+        "dataset.val.datasets[0].attribute_pairs_file"
+    ]["optional"] is True
+    assert evaluate_inputs[
+        "dataset.val.datasets[0].attribute_pairs_file"
+    ]["optional"] is True

--- a/skills/models/tao-finetune-clip/SKILL.md
+++ b/skills/models/tao-finetune-clip/SKILL.md
@@ -56,6 +56,13 @@ The standalone evaluate action reports the corresponding held-out metric as
 with the selected training validation metric rather than expecting a `val/`
 key from the evaluate action.
 
+PAS metadata-aware training is an explicit exception: it emits and selects
+`val/pas/overall_mAP`. When a request names PAS V3.1.1 PA/PASA loss, fixed
+partial-negative alignment, or the recorded 83.7930% test mAP run, read
+`references/pas-pa-reproduction.md` before constructing the spec. That profile
+sets `automl_policy: off`; do not route it through AutoML, substitute a 384px
+backbone, or substitute RandLoRA.
+
 ### Supported Models
 
 - **OpenCLIP / NV-CLIP:** `ViT-L-14-SigLIP-CLIPA-224` (default), `ViT-L-14-SigLIP-CLIPA-336`, `ViT-H-14-SigLIP-CLIPA-224`, `ViT-H-14-SigLIP-CLIPA-336`, `ViT-H-14-SigLIP-CLIPA-574`
@@ -185,6 +192,7 @@ Use `evaluate.trt_engine` for TensorRT evaluation and `inference.trt_engine` for
 - **train.optim.vision_lr / train.optim.text_lr**: Learning rates for the two encoders. CLIP is sensitive to high learning rates; reduce both if loss is unstable.
 - **model.freeze_vision_encoder / model.freeze_text_encoder**: Defaults are false. Freezing one encoder can help when the dataset is small or only one modality needs adaptation.
 - **train.loss_type**: `siglip` is recommended for SigLIP2 and Radio-CLIP. Use `clip` for CLIP-style softmax loss.
+- **train.pa_loss_weight / pa_margin / pa_inverse_temperature / pa_top_ratio**: Opt-in Partial-negative Alignment controls. They require a TAO PyTorch revision that contains the PA implementation; read `references/pas-pa-reproduction.md` for the pinned source and fixed PAS profile.
 - **export.encoder_type**: `combined` exports one ONNX graph. `separate` exports independent vision and text graphs.
 - **gen_trt_engine.tensorrt.data_type**: TensorRT deployment supports `fp16` and `fp32`.
 

--- a/skills/models/tao-finetune-clip/references/pas-pa-reproduction.md
+++ b/skills/models/tao-finetune-clip/references/pas-pa-reproduction.md
@@ -1,0 +1,117 @@
+# PAS V3.1.1 partial-negative alignment reproduction
+
+Use this reference only for the fixed PAS V3.1.1 SigLIP2-256 + standard LoRA
++ partial-negative alignment (PA) run. It is not an AutoML recipe and does not
+include SigLIP2-384, RandLoRA, reranking, AQE, or score fusion.
+
+PA here means only the partial-negative component from Song et al., “Dual
+alignment: Partial negative and soft-label alignment for text-to-image person
+retrieval,” Information Fusion 127 (2026), DOI
+`10.1016/j.inffus.2025.103644`. The soft-label alignment component is not
+implemented. Do not call this the paper's full method.
+
+## Pinned implementation
+
+- TAO PyTorch draft PR: https://github.com/NVIDIA-TAO/tao-pytorch/pull/118
+- Source branch: `feature/clip-pa-loss-repro-20260831`
+- Source commit: `aed14d5c09ecfa2ad5a79d95930784f4a06658c0`
+- PR base: `feature/clip-lora-dev-for-deft`
+- Tested image: `nvcr.io/nvidia/tao/tao-toolkit:6.25.11-pyt`
+- Registry digest: `sha256:0db93f4e531c12d01d833eb654255fdfff36ee0f46bee1c6be45be502e36c8e0`
+
+The current general CLIP image in `skill_info.yaml` is not evidence that these
+draft fields are installed. Before launch, import `CLIPTrainConfig` inside the
+selected runtime and verify that all four fields exist:
+
+```bash
+python - <<'PY'
+from nvidia_tao_pytorch.config.clip.default_config import CLIPTrainConfig
+fields = CLIPTrainConfig.__dataclass_fields__
+required = {
+    "pa_loss_weight",
+    "pa_margin",
+    "pa_inverse_temperature",
+    "pa_top_ratio",
+}
+missing = sorted(required - fields.keys())
+if missing:
+    raise SystemExit(f"runtime is missing PA fields: {missing}")
+print("PA runtime fields verified")
+PY
+```
+
+Until PR 118 is included in a published TAO image, mount that exact checkout
+read-only at `/workspace/tao-pytorch` and prepend it to `PYTHONPATH`. For local
+Docker this means adding:
+
+```bash
+-v /absolute/path/to/tao-pytorch:/workspace/tao-pytorch:ro \
+-e PYTHONPATH=/workspace/tao-pytorch
+```
+
+For SLURM/Pyxis, add the equivalent read-only container mount and export
+`PYTHONPATH=/workspace/tao-pytorch` in the job. The source checkout is the
+implementation; the historical `.sqsh` alone does not contain PA.
+
+## Data contract
+
+Stage one balanced PAS V3.1.1 derived dataset root with:
+
+- `images/` and `captions/`;
+- `train_list.txt` and `train_pairs.json`;
+- `val_list.txt` and `val_pairs.json`;
+- `attribute_vocab.json` and `accessory_vocab.json` beside the pair files.
+
+Keep the original train/validation/test lists unchanged. Training requires
+`dataset.train.include_attribute_metadata: true`. Validation and held-out
+evaluation both use `scalar_plus_accessories`. Select checkpoints using only
+`val/pas/overall_mAP`; never use the test split for selection.
+
+## Fixed profile
+
+Copy `pas_pa_reproduction.yaml`, replace only the data and results roots, and
+keep `automl_policy: off`. The launch spec is the nested YAML beneath
+`spec_overrides`; `automl_policy` is workflow routing metadata and must not be
+passed to `clip train`.
+
+The fixed controls are:
+
+| Control | Value |
+|---|---:|
+| Model | `siglip2-so400m-patch16-256` |
+| LoRA | standard, both towers, last 24 blocks |
+| Vision rank / alpha | 64 / 128 |
+| Text rank / alpha | 64 / 128 |
+| Epochs / GPUs | 20 / 8 |
+| Batch size | 128 per GPU |
+| PA weight | 0.01232533396889774 |
+| PA margin | 0.1976525764912367 |
+| PA inverse temperature | 1.9850472486080717 |
+| PA top ratio | 0.07580481977201999 |
+| Selection | maximum `val/pas/overall_mAP` |
+
+Launch with the normal model action after resolving the profile:
+
+```bash
+clip train -e /absolute/path/to/resolved_pas_pa.yaml
+```
+
+For evaluation, set `evaluate.checkpoint` to the selected validation
+checkpoint and use a new results directory:
+
+```bash
+clip evaluate -e /absolute/path/to/resolved_pas_pa_evaluate.yaml
+```
+
+## Historical reference
+
+The recorded run selected `model_best_002.pth`:
+
+| Split | mAP | Rank-1 | Rank-5 | Rank-10 |
+|---|---:|---:|---:|---:|
+| Validation | 85.8242% | 83.9294% | 98.1736% | 99.3848% |
+| Test | 83.7930% | 83.0727% | 97.7381% | 99.0349% |
+
+These numbers are a historical comparison, not a pass/fail tolerance. A fair
+reproduction must preserve the dataset version, split lists, metadata
+vocabularies, metric implementation, seeds, and checkpoint-selection rule.

--- a/skills/models/tao-finetune-clip/references/pas_pa_reproduction.yaml
+++ b/skills/models/tao-finetune-clip/references/pas_pa_reproduction.yaml
@@ -1,0 +1,106 @@
+# Routing metadata consumed by the skill; do not pass this key to clip train.
+automl_policy: "off"
+
+# Copy this nested mapping into the resolved TAO experiment spec.
+spec_overrides:
+  results_dir: /workspace/results/pas_pa
+  model:
+    type: siglip2-so400m-patch16-256
+    canonicalize_text: false
+    init_logit_scale: null
+    init_logit_bias: null
+  dataset:
+    seed: 42
+    pin_memory: true
+    train:
+      type: custom
+      balance_query_types: false
+      unique_caption_per_batch: false
+      include_attribute_metadata: true
+      datasets:
+      - image_dir: /workspace/data/pas/images
+        image_list_file: /workspace/data/pas/train_list.txt
+        caption_dir: /workspace/data/pas/captions
+        caption_file_suffix: .txt
+        train_pairs_file: /workspace/data/pas/train_pairs.json
+      batch_size: 128
+      num_workers: 16
+    val:
+      datasets:
+      - image_dir: /workspace/data/pas/images
+        image_list_file: /workspace/data/pas/val_list.txt
+        caption_dir: /workspace/data/pas/captions
+        caption_file_suffix: .txt
+        attribute_pairs_file: /workspace/data/pas/val_pairs.json
+      metadata_match_eval: true
+      metadata_match_mode: scalar_plus_accessories
+      batch_size: 16
+      num_workers: 4
+    augmentation:
+      scale: [0.4, 1.0]
+      color_jitter: [0.8, 0.32, 0.32, 0.32, 0.08]
+      grayscale: 0.2
+  train:
+    num_epochs: 20
+    num_gpus: 8
+    gpu_ids: [0, 1, 2, 3, 4, 5, 6, 7]
+    num_nodes: 1
+    seed: 1234
+    precision: fp16
+    distributed_strategy: ddp
+    grad_checkpointing: false
+    grad_clip_norm: 1.0
+    checkpoint_interval: 1
+    checkpoint_interval_unit: epoch
+    validation_interval: 1
+    checkpointer:
+      enable_topk: true
+      replace_periodic: true
+      monitor: val/pas/overall_mAP
+      mode: max
+      save_top_k: 1
+      filename: model_best_{epoch:03d}
+      auto_insert_metric_name: false
+    loss_type: siglip
+    siglip_loss_dist_impl: gather
+    siglip_loss_mask_mode: attribute_plus_accessory_match_positive
+    compatible_positive_weight: 0.5
+    compatible_positive_normalization: per_query
+    triplet_loss_weight: 0.0
+    pa_loss_weight: 0.01232533396889774
+    pa_margin: 0.1976525764912367
+    pa_inverse_temperature: 1.9850472486080717
+    pa_top_ratio: 0.07580481977201999
+    optim:
+      optimizer_type: adamw
+      vision_lr: 9.13971426614473e-06
+      text_lr: 2.9080338560326244e-05
+      weight_decay: 0.002249987748436666
+      betas: [0.9, 0.95]
+      eps: 1.0e-06
+      warmup_steps: 0
+      scheduler: cosine
+  peft:
+    enabled: true
+    method: lora
+    train_logit_calibration: true
+    vision:
+      mode: lora
+      target_modules: [q_proj, k_proj, v_proj, out_proj]
+      num_last_blocks: 24
+      rank: 64
+      alpha: 128
+      dropout: 0.10093809460006695
+    text:
+      mode: lora
+      target_modules: [q_proj, k_proj, v_proj, out_proj]
+      num_last_blocks: 24
+      rank: 64
+      alpha: 128
+      dropout: 0.009450008726896691
+  regularization:
+    enabled: false
+  evaluate:
+    checkpoint: null
+    batch_size: 128
+    pas_ground_truth_mode: scalar_plus_accessories

--- a/skills/models/tao-finetune-clip/references/skill_info.yaml
+++ b/skills/models/tao-finetune-clip/references/skill_info.yaml
@@ -18,6 +18,9 @@ actions:
       dataset.train.datasets[0].image_list_file:
         type: file
         optional: true
+      dataset.train.datasets[0].train_pairs_file:
+        type: file
+        optional: true
       dataset.train.wds.root_dir:
         type: folder
         optional: true
@@ -31,6 +34,9 @@ actions:
         type: folder
         optional: true
       dataset.val.datasets[0].image_list_file:
+        type: file
+        optional: true
+      dataset.val.datasets[0].attribute_pairs_file:
         type: file
         optional: true
       train.pretrained_model_path:
@@ -54,6 +60,9 @@ actions:
       dataset.val.datasets[0].caption_dir:
         type: folder
       dataset.val.datasets[0].image_list_file:
+        type: file
+        optional: true
+      dataset.val.datasets[0].attribute_pairs_file:
         type: file
         optional: true
       evaluate.checkpoint:
@@ -131,6 +140,9 @@ data_sources:
         image_list_file:
           path: image_list.txt
           optional: true
+        train_pairs_file:
+          path: train_pairs.json
+          optional: true
         caption_dir:
           path: captions.tar.gz
         caption_file_suffix:
@@ -155,6 +167,9 @@ data_sources:
         image_list_file:
           path: image_list.txt
           optional: true
+        attribute_pairs_file:
+          path: val_pairs.json
+          optional: true
         caption_dir:
           path: captions.tar.gz
         caption_file_suffix:
@@ -168,6 +183,9 @@ data_sources:
           path: images.tar.gz
         image_list_file:
           path: image_list.txt
+          optional: true
+        attribute_pairs_file:
+          path: val_pairs.json
           optional: true
         caption_dir:
           path: captions.tar.gz


### PR DESCRIPTION
## What this draft adds

- a fixed PAS V3.1.1 SigLIP2-256 + standard LoRA + PA reproduction profile;
- explicit routing to plain training with `automl_policy: "off"`;
- pinned TAO PyTorch source, commit, draft PR, historical runtime image, and immutable digest;
- a runtime field gate so an unpatched image cannot silently ignore PA settings;
- PAS train/validation pair-file inputs in the CLIP model contract;
- historical validation/test metrics and the validation-only checkpoint rule;
- release-contract tests that prevent accidental 384, RandLoRA, AutoML, split, or objective drift.

## Paired implementation

This profile is paired with NVIDIA-TAO/tao-pytorch#118 at commit `aed14d5c09ecfa2ad5a79d95930784f4a06658c0`.

Until that PR is included in a published image, the reference requires mounting the exact TAO PyTorch checkout read-only and setting `PYTHONPATH`. It explicitly states that the historical `.sqsh` alone does not contain the PA implementation.

## Terminology

The profile implements only the Partial-negative Alignment component from Song et al. It does not claim the paper's soft-label alignment component or full method.

## Validation

- `python -m pytest -q scripts/tests/test_clip_pas_pa_profile.py`: 3 passed.
- `VALIDATE_BASE_REF=origin/main bash scripts/validate-skills.sh`: passed.
- YAML parse and fixed-profile invariants: passed.
- `git diff --check`: passed.
