### PR TITLE
[TAO-0000][Bugfix] NVBug 6669758: gate the validation feature cache on supported model type

### DIFF
--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -76,6 +76,10 @@ SUPPORTED_ACTIONS = {
 PLAN_ARTIFACT_SCHEMA_VERSION = 1
 _PLAN_ARTIFACT_TRANSIENT_ARGS = {"verb", "format", "plan_artifact", "render_output"}
 DEFAULT_NANO_VLM_ARCHITECTURE_MODEL = "Qwen/Qwen3-VL-8B-Instruct"
+# Cosmos Framework implements HFModel._configure_validation_video_feature_cache
+# for these runtime model types only; every other family raises at model
+# construction. Keep this allowlist authoritative for the planner. NVBUG 6669758.
+FRAMEWORK_VALIDATION_FEATURE_CACHE_MODEL_TYPES = frozenset({"qwen3_vl"})
 
 
 def _huggingface_repo_id(value: str) -> str | None:
@@ -1481,8 +1485,14 @@ def _framework_video_runtime(
     args: argparse.Namespace,
     train_data: Mapping[str, Any],
     val_data: Mapping[str, Any],
+    runtime_model_type: str = "unknown",
 ) -> dict[str, Any]:
-    """Resolve the native Framework on-demand TorchCodec throughput profile."""
+    """Resolve the native Framework on-demand TorchCodec throughput profile.
+
+    ``runtime_model_type`` is the config.json ``model_type`` Cosmos Framework
+    will actually instantiate after model preparation. It gates the validation
+    video-feature cache; an unresolved value keeps the cache off.
+    """
     unique_media_capacity = max(
         int(train_data["profile"]["unique_media_count"]),
         int(val_data["profile"]["unique_media_count"]),
@@ -1525,9 +1535,21 @@ def _framework_video_runtime(
         raise WorkflowError(
             "Framework validation video feature cache size must be nonnegative"
         )
+    validation_feature_cache_supported = (
+        runtime_model_type in FRAMEWORK_VALIDATION_FEATURE_CACHE_MODEL_TYPES
+    )
+    if not validation_feature_cache_supported and validation_feature_cache_override:
+        raise WorkflowError(
+            "Cosmos Framework implements the validation video feature cache only "
+            "for model_type in "
+            f"{sorted(FRAMEWORK_VALIDATION_FEATURE_CACHE_MODEL_TYPES)}; the "
+            f"resolved runtime model_type is {runtime_model_type!r}. Re-plan with "
+            "--framework-validation-video-feature-cache-size 0"
+        )
     validation_feature_cache_size = (
         min(unique_media_capacity, 512)
         if validation_feature_cache_override is None
+        and validation_feature_cache_supported
         and repeated_validation_media
         and validation_shard_strategy == "media_grouped"
         else (validation_feature_cache_override or 0)
@@ -1653,6 +1675,8 @@ def _framework_video_runtime(
         ),
         "validation_video_feature_cache_scope": "rank_local_gpu_embeddings",
         "validation_video_feature_cache_population": "on_demand_during_validation",
+        "validation_video_feature_cache_model_type": runtime_model_type,
+        "validation_video_feature_cache_supported": validation_feature_cache_supported,
         "unique_media_capacity_basis": unique_media_capacity,
         "dataset_prewarm": False,
         "actual_device_attestation": "first_successful_decode_per_rank",
@@ -3986,8 +4010,15 @@ def build_plan(
         if backend == "cosmos-rl"
         else None
     )
+    framework_runtime_model_type = (
+        "qwen3_vl"
+        if model_preparation.get("kind") == "cosmos3_omni_to_exact_qwen3_vl"
+        else str(model_preparation.get("selected_input_model_type") or "unknown")
+    )
     framework_video_runtime = (
-        _framework_video_runtime(args, train_data, val_data)
+        _framework_video_runtime(
+            args, train_data, val_data, framework_runtime_model_type
+        )
         if backend == "cosmos-framework"
         else None
     )

--- a/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
+++ b/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 SCRIPT = Path(__file__).parents[1] / "scripts" / "cosmos_workflow.py"
 sys.path.insert(0, str(SCRIPT.parent))
 SPEC = importlib.util.spec_from_file_location("cosmos_workflow", SCRIPT)
@@ -668,6 +670,7 @@ def test_framework_repeated_media_auto_profile_emits_measured_validation_contrac
         args,
         train_data={"record_count": 5555, "profile": {"unique_media_count": 341}},
         val_data={"record_count": 2676, "profile": {"unique_media_count": 171}},
+        runtime_model_type="qwen3_vl",
     )
 
     assert runtime["validation_repeated_media"] is True
@@ -700,6 +703,7 @@ def test_framework_repeated_media_derives_frontload_from_user_batch() -> None:
         args,
         train_data={"record_count": 5555, "profile": {"unique_media_count": 341}},
         val_data={"record_count": 2676, "profile": {"unique_media_count": 171}},
+        runtime_model_type="qwen3_vl",
     )
 
     assert runtime["validation_batch_size"] == 16
@@ -887,3 +891,86 @@ def test_framework_validation_cache_preflight_attests_inherited_and_new_modules(
     startup = preflight["container_startup"]
     assert "/tao-patches-framework-c312482-evalval-lab-v13/modules" in startup
     assert "/tao-patches-framework-c312482-evalval-lab-v21/modules" in startup
+
+
+def test_framework_validation_feature_cache_is_gated_on_supported_model_type() -> None:
+    """NVBUG 6669758: Cosmos Framework supports the cache only for qwen3_vl.
+
+    Enabling it for cosmos3_edge aborts at model construction, so the planner
+    must not seal a nonzero size for unsupported families.
+    """
+    args = SimpleNamespace(
+        dataset_family="video_conversation",
+        run_mode="full",
+        nodes=1,
+        gpus_per_node=4,
+        validation_batch_size=1,
+        framework_validation_shard_strategy="auto",
+        framework_validation_video_feature_cache_size=None,
+        framework_validation_processed_video_cache_size=None,
+        framework_validation_cache_frontload_unique_per_batch=None,
+        framework_baked_overlay_pythonpath="",
+        framework_video_cache_size=None,
+        framework_sft_process_threads=0,
+        framework_video_decoder_threads=0,
+        framework_dataloader_num_workers=None,
+        framework_dataloader_prefetch_factor=None,
+    )
+    train_data = {"record_count": 5555, "profile": {"unique_media_count": 341}}
+    val_data = {"record_count": 2676, "profile": {"unique_media_count": 171}}
+
+    edge = MODULE._framework_video_runtime(
+        args, train_data, val_data, runtime_model_type="cosmos3_edge"
+    )
+    assert edge["validation_video_feature_cache_size"] == 0
+    assert edge["validation_cache_frontload_unique_per_batch"] == 0
+    assert edge["validation_video_feature_cache_supported"] is False
+    assert edge["validation_video_feature_cache_model_type"] == "cosmos3_edge"
+    # The gate disables only the GPU-embedding cache; grouped sharding and the
+    # processed-video cache are unrelated and must survive.
+    assert edge["validation_shard_strategy"] == "media_grouped"
+    assert edge["validation_processed_video_cache_size"] == 341
+
+    supported = MODULE._framework_video_runtime(
+        args, train_data, val_data, runtime_model_type="qwen3_vl"
+    )
+    assert supported["validation_video_feature_cache_size"] == 341
+    assert supported["validation_video_feature_cache_supported"] is True
+
+    # Unresolved family fails safe: cache off, never a model-init abort.
+    unknown = MODULE._framework_video_runtime(args, train_data, val_data)
+    assert unknown["validation_video_feature_cache_size"] == 0
+    assert unknown["validation_video_feature_cache_supported"] is False
+
+
+def test_framework_explicit_feature_cache_rejected_for_unsupported_model_type() -> None:
+    """An explicit request on an unsupported family fails at plan time.
+
+    Silently zeroing a user's explicit size would hide the incompatibility;
+    raising here replaces a post-distributed-init ChildFailedError with an
+    actionable planner error. NVBUG 6669758.
+    """
+    args = SimpleNamespace(
+        dataset_family="video_conversation",
+        run_mode="full",
+        nodes=1,
+        gpus_per_node=4,
+        validation_batch_size=1,
+        framework_validation_shard_strategy="auto",
+        framework_validation_video_feature_cache_size=512,
+        framework_validation_processed_video_cache_size=None,
+        framework_validation_cache_frontload_unique_per_batch=None,
+        framework_baked_overlay_pythonpath="",
+        framework_video_cache_size=None,
+        framework_sft_process_threads=0,
+        framework_video_decoder_threads=0,
+        framework_dataloader_num_workers=None,
+        framework_dataloader_prefetch_factor=None,
+    )
+    with pytest.raises(MODULE.WorkflowError, match="qwen3_vl"):
+        MODULE._framework_video_runtime(
+            args,
+            train_data={"record_count": 5555, "profile": {"unique_media_count": 341}},
+            val_data={"record_count": 2676, "profile": {"unique_media_count": 171}},
+            runtime_model_type="cosmos3_edge",
+        )


### PR DESCRIPTION
Manual backport of #216 (merged to `main` as `31487fc1`).

**Why manual:** the `release/7.2.0` label was added to #216 at `01:19:34Z`, eleven minutes *after* it merged at `01:08:27Z`. `.github/workflows/cherry-pick.yml` fires only on `pull_request_target: [closed]` and reads the label list from the merge event payload, so run `33457560954` took the "No release/* labels — nothing to backport" path and exited green having created nothing. There is no `labeled` trigger and no `workflow_dispatch`, and re-running replays the same empty payload — hence this PR.

**Cherry-pick:** `git cherry-pick -x 31487fc1` onto `release/7.2.0` (`feff868`). Applied clean — no conflicts, no committed conflict markers, and the `(cherry picked from commit ...)` trailer is preserved. Identical 2 files / +120 -2 as the source PR.

**Verified on this branch:**
- `scripts/validate-skills.sh` — passes
- `test_runtime_preflight_contract.py` — **21 passed, 0 failed**
- Gate behaviour re-checked on the release tree: `cosmos3_edge -> 0`, `qwen3_vl -> 341` (no regression), unresolved model type -> `0` (fail-safe)

**Pre-existing failure, not from this PR:** `scripts/stamp_versions.py --check` fails on `release/7.2.0` at `scripts/ci/render_and_validate_templates.py:49` — a stale `images.tao_toolkit.pyt` stamp pinned to `rc-53` while `versions.yaml` on this branch says `rc-60`. I confirmed it reproduces on the bare `release/7.2.0` tip with this commit reverted, and this PR does not touch that file. #215 already fixes that exact line.

@ramanathan831 — quick review please; you approved the source PR #216.