### PR TITLE
[TAO-0000][Docs] Bump the documented install pin from 7.1.0 to 7.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ changes flow from `main` into a release.
 
 The skill bank works with both Claude Code and Codex. Pick the runtime you use.
 
-**The commands below install the latest release build, `7.1.0`.** Every install
+**The commands below install the latest release build, `7.2.0`.** Every install
 path pins the marketplace to that tag, so a fresh install gets the same
 validated build every time instead of whatever `main` happens to hold. Newer
 tags appear on the [Releases page](https://github.com/NVIDIA-TAO/tao-skill-bank/releases);
@@ -39,7 +39,7 @@ work.
 In a Claude Code session, add the marketplace at the release tag and install the plugin:
 
 ```
-/plugin marketplace add NVIDIA-TAO/tao-skill-bank@7.1.0
+/plugin marketplace add NVIDIA-TAO/tao-skill-bank@7.2.0
 /plugin install tao-skills@tao-skill-bank
 ```
 
@@ -62,7 +62,7 @@ was cut.
 
 …or, if you've already cloned or extracted the repo from a zip, run
 `scripts/install-codex-agents.sh` from that directory. The script registers the
-marketplace **at the latest release tag** (`7.1.0`), installs the TAO Skill Bank
+marketplace **at the latest release tag** (`7.2.0`), installs the TAO Skill Bank
 plugin, and copies `AGENTS.md` to `~/.codex/AGENTS.md` so the TAO identity loads
 in every Codex session. It's idempotent and backs up any existing
 `~/.codex/AGENTS.md` before overwriting. Override the source with
@@ -83,7 +83,7 @@ If you'd rather drive each step yourself:
 **1. Install the plugin.** Either use the VS Code Codex extension's plugin UI (select **TAO Skill Bank**), or from the CLI:
 
 ```bash
-codex plugin marketplace add NVIDIA-TAO/tao-skill-bank@7.1.0
+codex plugin marketplace add NVIDIA-TAO/tao-skill-bank@7.2.0
 codex plugin add tao-skill-bank@tao-local-plugins
 ```
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -127,6 +127,7 @@ new release is published. After tagging release `X.Y.Z` on GitHub, update:
 |---|---|
 | [`README.md`](../README.md) | the tag in the Install section prose, the Claude Code `/plugin marketplace add NVIDIA-TAO/tao-skill-bank@X.Y.Z` block, and the manual `codex plugin marketplace add` block |
 | [`scripts/install-codex-agents.sh`](../scripts/install-codex-agents.sh) | `DEFAULT_MARKETPLACE_REF="X.Y.Z"` |
+| [`skills/core/tao-setup/scripts/install-codex-agents.sh`](../skills/core/tao-setup/scripts/install-codex-agents.sh) | packaged copy — must stay **byte-identical**, so `cp` the top-level file over it |
 
 Leave the curl one-liner pointing at `main`. It fetches the installer, and only
 the copy on `main` knows the current release tag — a copy served from tag
@@ -134,8 +135,15 @@ the copy on `main` knows the current release tag — a copy served from tag
 tags cut before this pin existed).
 
 ```bash
-grep -rn "7\.1\.0" README.md scripts/install-codex-agents.sh   # find every pin to bump
+# find every pin to bump (the packaged installer copy is easy to miss)
+grep -rn "7\.2\.0" README.md scripts/install-codex-agents.sh \
+  skills/core/tao-setup/scripts/install-codex-agents.sh
 ```
+
+`scripts/tests/test_install_codex_agents.py` enforces both halves of this: the
+packaged copy must match the top-level one byte for byte, and the tag in
+`DEFAULT_MARKETPLACE_REF` must appear in the README install commands. Run
+`pytest scripts/tests/test_install_codex_agents.py` after the bump.
 
 Verify against the published tag before merging — a pin to a tag that does not
 exist yet fails at `marketplace add` time, not in CI:

--- a/scripts/install-codex-agents.sh
+++ b/scripts/install-codex-agents.sh
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 # Latest release tag — keep in sync with the pins in README.md on every release.
-DEFAULT_MARKETPLACE_REF="7.1.0"
+DEFAULT_MARKETPLACE_REF="7.2.0"
 
 MARKETPLACE_SOURCE="${TAO_SKILL_BANK_MARKETPLACE:-https://github.com/NVIDIA-TAO/tao-skill-bank.git}"
 MARKETPLACE_REF="${TAO_SKILL_BANK_REF-$DEFAULT_MARKETPLACE_REF}"

--- a/skills/core/tao-setup/scripts/install-codex-agents.sh
+++ b/skills/core/tao-setup/scripts/install-codex-agents.sh
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 # Latest release tag — keep in sync with the pins in README.md on every release.
-DEFAULT_MARKETPLACE_REF="7.1.0"
+DEFAULT_MARKETPLACE_REF="7.2.0"
 
 MARKETPLACE_SOURCE="${TAO_SKILL_BANK_MARKETPLACE:-https://github.com/NVIDIA-TAO/tao-skill-bank.git}"
 MARKETPLACE_REF="${TAO_SKILL_BANK_REF-$DEFAULT_MARKETPLACE_REF}"


### PR DESCRIPTION
## Why

Release **7.2.0** was published on 2026-09-01, but the install instructions still pinned `7.1.0`, so new users were installing the previous release build.

## What

| File | Change |
|---|---|
| `README.md` | Install prose, Claude Code `/plugin marketplace add`, installer-script description, manual `codex plugin marketplace add` → `@7.2.0` |
| `scripts/install-codex-agents.sh` | `DEFAULT_MARKETPLACE_REF="7.2.0"` |
| `skills/core/tao-setup/scripts/install-codex-agents.sh` | packaged copy re-synced (a test asserts byte-identity) |
| `docs/maintenance.md` | bump checklist now lists the packaged copy and the tests that enforce it |

The curl one-liner stays on `main` by design — only the copy on `main` knows the current release tag.

## Checked before pinning

- Tag `7.2.0` exists on the remote.
- Tag `7.2.0` carries **no** `nvcr.io/nvstaging/*` image pin in `versions.yaml` or any `skill_info.yaml` (`main` currently has 48 such references), so the "no published tag pins an `nvstaging` image" statement added in #192 still holds.

## Verified against the published tag

In throwaway `CLAUDE_CONFIG_DIR` / `CODEX_HOME` dirs:

- Claude Code → `tao-skills` **0.1.13**, marketplace checked out at `7.2.0`
- Codex installer → `Adding marketplace ... (ref: 7.2.0)`, `tao-skill-bank` **0.1.13**, `ref = "7.2.0"` in `config.toml`

`scripts/validate-skills.sh` passes. `pytest scripts/tests` → 629 passed / 2 skipped, plus 6 failures in `test_pas_deft_platforms.py` and `test_pas_virtualenv_runtime.py` that **reproduce on clean `main`** and are unrelated to this change.

The `TAO-0000` placeholder in the title can be swapped for a real ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)