### PR TITLE
[TAO-2501][Bugfix] kpi: score the way the reference pipeline actually scores

### DIFF
--- a/skills/applications/tao-run-deft-object-detection/assets/overlays/kpi_analyze.yaml
+++ b/skills/applications/tao-run-deft-object-detection/assets/overlays/kpi_analyze.yaml
@@ -18,11 +18,14 @@ visualize.platform: local      # TAO: local. Pinned so a loop stage cannot acqui
                                # a wandb credential dependency.
 
 kpi.iou_threshold: 0.5         # TAO: 0.5
-kpi.num_recall_points: 11      # TAO: 11. 11-point interpolated AP (VOC); 101
-                               # selects COCO-style and shifts every reported AP.
-kpi.ignore_sqwidth: 40         # TAO: 0. Excludes boxes below this square-width
-                               # from scoring; 0 scores small boxes the reference
-                               # set excludes.
+kpi.num_recall_points: 101     # TAO: 11. 101-point interpolation, COCO-style, rather
+                               # than the 11-point VOC curve. Every reported AP moves
+                               # with this, so a run scored at 11 is not comparable to
+                               # one scored here.
+kpi.ignore_sqwidth: 0          # TAO: 0. Score every box, including small ones. Raising
+                               # it drops boxes below that square-width from scoring
+                               # entirely, which flatters AP by removing the hardest
+                               # detections rather than by detecting them.
 kpi.filter: false              # TAO: false
 kpi.is_internal: false         # TAO: false. True keeps only `person` and appends
                                # a Summary row, changing what the report means

--- a/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
+++ b/skills/applications/tao-run-deft-object-detection/references/scripts-and-agents.md
@@ -28,7 +28,7 @@ These replace internal container images from the reference pipeline whose script
 `assets/overlays/<stage>.yaml` holds the settings a stage needs but that do not
 vary per run. A field nobody mentions keeps whatever `default_specs` or the Hydra
 schema emitted, and TAO's default is not always the value the stage wants:
-`kpi.ignore_sqwidth` is 0 by default against the reference pipeline's 40, and the
+`kpi.ignore_sqwidth` is 0 by default and the reference pipeline agrees, and the
 only symptom of the difference is that a different set of boxes gets scored. Each
 overlay line carries TAO's default in a comment, so the cost of removing it is
 visible without diffing against a container.
@@ -39,7 +39,7 @@ visible without diffing against a container.
 | `coco_to_odvg.yaml` | `annotations convert` COCO→ODVG | formats only |
 | `codetr_inference.yaml` | pool pseudo-labelling | `num_select: 1000` (TAO 300 crowds rare classes out of the pool), `conf_threshold: 0.3`, and the ViT-L/16 architecture the checkpoint requires |
 | `grounding_dino_inference.yaml` | baseline + per-iteration inference | `conf_threshold: 0.0` (keep the full PR curve), `log_scale: auto`, `class_embed_bias: true` |
-| `kpi_analyze.yaml` | scoring | `num_recall_points: 11`, `ignore_sqwidth: 40` |
+| `kpi_analyze.yaml` | scoring | `num_recall_points: 101`, `ignore_sqwidth: 0` |
 
 `grounding_dino train` has no overlay: it is built from the full
 `assets/train_grounding_dino.yaml` template rather than emitted-then-overridden,

--- a/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
+++ b/skills/applications/tao-run-deft-object-detection/references/tao-analyze-detection-kpi.md
@@ -61,8 +61,8 @@ The resulting `kpi:` block:
 kpi:
   iou_threshold: 0.5
   conf_threshold: 0.0        # from state; the run's own setting — see below
-  num_recall_points: 11      # 11-point interpolated AP; 101 selects COCO-style
-  ignore_sqwidth: 40         # TAO emits 0, which scores smaller boxes
+  num_recall_points: 101     # COCO-style interpolation; 11 selects the VOC curve
+  ignore_sqwidth: 0          # score every box, including small ones
   filter: false
   is_internal: false
 ```
@@ -79,8 +79,8 @@ say so once, at init, and have every phase honour it.
 
 ### These values are the leaf skill's defaults too
 
-`tao-analyze-detection-kpi` ships the same `conf_threshold: 0.0`, `num_recall_points: 11`
-and `ignore_sqwidth: 40`, so delegating to it and applying this overlay agree by default.
+`tao-analyze-detection-kpi` ships the same `conf_threshold: 0.0`, `num_recall_points: 101`
+and `ignore_sqwidth: 0`, so delegating to it and applying this overlay agree by default.
 They stop agreeing on `conf_threshold` as soon as a run sets its own, which is why this
 stage passes it explicitly rather than relying on the leaf's default. Apply the overlay
 and the `--set` anyway: the agreement is a fact about the current versions, not a

--- a/skills/data/tao-analyze-detection-kpi/SKILL.md
+++ b/skills/data/tao-analyze-detection-kpi/SKILL.md
@@ -51,8 +51,8 @@ for each, so filling the template needs none of them changed:
 |---|---:|---|
 | `kpi.iou_threshold` | `0.5` | IoU at or above which a prediction counts as a true positive. |
 | `kpi.conf_threshold` | `0.5` | Predictions below this are dropped. The template uses `0.0`, which keeps the whole PR curve so a threshold can be swept afterwards without re-running inference. On the pinned image that is safe: unmatched ground truth carries a `-1.0` sentinel and lands in FN at any threshold. On a build predating that fix, `0.0` scored every missed box as a true positive — `TP` became the ground-truth count and `FN` was always 0 — so use a small positive value there. |
-| `kpi.num_recall_points` | `11` | Recall points for the interpolated PR curve. The template keeps `11` (VOC-style), matching the reference ITS pipeline. `101` selects COCO-standard sampling and reports different numbers for the same detections. |
-| `kpi.ignore_sqwidth` | `0` | Boxes narrower than this are ignored. The template uses `40`, matching the reference ITS pipeline, which never counted boxes below that. `0` scores small objects the reference excluded, so the two are not comparable. |
+| `kpi.num_recall_points` | `11` | Recall points for the interpolated PR curve. The template keeps `101` (COCO-style), matching the reference ITS pipeline. `11` selects VOC-style sampling and reports different numbers for the same detections. |
+| `kpi.ignore_sqwidth` | `0` | Boxes narrower than this are ignored. The template keeps `0`, matching the reference ITS pipeline, which scores every box. A higher value raises AP by dropping the hardest detections rather than by detecting them. |
 | `kpi.filter` | `false` | Enable source filtering. |
 | `kpi.is_internal` | `false` | When true, drops every class except `person` and appends a `Summary` row. |
 | `visualize.platform` | `local` | `local` writes a PR-curve plot into `results_dir`; `wandb` logs a run and table instead. |

--- a/skills/data/tao-analyze-detection-kpi/assets/default_kpi_analyze.yaml
+++ b/skills/data/tao-analyze-detection-kpi/assets/default_kpi_analyze.yaml
@@ -11,16 +11,18 @@ visualize:
 kpi:
   iou_threshold: 0.5
   filter: false
-  num_recall_points: 11        # TAO: 11. 11-point interpolated AP (VOC), which is what the
-                               # reference ITS pipeline these metrics are compared against uses.
-                               # 101 selects COCO-style sampling and reports different numbers.
+  num_recall_points: 101       # TAO: 11. 101-point interpolation, COCO-style, which is what
+                               # the reference ITS pipeline these metrics are compared against
+                               # uses. 11 selects the VOC curve and reports different numbers.
   conf_threshold: 0.0          # TAO: 0.5. Scores every detection the inference labels carry, so
                                # the full precision-recall curve is preserved and a threshold can
                                # be swept afterwards without re-running inference. Safe on the
                                # pinned image: unmatched ground truth uses a -1.0 sentinel, so it
                                # lands in FN at any threshold. On a build predating that fix, 0.0
                                # scored every missed box as a true positive -- use > 0 there.
-  ignore_sqwidth: 40           # TAO: 0. Drops boxes below 40px^2, matching the reference pipeline;
-                               # 0 scores small boxes the reference never counted.
+  ignore_sqwidth: 0            # TAO: 0. Scores every box, matching the reference pipeline. A
+                               # higher value drops boxes below that square-width from scoring
+                               # entirely, which raises AP by removing the hardest detections
+                               # rather than by detecting them.
   is_internal: false
 results_dir: null


### PR DESCRIPTION
## Why

`num_recall_points` and `ignore_sqwidth` were pinned at `11` and `40` — in the DEFT OD overlay and in the `tao-analyze-detection-kpi` asset — each with a comment naming the reference ITS pipeline as the authority:

> `num_recall_points: 11` … *"which is what the reference ITS pipeline these metrics are compared against uses"*
> `ignore_sqwidth: 40` … *"matching the reference pipeline"*

All seven reference specs use `101` and `0`:

```
SanTomas_HL_kpi_analyze.yaml                     recall=101 sqwidth=0
SanTomas_v3_HL_kpi_analyze.yaml                  recall=101 sqwidth=0
SanTomas_v3_held_out_HL_kpi_analyze.yaml         recall=101 sqwidth=0
SanTomas_v3_held_out_no_roi_HL_kpi_analyze.yaml  recall=101 sqwidth=0
SanTomas_v3_no_pic_HL_kpi_analyze.yaml           recall=101 sqwidth=0
SanTomas_v3_no_roi_HL_kpi_analyze.yaml           recall=101 sqwidth=0
SanTomas_v3_no_roi_no_pic_HL_kpi_analyze.yaml    recall=101 sqwidth=0
```

So the pins have contradicted their own stated authority since the skill was added.

## What

- `num_recall_points` → `101` (COCO-style interpolation), `ignore_sqwidth` → `0` (score every box).
- Applied in both places that hold the values — the workflow overlay and the leaf skill's asset — so the two still agree, which the workflow doc asserts.
- Corrected the four places the values are restated in prose, including the two comments that cited the reference incorrectly.

## Impact

**This changes every reported AP.** Numbers measured before this commit are not comparable to numbers measured after it, including the baselines quoted in earlier run reports. The change makes them comparable to the reference pipeline, which is what they were always presented as.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
