### PR TITLE
Use the native Framework checkpoint converter

### DIFF
--- a/scripts/tests/test_cosmos_skill_workflow.py
+++ b/scripts/tests/test_cosmos_skill_workflow.py
@@ -1691,6 +1691,9 @@ def test_omni_conversion_uses_platform_checkpoint_storage_and_rebinds_training_m
     )
     assert plan["prepared_model_container_path"] != str(source)
     assert preparation["preparation_sqsh_path"] == args.sqsh_path
+    assert "--backend cosmos-framework" in preparation["platform_action"][
+        "container_command"
+    ]
     workflow.write_spec(args, plan)
     workflow.verify_model_preparation_helper(args, plan)
     args.tao_job_id = "cosmos-reason-train-omni-prepare"
@@ -1780,6 +1783,31 @@ def test_checkpoint_preparation_targets_the_requested_output_directory(tmp_path)
     assert f"{output.parent}:/output" in command
 
 
+def test_framework_checkpoint_preparation_uses_native_converter(tmp_path):
+    output = tmp_path / "checkpoints" / "prepared" / "fingerprint"
+    cache = tmp_path / "cache"
+    output.parent.mkdir(parents=True)
+    cache.mkdir()
+    source = tmp_path / "source"
+    donor = tmp_path / "donor"
+    source.mkdir()
+    donor.mkdir()
+    args = SimpleNamespace(
+        backend="cosmos-framework",
+        base_model_path_or_uri=str(source),
+        base_model_revision="",
+        vlm_architecture_model_path_or_uri=str(donor),
+        vlm_architecture_model_revision="",
+        runtime_image="example/cosmos-framework:test",
+    )
+
+    command = checkpoint_preparation.command(args, output, cache)
+    shell = command[-1]
+
+    assert "python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors" in shell
+    assert "cosmos_rl" not in shell
+
+
 def test_sqsh_model_preparation_contract_reports_only_missing_entries(monkeypatch):
     results = iter(
         [
@@ -1815,6 +1843,33 @@ def test_sqsh_model_preparation_contract_reports_only_missing_entries(monkeypatc
         "cosmos_rl/model_preparation/vlm_safetensors.py",
         "opt/tao/framework-converter-runtime.json",
     ]
+
+
+def test_framework_sqsh_preparation_requires_only_native_converter(monkeypatch):
+    result = SimpleNamespace(returncode=0, stdout="", stderr="")
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return result
+
+    monkeypatch.setattr(workflow.subprocess, "run", fake_run)
+    args = SimpleNamespace(
+        ssh_key_path="/tmp/key",
+        slurm_user="user",
+        ssh_option=[],
+    )
+
+    assert workflow._remote_sqsh_missing_entries(
+        args,
+        path="/shared/cosmos-framework.sqsh",
+        host="login.example",
+        entries=workflow.FRAMEWORK_MODEL_PREPARATION_SQSH_ENTRIES,
+    ) == []
+    command = commands[0][-1]
+    assert "cosmos_framework/scripts/convert_model_to_vlm_safetensors.py" in command
+    assert "cosmos_rl/model_preparation" not in command
+    assert "framework-converter-runtime.json" not in command
 
 
 def test_sqsh_model_preparation_contract_rejects_presence_only_attestation(

--- a/skills/models/tao-finetune-cosmos-reason/SKILL.md
+++ b/skills/models/tao-finetune-cosmos-reason/SKILL.md
@@ -47,13 +47,12 @@ from history, another user, a prior job, an image, or a developer checkout.
   `cosmos3_edge` from the resolved model ID and does not present this Nano-only
   choice.
 - Do not expose Omni preparation implementation fields during normal intake.
-  For Nano, use the packaged `Qwen/Qwen3-VL-8B-Instruct` architecture mapping,
-  resolve both Hub models to immutable commits automatically, and run the
-  TAO-owned `cosmos_rl.model_preparation.vlm_safetensors` entrypoint with the
-  already selected backend image/SQSH. Both backend images must package that
-  entrypoint and its pinned native Framework conversion runtime. An explicitly
-  supplied `prepared_checkpoint_path` or donor is an advanced override: validate
-  it, but never present a route A/B choice or ask for one by default.
+  For Nano, use `Qwen/Qwen3-VL-8B-Instruct`, resolve both Hub models to
+  immutable commits, and run the selected backend's packaged converter.
+  Framework uses `cosmos_framework.scripts.convert_model_to_vlm_safetensors`;
+  Cosmos-RL uses `cosmos_rl.model_preparation.vlm_safetensors` with its pinned
+  isolated converter runtime. Validate an explicitly supplied
+  `prepared_checkpoint_path` or donor, but never ask for one by default.
 - Accept `hf_model://nvidia/Cosmos3-Nano` directly. If a gated/private model
   cannot be resolved, ask the user only to set `HF_TOKEN` in the session
   environment; never ask them to discover a SHA or provide the token value in

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-backend-operations.md
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-backend-operations.md
@@ -43,15 +43,16 @@ user’s optional branch/tag to an immutable commit and snapshots that commit to
 runtime checkpoint area. Cosmos3 Nano Omni inputs use the packaged
 `Qwen/Qwen3-VL-8B-Instruct` architecture mapping and the already selected
 backend runtime; the planner resolves both Hub identities to immutable commits.
-The selected image invokes the TAO-owned
-`cosmos_rl.model_preparation.vlm_safetensors` entrypoint. Cosmos-RL packages an
-isolated Framework converter environment pinned by the Framework repository's
-`uv.lock`; Cosmos Framework uses its native environment behind the same
-entrypoint. Its baked `/opt/tao/framework-converter-runtime.json` must attest
+The selected image invokes its backend-owned entrypoint. Cosmos Framework uses
+`cosmos_framework.scripts.convert_model_to_vlm_safetensors` directly in its
+native environment, without importing Cosmos-RL. Cosmos-RL uses the TAO-owned
+`cosmos_rl.model_preparation.vlm_safetensors` wrapper and packages an isolated
+Framework converter environment pinned by the Framework repository's `uv.lock`.
+For Cosmos-RL, the baked `/opt/tao/framework-converter-runtime.json` must attest
 `validation_mode=imported_converter_module`, which proves that the converter
 and its transitive dependencies imported in the isolated interpreter during
-the image build. Reject an existing SQSH before submit if either implementation
-or this import-level attestation is absent.
+the image build. Reject an existing SQSH before submit if the selected
+backend's entrypoint, or Cosmos-RL's import-level attestation, is absent.
 Do not ask a Cosmos-RL user for a donor checkpoint, a second backend image, or
 a second SQSH. The conversion manifest proves the common source model and
 fingerprints the prepared representation. Framework DCP evaluation uses the

--- a/skills/models/tao-finetune-cosmos-reason/references/cosmos-framework-backend.yaml
+++ b/skills/models/tao-finetune-cosmos-reason/references/cosmos-framework-backend.yaml
@@ -75,8 +75,8 @@ checkpoint:
   input: prepared_qwen3_vl_hf_safetensors
   accepted_source_inputs: [qwen3_vl_hf_safetensors, cosmos3_omni, cosmos3_edge_public_hf_snapshot]
   source_model_type_selection: explicit_for_nano
-  cosmos3_omni_preparation: shared_tao_entrypoint_with_native_framework_converter_in_selected_platform_checkpoint_storage
-  cosmos3_omni_preparation_entrypoint: cosmos_rl.model_preparation.vlm_safetensors
+  cosmos3_omni_preparation: native_framework_converter_in_selected_platform_checkpoint_storage
+  cosmos3_omni_preparation_entrypoint: cosmos_framework.scripts.convert_model_to_vlm_safetensors
   cosmos3_omni_native_converter: cosmos_framework.scripts.convert_model_to_vlm_safetensors
   runtime_input_after_preparation: qwen3_vl_hf_safetensors
   public_checkpoint_is_immutable: true

--- a/skills/models/tao-finetune-cosmos-reason/references/skill_info.yaml
+++ b/skills/models/tao-finetune-cosmos-reason/references/skill_info.yaml
@@ -71,12 +71,16 @@ workflow_contract:
     preparation_runtime:
       source: selected_backend_image_and_sqsh
       separate_user_input: forbidden
-      shared_entrypoint: cosmos_rl.model_preparation.vlm_safetensors
-      native_implementation: cosmos_framework.scripts.convert_model_to_vlm_safetensors
+      entrypoints:
+        cosmos-framework: cosmos_framework.scripts.convert_model_to_vlm_safetensors
+        cosmos-rl: cosmos_rl.model_preparation.vlm_safetensors
       sqsh_required_entries:
-        - cosmos_rl/model_preparation/vlm_safetensors.py
-        - cosmos_framework/scripts/convert_model_to_vlm_safetensors.py
-        - opt/tao/framework-converter-runtime.json
+        cosmos-framework:
+          - cosmos_framework/scripts/convert_model_to_vlm_safetensors.py
+        cosmos-rl:
+          - cosmos_rl/model_preparation/vlm_safetensors.py
+          - cosmos_framework/scripts/convert_model_to_vlm_safetensors.py
+          - opt/tao/framework-converter-runtime.json
     huggingface_revision_resolution:
       user_commit_sha_required: false
       default_requested_ref: main

--- a/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/cosmos_workflow.py
@@ -926,6 +926,9 @@ MODEL_PREPARATION_SQSH_ENTRIES = (
     "cosmos_framework/scripts/convert_model_to_vlm_safetensors.py",
     "opt/tao/framework-converter-runtime.json",
 )
+FRAMEWORK_MODEL_PREPARATION_SQSH_ENTRIES = (
+    "cosmos_framework/scripts/convert_model_to_vlm_safetensors.py",
+)
 MODEL_PREPARATION_RUNTIME_ENTRY = "opt/tao/framework-converter-runtime.json"
 MODEL_PREPARATION_RUNTIME_VALIDATION_MODE = "imported_converter_module"
 MODEL_PREPARATION_RUNTIME_ATTESTATION = (
@@ -2734,6 +2737,8 @@ def _model_preparation(
         args.cache_dir,
         "--runtime-image",
         preparation_image,
+        "--backend",
+        backend,
     ]
     if args.base_model_revision:
         command.extend(["--base-model-revision", args.base_model_revision])
@@ -2787,6 +2792,8 @@ def _model_preparation(
             args.container_cache_dir,
             "--runtime-image",
             preparation_sqsh,
+            "--backend",
+            backend,
         ]
         if args.base_model_revision:
             container_command.extend(
@@ -2854,13 +2861,6 @@ def _preflight_contract(
     )
     imports = [
         "import torch",
-        "from cosmos_rl.model_preparation.vlm_safetensors import inspect_converter_runtime",
-        "converter_runtime=inspect_converter_runtime()",
-        (
-            "assert converter_runtime['module'] == "
-            "'cosmos_framework.scripts.convert_model_to_vlm_safetensors', "
-            "'TAO_PREFLIGHT_ASSERTION_FAILED:model_preparation_runtime'"
-        ),
         "assert torch.cuda.is_available(), 'TAO_PREFLIGHT_ASSERTION_FAILED:cuda_available'",
         (
             f"assert torch.cuda.device_count() == {args.gpus_per_node}, "
@@ -2874,6 +2874,8 @@ def _preflight_contract(
             )
         imports.extend(
             [
+                "from cosmos_framework.scripts import convert_model_to_vlm_safetensors as converter_module",
+                "assert converter_module.__file__, 'TAO_PREFLIGHT_ASSERTION_FAILED:model_preparation_runtime'",
                 "import cosmos_framework",
                 "import inspect",
                 "import os",
@@ -3027,6 +3029,13 @@ def _preflight_contract(
     else:
         imports.extend(
             [
+                "from cosmos_rl.model_preparation.vlm_safetensors import inspect_converter_runtime",
+                "converter_runtime=inspect_converter_runtime()",
+                (
+                    "assert converter_runtime['module'] == "
+                    "'cosmos_framework.scripts.convert_model_to_vlm_safetensors', "
+                    "'TAO_PREFLIGHT_ASSERTION_FAILED:model_preparation_runtime'"
+                ),
                 "import cosmos_rl",
                 "import av",
                 "import inspect",
@@ -5565,6 +5574,11 @@ def local_preflight(
                     args,
                     path=preparation_sqsh,
                     host=inspection_host,
+                    entries=(
+                        FRAMEWORK_MODEL_PREPARATION_SQSH_ENTRIES
+                        if plan["backend"] == "cosmos-framework"
+                        else MODEL_PREPARATION_SQSH_ENTRIES
+                    ),
                 )
             except WorkflowError as exc:
                 errors.append(str(exc))

--- a/skills/models/tao-finetune-cosmos-reason/scripts/prepare_cosmos3_vlm_checkpoint.py
+++ b/skills/models/tao-finetune-cosmos-reason/scripts/prepare_cosmos3_vlm_checkpoint.py
@@ -23,7 +23,18 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_NANO_VLM_ARCHITECTURE_MODEL = "Qwen/Qwen3-VL-8B-Instruct"
-CONVERTER_ENTRYPOINT_MODULE = "cosmos_rl.model_preparation.vlm_safetensors"
+CONVERTER_ENTRYPOINT_MODULES = {
+    "cosmos-framework": "cosmos_framework.scripts.convert_model_to_vlm_safetensors",
+    "cosmos-rl": "cosmos_rl.model_preparation.vlm_safetensors",
+}
+
+
+def converter_entrypoint(args: argparse.Namespace) -> str:
+    backend = getattr(args, "backend", "cosmos-rl")
+    try:
+        return CONVERTER_ENTRYPOINT_MODULES[backend]
+    except KeyError as exc:
+        raise ValueError(f"unsupported Cosmos preparation backend: {backend!r}") from exc
 
 
 def sha256(path: Path) -> str:
@@ -115,7 +126,8 @@ def command(args: argparse.Namespace, output: Path, cache: Path) -> list[str]:
     architecture_input = huggingface_model_id(args.vlm_architecture_model_path_or_uri)
     source_mount, source = docker_mount(source_input, "/inputs/base")
     donor_mount, donor = docker_mount(architecture_input, "/inputs/architecture")
-    script = r"""
+    entrypoint = converter_entrypoint(args)
+    script = f"""
 set -Eeuo pipefail
 source_value="$BASE_MODEL"
 architecture_value="$ARCHITECTURE_MODEL"
@@ -135,7 +147,7 @@ print(snapshot_download(os.environ['ARCHITECTURE_MODEL'], revision=os.environ['A
 PY
 )"
 fi
-python -m cosmos_rl.model_preparation.vlm_safetensors \
+python -m {entrypoint} \
   --checkpoint-path "$source_value" --output-path "/output/$OUTPUT_NAME" \
   --vlm-model-name "$architecture_value"
 """
@@ -220,7 +232,7 @@ def inside_container_command(
     return [
         sys.executable,
         "-m",
-        CONVERTER_ENTRYPOINT_MODULE,
+        converter_entrypoint(args),
         "--checkpoint-path",
         source,
         "--output-path",
@@ -232,6 +244,12 @@ def inside_container_command(
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend",
+        choices=tuple(CONVERTER_ENTRYPOINT_MODULES),
+        default="cosmos-rl",
+        help="Selected backend whose packaged converter must be used.",
+    )
     parser.add_argument("--base-model-path-or-uri", required=True)
     parser.add_argument("--base-model-revision", default="")
     parser.add_argument(

--- a/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
+++ b/skills/models/tao-finetune-cosmos-reason/tests/test_runtime_preflight_contract.py
@@ -782,7 +782,9 @@ def test_framework_v12_preflight_requires_finite_validation_stream() -> None:
     )
 
     startup = preflight["container_startup"]
-    assert "inspect_converter_runtime" in startup
+    assert "cosmos_framework.scripts" in startup
+    assert "convert_model_to_vlm_safetensors" in startup
+    assert "cosmos_rl.model_preparation" not in startup
     assert "TAO_PREFLIGHT_ASSERTION_FAILED:model_preparation_runtime" in startup
     assert "framework_finite_validation_stream" in startup
     assert "evalval-lab-v10/modules" in startup


### PR DESCRIPTION
## Summary

- select the Cosmos3 Omni checkpoint converter from the resolved backend
- invoke `cosmos_framework.scripts.convert_model_to_vlm_safetensors` directly for the `cosmos-framework` backend
- preserve the isolated `cosmos_rl.model_preparation.vlm_safetensors` wrapper and attestation for `cosmos-rl`
- make Framework SQSH validation require only the native converter, with no Cosmos-RL package dependency
- leave all packaged image pins unchanged

This is the model-skill prerequisite for the Framework-only DEFT AOI route in #225; it is intentionally separate from that application rewrite.

## Reproduction

On untouched `main` (`52b975f6329ffdfb32d5550349a79dca542899e3`), constructing the preparation command for `backend=cosmos-framework` emitted:

```text
python -m cosmos_rl.model_preparation.vlm_safetensors
```

The deterministic reproducer exited 1 because a Framework preparation still required Cosmos-RL.

## Verification

- Same command-construction reproducer: exit 0; emits `python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors` and contains no `cosmos_rl`
- `python -m pytest -q scripts/tests/test_cosmos_skill_workflow.py skills/models/tao-finetune-cosmos-reason/tests` — 142 passed
- `scripts/validate-skills.sh` — passed
- Combined with PR #225 in a clean detached worktree — 213 passed, 22 subtests passed
