### PR TITLE
feat(data): prepare normalized AnomalyGenNext FN plans

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,7 @@
       "strict": true,
       "skills": [
         "./skills/data/tao-generate-anomalies",
+        "./skills/data/tao-prepare-anomalygennext-inputs",
         "./skills/applications/tao-run-automl-deft-pipeline",
         "./skills/applications/tao-train-single-step",
         "./skills/applications/tao-analyze-changenet-rca",

--- a/skills/data/tao-prepare-anomalygennext-inputs/SKILL.md
+++ b/skills/data/tao-prepare-anomalygennext-inputs/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tao-prepare-anomalygennext-inputs
+description: >-
+  Prepare normalized object-detection false negatives, source masks, and clean-image
+  embedding inputs for AnomalyGenNext. Use when turning box-level FN gaps into a
+  frozen, pair-preserving preparation plan. Do not use for training or generation.
+license: Apache-2.0
+compatibility: Requires the AnomalyGenNext 1.1 image, pandas, pyarrow, NumPy, Pillow, and PyYAML.
+metadata:
+  author: NVIDIA Corporation
+  version: "0.1.0"
+allowed-tools: Read Bash
+tags: [tao, data, anomalygen-next, object-detection, input-preparation]
+---
+
+# Prepare AnomalyGenNext Inputs
+
+This first action freezes eligible false-negative identities, isolates each FN
+mask to its bounding box, selects one deterministic same-type mask, and emits
+the clean and FN embedding specs. It neither computes embeddings nor runs AMP.
+
+## Input contract
+
+Start from `assets/default_filtering.yaml`. The gap parquet must contain:
+
+```text
+image_id filepath gap_type bbox class split
+dataset_id texture_id defect_class anomaly_type fn_mask_source
+```
+
+Identity is explicit: `anomaly_type` must equal
+`texture_id+defect_class`. Preparation intentionally has no filename or
+directory-layout inference. A caller adapting an unfamiliar dataset must
+normalize these fields before this boundary.
+
+Each selected dataset maps to an existing fine-tuned checkpoint and recipe.
+The recipe must declare the exact anomaly type, and `defect_spec.jsonl` must
+contain its placement definition. Text-routed definitions require a nonempty
+`roi_prompt_defect_location`. The pool layout is:
+
+```text
+POOL/TEXTURE/clean_image/*
+POOL/TEXTURE/mask/DEFECT/*
+```
+
+## Action
+
+Run through the selected platform after the common launch review:
+
+```bash
+scripts/prepare_anomalygennext_inputs.py \
+  --config /path/to/filtering.yaml \
+  --output-dir /new/result/root
+```
+
+The output root must not exist. The action emits `fn_queries.parquet`,
+`selected_fn_queries.parquet`, `mask_selection.parquet`, `clean_pool.parquet`,
+two `tao-generate-image-embeddings` specs, the copied filtering config, and
+`input_contract.json`.
+
+## Gates
+
+- Preserve each box-level FN as a distinct `fn_id`.
+- Produce exactly two masks per FN: isolated FN and deterministic same-type.
+- Embed a repeated source image once while preserving every FN query row.
+- Never infer an anomaly type or placement prompt.
+- Refuse output reuse and never mutate a training pool.
+- Platform skills own transient staging, caches, and copy-back.
+
+Read `references/input-contract.md` when authoring the normalized parquet or
+dataset mapping.

--- a/skills/data/tao-prepare-anomalygennext-inputs/assets/default_filtering.yaml
+++ b/skills/data/tao-prepare-anomalygennext-inputs/assets/default_filtering.yaml
@@ -1,0 +1,34 @@
+# Copy this file and replace every /path/to value before running.
+# Optional opaque provenance label; no policy is inferred from this value.
+source_tag: user_provided
+gap_parquet: /path/to/box_gaps.parquet
+pool_dataset_root: /path/to/anomalygen_dataset
+# Required. Each text-routed defect must include a non-empty
+# roi_prompt_defect_location in this JSONL.
+defect_spec: /path/to/anomalygen_dataset/defect_spec.jsonl
+
+datasets:
+  example:
+    # The normalized FN rows carry dataset/type/mask identities. The recipe
+    # proves supported anomaly types; the checkpoint is frozen provenance.
+    checkpoint: /path/to/checkpoints/model/iter_000001000.pt
+    recipe: /path/to/exp_texture_ft.yaml
+
+selection:
+  mode: per_dataset
+  datasets: [example]
+  split: kpi
+  per_dataset: 1
+  mask_sample_seed: 42
+
+embedding:
+  model: SigLIP
+  model_path: google/siglip-base-patch16-224
+  batch_size: 64
+
+retrieval:
+  metric: cosine
+  candidate_topn: 15
+  max_neighbors_per_fn: 5
+  min_similarity: 0.9
+  prior_clean_exclusion_manifest: ""

--- a/skills/data/tao-prepare-anomalygennext-inputs/evals/evals.json
+++ b/skills/data/tao-prepare-anomalygennext-inputs/evals/evals.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "prepare-fn-driven-inputs",
+    "question": "Identify the skill and outline how it prepares normalized OD false negatives for AnomalyGenNext embeddings. Do not run commands, scripts, or web searches.",
+    "expected_skill": "tao-prepare-anomalygennext-inputs",
+    "ground_truth": "Select this skill, require explicit dataset/type/mask identity plus a defect spec and existing checkpoint/recipe, preserve box-level FN identity and two masks per FN, and leave embedding execution and AMP to later actions.",
+    "expected_behavior": [
+      "Select tao-prepare-anomalygennext-inputs",
+      "Require normalized identity rather than path inference",
+      "Describe the two emitted embedding specs",
+      "Keep embedding execution and AMP separate",
+      "Require the fine-tuned checkpoint, matching recipe, and text placement prompts"
+    ],
+    "expected_script": "scripts/prepare_anomalygennext_inputs.py"
+  }
+]

--- a/skills/data/tao-prepare-anomalygennext-inputs/references/input-contract.md
+++ b/skills/data/tao-prepare-anomalygennext-inputs/references/input-contract.md
@@ -1,0 +1,24 @@
+# Normalized AnomalyGenNext preparation contract
+
+The preparation leaf accepts normalized identity instead of legacy path rules.
+The producer must freeze `dataset_id`, `texture_id`, `defect_class`,
+`anomaly_type`, and `fn_mask_source` on every gap row before launch.
+
+`bbox` is `[x1, y1, x2, y2]` in source-image pixels. `fn_mask_source` must be a
+same-size pixel mask; a detector box is not a replacement. `split` is an opaque
+selection bucket such as `kpi` or `test`.
+
+The YAML `datasets` mapping assigns each `dataset_id` an existing checkpoint
+and recipe. This action verifies that both files exist and that the recipe's
+`anomaly_types` contains the normalized `TEXTURE+TYPE`. A later synthesis
+integration may resolve those two paths from a completed fine-tuning handoff,
+but they must be concrete before invoking this leaf.
+
+Selection supports:
+
+- `all_eligible`: every eligible FN in the listed datasets.
+- `per_dataset`: the first deterministic `per_dataset` rows from the named
+  `split` for each listed dataset.
+
+The same frozen encoder identity is written to both embedding specs. The next
+action must use those specs unchanged so clean and FN vectors remain comparable.

--- a/skills/data/tao-prepare-anomalygennext-inputs/references/skill_info.yaml
+++ b/skills/data/tao-prepare-anomalygennext-inputs/references/skill_info.yaml
@@ -1,0 +1,31 @@
+network_arch: tao-prepare-anomalygennext-inputs
+type: data
+container_image: nvcr.io/nvidia/paidf-anomalygen:1.1.0  # versions-key: images.metropolis_sdg.anomalygen_next
+execution_environment: container
+gpu_spec_key: null
+required_credentials: []
+optional_credentials:
+- name: NGC_KEY
+  source: env_var
+  only_when: the selected platform requires authenticated access to nvcr.io
+actions:
+  prepare_plan:
+    command: scripts/prepare_anomalygennext_inputs.py
+    mode: args
+    inputs:
+      config:
+        type: file
+    outputs:
+      results_dir:
+        type: folder
+      clean_embedding_spec:
+        type: file
+      fn_embedding_spec:
+        type: file
+      selected_fn_queries:
+        type: file
+    upload_excludes:
+    - inputs/
+    args:
+      config: --config {config}
+      output_dir: --output-dir {results_dir}

--- a/skills/data/tao-prepare-anomalygennext-inputs/scripts/prepare_anomalygennext_inputs.py
+++ b/skills/data/tao-prepare-anomalygennext-inputs/scripts/prepare_anomalygennext_inputs.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Freeze FN masks and embedding inputs for AnomalyGenNext preparation."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yaml
+from PIL import Image
+
+
+IMAGE_SUFFIXES = {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff"}
+IDENTITY_COLUMNS = {
+    "dataset_id", "texture_id", "defect_class", "anomaly_type", "fn_mask_source"
+}
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _stable_id(*values: Any) -> str:
+    text = "\0".join(str(value) for value in values)
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+def _images(root: Path) -> list[Path]:
+    return sorted(path.resolve() for path in root.iterdir() if path.suffix.lower() in IMAGE_SUFFIXES)
+
+
+def _defect_specs(path: Path) -> dict[str, dict[str, Any]]:
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    result: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        name = str(row.get("defect_type") or row.get("anomaly_type") or row.get("name") or "").strip()
+        if not name or name in result:
+            raise ValueError("defect_spec rows need unique anomaly_type values")
+        if row.get("spatial_dependency") == "text" and not str(
+            row.get("roi_prompt_defect_location") or ""
+        ).strip():
+            raise ValueError(f"text-routed defect lacks roi_prompt_defect_location: {name}")
+        result[name] = row
+    return result
+
+
+def _recipe_types(path: Path) -> set[str]:
+    value = yaml.safe_load(path.read_text())
+    rows = value.get("anomaly_types") if isinstance(value, dict) else None
+    if not isinstance(rows, list):
+        raise ValueError(f"recipe lacks anomaly_types: {path}")
+    return {f"{row[0]}+{row[1]}" for row in rows if isinstance(row, list) and len(row) == 2}
+
+
+def _isolate_mask(mask_path: Path, image_path: Path, bbox: Any, output: Path) -> None:
+    with Image.open(image_path) as image, Image.open(mask_path) as mask_image:
+        mask = np.asarray(mask_image.convert("L"))
+        if mask.shape != (image.height, image.width):
+            raise ValueError(f"mask/image dimensions differ: {mask_path}")
+    box = np.asarray(bbox, dtype=float).reshape(-1)
+    if box.size != 4 or not np.isfinite(box).all():
+        raise ValueError(f"invalid bbox: {bbox!r}")
+    x1, y1, x2, y2 = box
+    x1, y1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
+    x2, y2 = min(mask.shape[1], int(np.ceil(x2))), min(mask.shape[0], int(np.ceil(y2)))
+    if x2 <= x1 or y2 <= y1:
+        raise ValueError(f"empty clipped bbox: {bbox!r}")
+    isolated = np.zeros_like(mask)
+    isolated[y1:y2, x1:x2] = mask[y1:y2, x1:x2]
+    if not np.any(isolated):
+        raise ValueError(f"FN bbox contains no mask pixels: {mask_path}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(isolated).save(output)
+
+
+def _select(rows: pd.DataFrame, selection: dict[str, Any]) -> pd.DataFrame:
+    datasets = [str(value) for value in selection.get("datasets", [])]
+    eligible = rows[rows.dataset_id.astype(str).isin(datasets)].copy()
+    eligible = eligible.sort_values(["dataset_id", "image_id", "filepath", "fn_id"])
+    mode = selection.get("mode", "all_eligible")
+    if mode == "all_eligible":
+        selected = eligible
+    elif mode == "per_dataset":
+        split, count = str(selection["split"]), int(selection.get("per_dataset", 1))
+        selected = pd.concat(
+            [eligible[(eligible.dataset_id == name) & (eligible.split == split)].head(count)
+             for name in datasets], ignore_index=True
+        )
+        if any(len(eligible[(eligible.dataset_id == name) & (eligible.split == split)]) < count
+               for name in datasets):
+            raise ValueError("not enough eligible FNs for per_dataset selection")
+    else:
+        raise ValueError(f"unsupported selection.mode: {mode}")
+    if selected.empty:
+        raise ValueError("selection produced no eligible false negatives")
+    return selected.reset_index(drop=True)
+
+
+def prepare(config_path: Path, output: Path) -> dict[str, Any]:
+    if output.exists():
+        raise FileExistsError(f"refusing to overwrite output: {output}")
+    config = yaml.safe_load(config_path.read_text())
+    if not isinstance(config, dict):
+        raise ValueError("config must be a YAML mapping")
+    gaps = pd.read_parquet(Path(config["gap_parquet"]).expanduser().resolve())
+    required = {"image_id", "filepath", "gap_type", "bbox", "class", "split"} | IDENTITY_COLUMNS
+    missing = sorted(required - set(gaps.columns))
+    if missing:
+        raise ValueError(f"gap parquet lacks normalized columns: {missing}")
+    gaps = gaps[gaps.gap_type.astype(str).str.upper().eq("FN")].copy()
+    specs = _defect_specs(Path(config["defect_spec"]).expanduser().resolve())
+    pool_root = Path(config["pool_dataset_root"]).expanduser().resolve()
+    datasets = config.get("datasets") or {}
+    recipe_types: dict[str, set[str]] = {}
+    for name, dataset in datasets.items():
+        checkpoint = Path(dataset["checkpoint"]).expanduser().resolve()
+        recipe = Path(dataset["recipe"]).expanduser().resolve()
+        if not checkpoint.is_file() or not recipe.is_file():
+            raise FileNotFoundError(f"dataset {name} checkpoint/recipe is missing")
+        recipe_types[str(name)] = _recipe_types(recipe)
+
+    normalized: list[dict[str, Any]] = []
+    for row in gaps.to_dict("records"):
+        dataset, texture = str(row["dataset_id"]), str(row["texture_id"])
+        defect, anomaly = str(row["defect_class"]), str(row["anomaly_type"])
+        if dataset not in datasets or anomaly != f"{texture}+{defect}":
+            continue
+        image = Path(str(row["filepath"])).expanduser().resolve()
+        mask = Path(str(row["fn_mask_source"])).expanduser().resolve()
+        clean_dir = pool_root / texture / "clean_image"
+        sampled_dir = pool_root / texture / "mask" / defect
+        if anomaly not in specs or anomaly not in recipe_types[dataset]:
+            continue
+        if not image.is_file() or not mask.is_file() or not clean_dir.is_dir() or not sampled_dir.is_dir():
+            continue
+        if not _images(clean_dir) or not _images(sampled_dir):
+            continue
+        bbox_json = json.dumps(np.asarray(row["bbox"]).reshape(-1).tolist(), separators=(",", ":"))
+        normalized.append({**row, "filepath": str(image), "fn_mask_source": str(mask),
+                           "clean_dir": str(clean_dir), "sampled_dir": str(sampled_dir),
+                           "bbox_json": bbox_json,
+                           "fn_id": "fn-" + _stable_id(dataset, row["image_id"], image, bbox_json)})
+    if not normalized:
+        raise ValueError("no eligible normalized false negatives")
+    selected = _select(pd.DataFrame(normalized), config["selection"])
+
+    root = output / "prepared_anomalygennext_inputs"
+    manifests, specs_dir = output / "manifests", output / "specs"
+    masks_root = root / "source_masks"
+    for directory in (manifests, specs_dir, masks_root):
+        directory.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(config_path, root / "filtering_config.yaml")
+    mask_rows, query_rows, clean_rows = [], [], []
+    clean_seen: set[tuple[str, str]] = set()
+    sampled_used: dict[str, set[Path]] = defaultdict(set)
+    seed = int(config["selection"].get("mask_sample_seed", 42))
+    for order, row in selected.iterrows():
+        fn_id, anomaly = str(row.fn_id), str(row.anomaly_type)
+        mask_dir = masks_root / fn_id
+        isolated = mask_dir / f"{fn_id}__fn_mask.png"
+        _isolate_mask(Path(row.fn_mask_source), Path(row.filepath), row.bbox, isolated)
+        candidates = _images(Path(row.sampled_dir))
+        rng = random.Random(int(_stable_id(seed, fn_id), 16))
+        available = [path for path in candidates if path not in sampled_used[anomaly]] or candidates
+        sampled = available[rng.randrange(len(available))]
+        sampled_used[anomaly].add(sampled)
+        sampled_output = mask_dir / f"{fn_id}__same_type_sampled_mask.png"
+        with Image.open(sampled) as image:
+            image.convert("L").save(sampled_output)
+        for branch, path in (("fn_mask", isolated), ("same_type_sampled_mask", sampled_output)):
+            mask_rows.append({"fn_id": fn_id, "query_order": order, "dataset_id": row.dataset_id,
+                              "anomaly_type": anomaly, "branch": branch, "mask_path": str(path)})
+        query_rows.append({"filepath": row.filepath, "fn_id": fn_id, "query_order": order,
+                           "dataset_id": row.dataset_id, "pool_key": row.texture_id,
+                           "anomaly_type": anomaly, "od_category": row["class"]})
+        for clean in _images(Path(row.clean_dir)):
+            key = (str(clean), anomaly)
+            if key not in clean_seen:
+                clean_seen.add(key)
+                clean_rows.append({"filepath": str(clean), "dataset_id": row.dataset_id,
+                                   "pool_key": row.texture_id,
+                                   "anomaly_type_eligibility": anomaly})
+    selected.to_parquet(manifests / "fn_queries.parquet", index=False)
+    query_frame = pd.DataFrame(query_rows)
+    query_frame.to_parquet(manifests / "selected_fn_queries.parquet", index=False)
+    query_frame.drop_duplicates("filepath").to_parquet(
+        manifests / "fn_embedding_inputs.parquet", index=False
+    )
+    pd.DataFrame(mask_rows).to_parquet(manifests / "mask_selection.parquet", index=False)
+    clean_frame = pd.DataFrame(clean_rows)
+    clean_frame.to_parquet(manifests / "clean_pool.parquet", index=False)
+    embedding = config["embedding"]
+    for name, input_path in (("clean", manifests / "clean_pool.parquet"),
+                             ("fn", manifests / "fn_embedding_inputs.parquet")):
+        spec = {"input_parquet": str(input_path),
+                "output_parquet": str(output / "embeddings" / f"{name}_embeddings.parquet"),
+                "model": embedding["model"], "model_path": embedding["model_path"],
+                "model_config_path": "", "batch_size": int(embedding.get("batch_size", 64))}
+        (specs_dir / f"{name}_embeddings.yaml").write_text(yaml.safe_dump(spec, sort_keys=False))
+    contract = {"status": "COMPLETE", "source_tag": config.get("source_tag", "user_provided"),
+                "selected_fn_count": len(selected), "clean_image_count": len(clean_frame),
+                "source_mask_count": len(mask_rows), "training_pool_mutated": False}
+    _write_json(root / "input_contract.json", contract)
+    return contract
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+    print(json.dumps(prepare(Path(args.config).resolve(), Path(args.output_dir).resolve()), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_prepare_anomalygennext_inputs.py
+++ b/skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_prepare_anomalygennext_inputs.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+from PIL import Image
+
+
+SCRIPT = Path(__file__).parents[1] / "prepare_anomalygennext_inputs.py"
+SPEC = importlib.util.spec_from_file_location("prepare_anomalygennext_inputs", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def image(path: Path, value: int = 80) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full((32, 32, 3), value, dtype=np.uint8)).save(path)
+
+
+def mask(path: Path, offset: int = 0) -> None:
+    value = np.zeros((32, 32), dtype=np.uint8)
+    value[4 + offset:20 + offset, 4:20] = 255
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(value).save(path)
+
+
+def fixture(tmp_path: Path) -> tuple[Path, Path]:
+    defective = tmp_path / "defect.png"
+    source_mask = tmp_path / "defect_mask.png"
+    image(defective)
+    mask(source_mask)
+    pool = tmp_path / "pool" / "texture_1"
+    image(pool / "clean_image" / "clean1.png", 10)
+    image(pool / "clean_image" / "clean2.png", 20)
+    mask(pool / "mask" / "crack" / "mask1.png")
+    mask(pool / "mask" / "crack" / "mask2.png", 1)
+    gaps = tmp_path / "gaps.parquet"
+    pd.DataFrame([
+        {"image_id": 1, "filepath": str(defective), "gap_type": "FN",
+         "bbox": [4, 4, 20, 20], "class": "defect", "split": "kpi",
+         "dataset_id": "example", "texture_id": "texture_1",
+         "defect_class": "crack", "anomaly_type": "texture_1+crack",
+         "fn_mask_source": str(source_mask)},
+        {"image_id": 1, "filepath": str(defective), "gap_type": "FN",
+         "bbox": [6, 6, 18, 18], "class": "defect", "split": "kpi",
+         "dataset_id": "example", "texture_id": "texture_1",
+         "defect_class": "crack", "anomaly_type": "texture_1+crack",
+         "fn_mask_source": str(source_mask)},
+    ]).to_parquet(gaps)
+    checkpoint = tmp_path / "adapter.pt"
+    checkpoint.write_bytes(b"checkpoint")
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(yaml.safe_dump({"anomaly_types": [["texture_1", "crack"]]}))
+    defect_spec = tmp_path / "defect_spec.jsonl"
+    defect_spec.write_text(json.dumps({"defect_type": "texture_1+crack",
+                                       "spatial_dependency": "free"}) + "\n")
+    config = tmp_path / "filtering.yaml"
+    config.write_text(yaml.safe_dump({
+        "source_tag": "test", "gap_parquet": str(gaps),
+        "pool_dataset_root": str(tmp_path / "pool"), "defect_spec": str(defect_spec),
+        "datasets": {"example": {"checkpoint": str(checkpoint), "recipe": str(recipe)}},
+        "selection": {"mode": "all_eligible", "datasets": ["example"],
+                      "mask_sample_seed": 7},
+        "embedding": {"model": "SigLIP", "model_path": "local/siglip", "batch_size": 8},
+    }, sort_keys=False))
+    return config, gaps
+
+
+def test_prepare_preserves_box_level_queries_and_unique_embedding_input(tmp_path: Path) -> None:
+    config, _ = fixture(tmp_path)
+    output = tmp_path / "output"
+    report = MODULE.prepare(config, output)
+    assert report == {"status": "COMPLETE", "source_tag": "test",
+                      "selected_fn_count": 2, "clean_image_count": 2,
+                      "source_mask_count": 4, "training_pool_mutated": False}
+    queries = pd.read_parquet(output / "manifests" / "selected_fn_queries.parquet")
+    embedding = pd.read_parquet(output / "manifests" / "fn_embedding_inputs.parquet")
+    masks = pd.read_parquet(output / "manifests" / "mask_selection.parquet")
+    assert len(queries) == 2 and queries.fn_id.nunique() == 2
+    assert len(embedding) == 1
+    assert masks.groupby("fn_id").branch.nunique().eq(2).all()
+    assert all(Path(path).is_file() for path in masks.mask_path)
+    clean_spec = yaml.safe_load((output / "specs" / "clean_embeddings.yaml").read_text())
+    fn_spec = yaml.safe_load((output / "specs" / "fn_embeddings.yaml").read_text())
+    assert clean_spec["model_path"] == fn_spec["model_path"] == "local/siglip"
+
+
+def test_prepare_requires_normalized_identity(tmp_path: Path) -> None:
+    config, gaps = fixture(tmp_path)
+    frame = pd.read_parquet(gaps).drop(columns=["fn_mask_source"])
+    frame.to_parquet(gaps)
+    with pytest.raises(ValueError, match="normalized columns"):
+        MODULE.prepare(config, tmp_path / "output")
+
+
+def test_prepare_refuses_output_reuse(tmp_path: Path) -> None:
+    config, _ = fixture(tmp_path)
+    output = tmp_path / "output"
+    output.mkdir()
+    with pytest.raises(FileExistsError):
+        MODULE.prepare(config, output)

--- a/versions.yaml
+++ b/versions.yaml
@@ -47,6 +47,7 @@ images:
 
   metropolis_sdg:
     paidf_anomalygen: nvcr.io/nvidia/paidf-anomalygen:1.0.1
+    anomalygen_next: nvcr.io/nvidia/paidf-anomalygen:1.1.0
     paidf_augmentation: nvcr.io/nvidia/paidf-augmentation:1.0.0
 wheels:
   # TAO Python wheels, published to public PyPI. Skill Preflight sections


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds the first stage of a reusable `tao-prepare-anomalygennext-inputs` data skill.

The new `prepare_plan` action converts normalized object-detection false negatives into a deterministic, validated preparation plan for later AnomalyGenNext processing. It:

- Requires explicit `dataset_id`, `texture_id`, `defect_class`, `anomaly_type`, and `fn_mask_source` fields rather than inferring identity from customer-specific paths.
- Preserves each box-level false negative as a distinct `fn_id`.
- Verifies source images, same-size pixel masks, dataset routes, task checkpoints, recipes, anomaly-type coverage, and defect specifications.
- Isolates each false-negative mask to its bounding box.
- Selects a deterministic same-type mask for each false negative.
- Creates a deduplicated false-negative embedding input while retaining the complete box-level query mapping.
- Enumerates clean reference images and emits matching clean and false-negative embedding specifications using one frozen encoder identity.
- Refuses to overwrite an existing output directory and does not modify a detector training pool.

The PR also includes:

- A default filtering configuration.
- Structured action metadata.
- The normalized input contract.
- Skill documentation and evaluation cases.
- Marketplace registration.
- The public AnomalyGenNext 1.1 container entry in `versions.yaml`.

Usage from the repository root:

```bash
python skills/data/tao-prepare-anomalygennext-inputs/scripts/prepare_anomalygennext_inputs.py \
  --config /absolute/path/to/filtering.yaml \
  --output-dir /absolute/path/to/new/prepared-result
```

The action produces the selected FN queries, mask-selection manifest, clean-image pool, clean/FN embedding specifications, frozen filtering configuration, and input-contract report.

This is the contract-setting first slice of a larger stacked contribution. Follow-up PRs add native automatic mask placement, final generation-input publication, optional AnomalyGenNext fine-tuning, OD defect generation, and integration into the DEFT OD AOI application. Those later stages consume the artifacts introduced here rather than reimplementing dataset parsing or identity inference.

### Why are the changes needed?

AnomalyGenNext synthesis requires more information than an object detector’s bounding-box gap output provides. It needs stable dataset and anomaly identities, pixel masks, clean references, supported defect specifications, and matching task checkpoint/recipe pairs.

Without a dedicated boundary, each application would need customer-layout-specific path parsing and ad hoc preparation logic. That makes dataset identity ambiguous, risks treating boxes as masks, and can lose the relationship between multiple false negatives from the same source image.

This skill establishes a reusable normalized contract before any GPU generation work begins. Dataset-specific adapters normalize their inputs once, while downstream AnomalyGenNext stages receive deterministic, validated artifacts with explicit provenance.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, TAO Skill Bank did not provide a reusable action for converting normalized object-detection false negatives into AnomalyGenNext mask-selection and embedding plans. Applications had to prepare those inputs independently.

After this change, users can invoke `tao-prepare-anomalygennext-inputs` with a normalized gap parquet and filtering YAML. The action validates the complete planning contract and emits deterministic artifacts for the follow-up embedding and AnomalyGenNext stages.

This is an additive capability and does not break existing usage. Users of the new skill must normalize dataset identity and pixel-mask fields before invoking it; filename and directory-layout inference is deliberately outside this leaf.

### How was this patch tested?

Unit tests were run on the exact `dev/anomalygen-next-prepare-plan` branch:

```text
$ .venv/deft/bin/python -m pytest -q \
    skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_prepare_anomalygennext_inputs.py

...                                                                      [100%]
3 passed in 3.31s
```

The tests cover:

- Preserving distinct box-level FN identities when multiple gaps reference one image.
- Deduplicating the corresponding embedding input.
- Producing both the isolated-FN and deterministic same-type mask branches.
- Keeping clean and FN embedding specifications on the same encoder.
- Rejecting gaps missing required normalized identity fields.
- Refusing to reuse an existing output directory.

The skill-bank validator also passed:

```text
$ source .venv/deft/bin/activate
$ VALIDATE_BASE_REF=origin/main ./scripts/validate-skills.sh

✓ validate-skills passed
```

The patch has no whitespace errors:

```text
$ git diff --check origin/main...HEAD

# no output
```

The plan emitted by this implementation was also consumed unchanged in a follow-up integration smoke using the public `nvcr.io/nvidia/paidf-anomalygen:1.1.0` image. A two-FN fixture progressed through the later GPU-backed stages, producing 12/12 native AMP outputs and four generation rows. AMP, finalization, and generation are intentionally delivered in subsequent PRs rather than this slice.

### Was this patch authored or co-authored using generative AI tooling?

co-author: OpenAI Codex (GPT-5.6)

### Release note

```release-note
Added a reusable AnomalyGenNext input-planning skill that validates normalized object-detection false negatives and emits deterministic mask-selection and embedding plans.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded so the package still works without them (the new dependencies are loaded only when the standalone action is invoked)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that my commit author name and email become permanently public once merged

### Notes for reviewers

The most useful review order is:

1. `SKILL.md` and `references/input-contract.md` for the public boundary.
2. `assets/default_filtering.yaml` and `references/skill_info.yaml` for the configuration and action contract.
3. `scripts/prepare_anomalygennext_inputs.py` for validation and materialization.
4. `scripts/tests/test_prepare_anomalygennext_inputs.py` for the expected behavior and negative cases.

The normalized boundary is deliberate: this leaf does not contain customer- or benchmark-specific filename parsing. A calling application or dataset adapter must supply explicit identity and mask fields.

This PR prepares the plan only. The stacked follow-ups are:

- `dev/anomalygen-next-prepare-amp`
- `dev/anomalygen-next-prepare-finalize`
- `dev/anomalygen-next-finetune-recipe`
- `dev/anomalygen-next-finetune-train`
- `dev/anomalygen-next-generate`
- the subsequent DEFT OD AOI integration branches

The preparation action does not run embeddings, AMP, fine-tuning, generation, or detector-training admission.