### PR TITLE
feat(data): add pair-preserving AnomalyGenNext AMP

### DIFF
--- a/skills/data/tao-prepare-anomalygennext-inputs/SKILL.md
+++ b/skills/data/tao-prepare-anomalygennext-inputs/SKILL.md
@@ -15,9 +15,11 @@ tags: [tao, data, anomalygen-next, object-detection, input-preparation]
 
 # Prepare AnomalyGenNext Inputs
 
-This first action freezes eligible false-negative identities, isolates each FN
+The first action freezes eligible false-negative identities, isolates each FN
 mask to its bounding box, selects one deterministic same-type mask, and emits
-the clean and FN embedding specs. It neither computes embeddings nor runs AMP.
+the clean and FN embedding specs. The second action consumes those embedding
+results, preserves every FN-to-clean pair, and runs native automatic mask
+placement (AMP) from the AnomalyGenNext container.
 
 ## Input contract
 
@@ -57,6 +59,19 @@ The output root must not exist. The action emits `fn_queries.parquet`,
 `selected_fn_queries.parquet`, `mask_selection.parquet`, `clean_pool.parquet`,
 two `tao-generate-image-embeddings` specs, the copied filtering config, and
 `input_contract.json`.
+
+Run both emitted specs through `tao-generate-image-embeddings`, preserving the
+same encoder. Place their outputs under `embeddings/` as named by the specs,
+then submit the `run_amp` action:
+
+```bash
+scripts/run_anomalygennext_amp.py \
+  --config /path/to/filtering.yaml \
+  --prepared-root /existing/result/root
+```
+
+This writes `knn_candidates.parquet`, the native AMP request, and
+`amp/testcase.jsonl`. Platform skills own staging and cache placement.
 
 ## Gates
 

--- a/skills/data/tao-prepare-anomalygennext-inputs/assets/default_filtering.yaml
+++ b/skills/data/tao-prepare-anomalygennext-inputs/assets/default_filtering.yaml
@@ -32,3 +32,7 @@ retrieval:
   max_neighbors_per_fn: 5
   min_similarity: 0.9
   prior_clean_exclusion_manifest: ""
+
+amp:
+  model_id: nvidia/Cosmos3-Nano
+  seed: 43

--- a/skills/data/tao-prepare-anomalygennext-inputs/references/input-contract.md
+++ b/skills/data/tao-prepare-anomalygennext-inputs/references/input-contract.md
@@ -22,3 +22,9 @@ Selection supports:
 
 The same frozen encoder identity is written to both embedding specs. The next
 action must use those specs unchanged so clean and FN vectors remain comparable.
+
+`run_amp` joins the unique source-image embedding back to every box-level FN,
+ranks clean images within the normalized texture pool, and creates two AMP
+requests for every eligible pair. It rejects missing, non-finite, zero-norm, or
+width-mismatched embeddings. AMP itself remains owned by the container-native
+`anomalygen.scripts.auto_mask_placement.roi_place` entry point.

--- a/skills/data/tao-prepare-anomalygennext-inputs/references/skill_info.yaml
+++ b/skills/data/tao-prepare-anomalygennext-inputs/references/skill_info.yaml
@@ -29,3 +29,21 @@ actions:
     args:
       config: --config {config}
       output_dir: --output-dir {results_dir}
+  run_amp:
+    command: scripts/run_anomalygennext_amp.py
+    mode: args
+    inputs:
+      config:
+        type: file
+      prepared_root:
+        type: folder
+    outputs:
+      amp_testcase:
+        type: file
+      knn_candidates:
+        type: file
+    upload_excludes:
+    - inputs/
+    args:
+      config: --config {config}
+      prepared_root: --prepared-root {prepared_root}

--- a/skills/data/tao-prepare-anomalygennext-inputs/scripts/run_anomalygennext_amp.py
+++ b/skills/data/tao-prepare-anomalygennext-inputs/scripts/run_anomalygennext_amp.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Build pair-preserving KNN requests and run AnomalyGenNext AMP."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yaml
+
+
+BRANCHES = {"fn_mask", "same_type_sampled_mask"}
+
+
+def _matrix(values: pd.Series) -> np.ndarray:
+    rows = [np.asarray(value, dtype=np.float32).reshape(-1) for value in values]
+    if not rows or len({row.size for row in rows}) != 1:
+        raise ValueError("embeddings are empty or have inconsistent widths")
+    matrix = np.stack(rows)
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    if not np.isfinite(matrix).all() or np.any(norms == 0):
+        raise ValueError("embeddings contain non-finite or zero-norm rows")
+    return matrix / norms
+
+
+def _pair_id(fn_id: str, clean: str) -> str:
+    return "pair-" + hashlib.sha256(f"{fn_id}\0{clean}".encode()).hexdigest()[:16]
+
+
+def plan(root: Path, config: dict[str, Any]) -> dict[str, Any]:
+    manifests, embeddings = root / "manifests", root / "embeddings"
+    clean = pd.read_parquet(embeddings / "clean_embeddings.parquet").reset_index(drop=True)
+    embedded = pd.read_parquet(embeddings / "fn_embeddings.parquet")
+    queries = pd.read_parquet(manifests / "selected_fn_queries.parquet")
+    masks = pd.read_parquet(manifests / "mask_selection.parquet")
+    for label, frame in (("clean", clean), ("FN", embedded)):
+        if frame.empty or not {"filepath", "embedding"}.issubset(frame.columns):
+            raise ValueError(f"{label} embeddings lack filepath/embedding")
+    if embedded.filepath.astype(str).duplicated().any():
+        raise ValueError("FN embedding rows must be unique by filepath")
+    queries = queries.merge(embedded[["filepath", "embedding"]], on="filepath",
+                            how="left", validate="many_to_one")
+    if queries.embedding.isna().any():
+        raise ValueError("one or more FN queries have no embedding")
+    clean_vectors, query_vectors = _matrix(clean.embedding), _matrix(queries.embedding)
+    retrieval = config["retrieval"]
+    if retrieval.get("metric", "cosine") != "cosine":
+        raise ValueError("only cosine retrieval is supported")
+    topn, floor = int(retrieval["candidate_topn"]), float(retrieval["min_similarity"])
+    excluded: set[str] = set()
+    exclusion = str(retrieval.get("prior_clean_exclusion_manifest") or "")
+    if exclusion:
+        excluded = set(pd.read_parquet(exclusion).filepath.astype(str))
+
+    candidates, requests = [], []
+    for position, query in queries.reset_index(drop=True).iterrows():
+        pool = clean.index[clean.pool_key.astype(str) == str(query.pool_key)].to_numpy()
+        if not len(pool):
+            raise ValueError(f"no clean embeddings for pool_key={query.pool_key}")
+        scores = clean_vectors[pool] @ query_vectors[position]
+        mask_rows = masks[masks.fn_id == query.fn_id]
+        if set(mask_rows.branch.astype(str)) != BRANCHES or len(mask_rows) != 2:
+            raise ValueError(f"FN {query.fn_id} needs exactly two mask branches")
+        for rank, local in enumerate(np.argsort(-scores, kind="stable")[:topn], start=1):
+            clean_path = str(clean.loc[int(pool[local]), "filepath"])
+            score = float(scores[local])
+            reason = "below_similarity_floor" if score < floor else (
+                "prior_iteration_exclusion" if clean_path in excluded else ""
+            )
+            pair = _pair_id(str(query.fn_id), clean_path)
+            candidate = {
+                "candidate_id": pair, "fn_id": str(query.fn_id),
+                "query_order": int(query.query_order), "dataset_id": str(query.dataset_id),
+                "anomaly_type": str(query.anomaly_type), "od_category": str(query.od_category),
+                "pool_key": str(query.pool_key), "fn_filepath": str(query.filepath),
+                "clean_filepath": clean_path, "neighbor_rank": rank,
+                "cosine_similarity": score, "eligible_for_amp": not reason,
+                "gate_reason": reason,
+            }
+            candidates.append(candidate)
+            if not reason:
+                for mask in mask_rows.sort_values("branch").itertuples():
+                    requests.append({
+                        "clean_image": clean_path, "defect_type": str(query.anomaly_type),
+                        "submask": str(mask.mask_path), "name": f"{pair}__{mask.branch}",
+                        "cad_mask": None, "cad_mask_label": None, "n_seeds": 1,
+                        "submask_split_largest": False,
+                    })
+    if not requests:
+        raise ValueError("no candidates passed the AMP gate")
+    pd.DataFrame(candidates).to_parquet(manifests / "knn_candidates.parquet", index=False)
+    amp = root / "amp"
+    amp.mkdir(parents=True, exist_ok=True)
+    (amp / "amp_samples.json").write_text(json.dumps(requests, indent=2) + "\n")
+    return {"candidates": len(candidates), "amp_rows": len(requests),
+            "embedding_dim": int(clean_vectors.shape[1])}
+
+
+def run(config_path: Path, root: Path) -> dict[str, Any]:
+    frozen = root / "prepared_anomalygennext_inputs" / "filtering_config.yaml"
+    if config_path.read_bytes() != frozen.read_bytes():
+        raise ValueError("config differs from the frozen preparation snapshot")
+    config = yaml.safe_load(frozen.read_text())
+    report = plan(root, config)
+    amp = config.get("amp") or {}
+    command = [sys.executable, "-m", "anomalygen.scripts.auto_mask_placement.roi_place",
+               "--input_pair_path", str(root / "amp" / "amp_samples.json"),
+               "--defect_desc", str(Path(config["defect_spec"]).resolve()),
+               "--output_dir", str(root / "amp"), "--n_seeds", "1",
+               "--seed", str(int(amp.get("seed", 43))),
+               "--model_id", str(amp.get("model_id", "nvidia/Cosmos3-Nano"))]
+    subprocess.run(command, check=True)
+    testcase = root / "amp" / "testcase.jsonl"
+    if not testcase.is_file() or not testcase.read_text().strip():
+        raise ValueError("AMP produced no testcase rows")
+    report["testcase"] = str(testcase)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--prepared-root", required=True)
+    args = parser.parse_args()
+    result = run(Path(args.config).resolve(), Path(args.prepared_root).resolve())
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_run_anomalygennext_amp.py
+++ b/skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_run_anomalygennext_amp.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "run_anomalygennext_amp.py"
+SPEC = importlib.util.spec_from_file_location("run_anomalygennext_amp", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def inputs(root: Path) -> dict:
+    (root / "manifests").mkdir(parents=True)
+    (root / "embeddings").mkdir()
+    pd.DataFrame([
+        {"filepath": "/clean/a.png", "pool_key": "texture_1", "embedding": [1.0, 0.0]},
+        {"filepath": "/clean/b.png", "pool_key": "texture_1", "embedding": [0.8, 0.2]},
+    ]).to_parquet(root / "embeddings" / "clean_embeddings.parquet")
+    pd.DataFrame([
+        {"filepath": "/defect/shared.png", "embedding": [1.0, 0.0]},
+    ]).to_parquet(root / "embeddings" / "fn_embeddings.parquet")
+    pd.DataFrame([
+        {"filepath": "/defect/shared.png", "fn_id": "fn-1", "query_order": 0,
+         "dataset_id": "d", "pool_key": "texture_1",
+         "anomaly_type": "texture_1+crack", "od_category": "defect"},
+        {"filepath": "/defect/shared.png", "fn_id": "fn-2", "query_order": 1,
+         "dataset_id": "d", "pool_key": "texture_1",
+         "anomaly_type": "texture_1+crack", "od_category": "defect"},
+    ]).to_parquet(root / "manifests" / "selected_fn_queries.parquet")
+    pd.DataFrame([
+        {"fn_id": fn, "branch": branch, "mask_path": f"/masks/{fn}-{branch}.png"}
+        for fn in ("fn-1", "fn-2")
+        for branch in sorted(MODULE.BRANCHES)
+    ]).to_parquet(root / "manifests" / "mask_selection.parquet")
+    return {"retrieval": {"metric": "cosine", "candidate_topn": 2,
+                           "min_similarity": -1.0,
+                           "prior_clean_exclusion_manifest": ""}}
+
+
+def test_plan_preserves_pairs_for_same_source_image(tmp_path: Path) -> None:
+    report = MODULE.plan(tmp_path, inputs(tmp_path))
+    assert report == {"candidates": 4, "amp_rows": 8, "embedding_dim": 2}
+    candidates = pd.read_parquet(tmp_path / "manifests" / "knn_candidates.parquet")
+    assert candidates.fn_id.nunique() == 2
+    assert candidates.groupby("fn_id").clean_filepath.nunique().eq(2).all()
+    requests = json.loads((tmp_path / "amp" / "amp_samples.json").read_text())
+    assert len({row["name"] for row in requests}) == 8
+
+
+def test_plan_rejects_zero_norm_embeddings(tmp_path: Path) -> None:
+    config = inputs(tmp_path)
+    frame = pd.read_parquet(tmp_path / "embeddings" / "fn_embeddings.parquet")
+    frame["embedding"] = pd.Series([[0.0, 0.0]], dtype=object)
+    frame.to_parquet(tmp_path / "embeddings" / "fn_embeddings.parquet")
+    with pytest.raises(ValueError, match="zero-norm"):
+        MODULE.plan(tmp_path, config)


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds the `run_amp` action to `tao-prepare-anomalygennext-inputs`. It consumes the clean-image and false-negative embedding results produced from the preparation plan in the preceding PR, ranks clean references within each normalized texture pool, and invokes AnomalyGenNext's native automatic mask placement (AMP) entry point from the pinned public 1.1 container.

The action:

- Joins each unique source-image embedding back to every box-level false negative, preserving distinct `fn_id` values when multiple gaps share an image.
- Normalizes vectors and performs deterministic cosine-similarity ranking within each false negative's `pool_key`.
- Applies the configured similarity floor and prior-clean exclusion manifest before AMP.
- Requires exactly the isolated-FN and same-type-sampled mask branches for each eligible false negative.
- Creates stable pair IDs and one AMP request per pair and mask branch.
- Rejects missing, duplicated, inconsistent-width, non-finite, or zero-norm embeddings.
- Verifies that native AMP emitted a nonempty `testcase.jsonl` before reporting success.

The action contract, default AMP model and seed, input reference, and skill usage documentation are updated with the new stage.

Usage after running both embedding specs emitted by `prepare_plan`:

```bash
python skills/data/tao-prepare-anomalygennext-inputs/scripts/run_anomalygennext_amp.py \
  --config /absolute/path/to/filtering.yaml \
  --prepared-root /absolute/path/to/prepared-result
```

The action writes `manifests/knn_candidates.parquet`, `amp/amp_samples.json`, and the container-native `amp/testcase.jsonl` in the existing prepared result root.

This is the second slice of the stacked AnomalyGenNext preparation contribution. The following PR finalizes only pairs for which both AMP mask branches succeeded and freezes the exact generation inputs and hashes.

### Why are the changes needed?

The preparation plan intentionally embeds each repeated source image only once, but synthesis decisions must remain attached to individual box-level false negatives. A separate pair-preserving retrieval stage is needed to join that deduplicated representation back to every false-negative query without collapsing distinct gaps.

This action also creates a clean boundary between reusable TAO-side retrieval policy and AnomalyGenNext's native AMP implementation. The skill owns deterministic candidate selection, provenance, and validation, while the pinned container continues to own mask placement.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, `tao-prepare-anomalygennext-inputs` stopped after emitting embedding specifications. Users had no packaged action to turn those embeddings into clean/FN candidate pairs and native AMP requests.

After this change, users can invoke `run_amp` on the prepared root. The action validates the frozen configuration and embeddings, records accepted and rejected KNN candidates, runs native AMP, and requires a nonempty testcase before success.

This is additive and does not break the preceding `prepare_plan` action. Users must first execute both emitted embedding specs with the same frozen encoder and place the resulting parquet files under the prepared root's `embeddings/` directory.

### How was this patch tested?

The branch-focused unit tests passed:

```text
$ .venv/deft/bin/python -m pytest -q \
    skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_run_anomalygennext_amp.py

..                                                                       [100%]
2 passed in 0.33s
```

The tests cover:

- Preserving two distinct false-negative queries that share one source-image embedding.
- Retaining two clean candidates per false negative and producing both mask branches for every pair.
- Stable, unique AMP request names.
- Rejecting zero-norm embeddings before retrieval or AMP.

The exact branch independently passed the skill-bank validator, and its stacked diff has no whitespace errors:

```text
$ VALIDATE_BASE_REF=dev/anomalygen-next-prepare-plan ./scripts/validate-skills.sh
✓ validate-skills passed

$ git diff --check dev/anomalygen-next-prepare-plan...dev/anomalygen-next-prepare-amp
# no output
```

The action was also exercised on one H100 with `nvcr.io/nvidia/paidf-anomalygen:1.1.0`. Two explicit false negatives produced six KNN candidates and 12/12 native AMP rows. This runtime smoke covered the stacked preparation implementation; the subsequent finalization outputs are reviewed separately in the next PR.

### Was this patch authored or co-authored using generative AI tooling?

Yes. This patch was co-authored using OpenAI Codex.

Generated-by: OpenAI Codex (GPT-5.6)

### Release note

```release-note
Added pair-preserving clean-image retrieval and native automatic mask placement to the AnomalyGenNext input-preparation skill.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded so the package still works without them (the action's runtime dependencies are loaded only when its standalone script is invoked)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that my commit author name and email become permanently public once merged

### Notes for reviewers

Suggested review order:

1. `references/input-contract.md` and `references/skill_info.yaml` for the boundary.
2. `scripts/run_anomalygennext_amp.py` for vector validation, pair preservation, retrieval gates, and native AMP invocation.
3. `scripts/tests/test_run_anomalygennext_amp.py` for the shared-source-image and invalid-embedding cases.
4. `SKILL.md` and `assets/default_filtering.yaml` for usage and defaults.

This PR deliberately does not validate or publish final generation inputs. The next stacked PR, `dev/anomalygen-next-prepare-finalize`, verifies both aligned mask branches, selects successful pairs, and writes hash-bound generation artifacts.