### PR TITLE
feat(data): finalize AnomalyGenNext generation inputs

### DIFF
--- a/skills/data/tao-prepare-anomalygennext-inputs/SKILL.md
+++ b/skills/data/tao-prepare-anomalygennext-inputs/SKILL.md
@@ -19,7 +19,9 @@ The first action freezes eligible false-negative identities, isolates each FN
 mask to its bounding box, selects one deterministic same-type mask, and emits
 the clean and FN embedding specs. The second action consumes those embedding
 results, preserves every FN-to-clean pair, and runs native automatic mask
-placement (AMP) from the AnomalyGenNext container.
+placement (AMP) from the AnomalyGenNext container. The final action accepts
+only pairs for which both mask branches passed AMP, then freezes the exact
+generation inputs and their hashes.
 
 ## Input contract
 
@@ -71,13 +73,23 @@ scripts/run_anomalygennext_amp.py \
 ```
 
 This writes `knn_candidates.parquet`, the native AMP request, and
-`amp/testcase.jsonl`. Platform skills own staging and cache placement.
+`amp/testcase.jsonl`. Finalize it in the same durable result root:
+
+```bash
+scripts/finalize_anomalygennext_inputs.py --prepared-root /existing/result/root
+```
+
+The finalizer writes pair status, selected pairs, copied aligned masks,
+per-dataset testcase and provenance JSONL, and a generation plan plus integrity
+manifest. A clean image is unique only within one FN; separate FNs may reuse it.
+Platform skills own staging and cache placement.
 
 ## Gates
 
 - Preserve each box-level FN as a distinct `fn_id`.
 - Produce exactly two masks per FN: isolated FN and deterministic same-type.
 - Embed a repeated source image once while preserving every FN query row.
+- Require successful, nonempty, non-full-image aligned masks for both branches.
 - Never infer an anomaly type or placement prompt.
 - Refuse output reuse and never mutate a training pool.
 - Platform skills own transient staging, caches, and copy-back.

--- a/skills/data/tao-prepare-anomalygennext-inputs/references/input-contract.md
+++ b/skills/data/tao-prepare-anomalygennext-inputs/references/input-contract.md
@@ -28,3 +28,8 @@ ranks clean images within the normalized texture pool, and creates two AMP
 requests for every eligible pair. It rejects missing, non-finite, zero-norm, or
 width-mismatched embeddings. AMP itself remains owned by the container-native
 `anomalygen.scripts.auto_mask_placement.roi_place` entry point.
+
+`finalize_inputs` retains the configured number of successful neighbors per FN.
+Both aligned mask branches must match the clean image and cover neither zero nor
+all pixels. It copies accepted masks under the prepared root and hashes every
+generation contract artifact, without changing the source training pool.

--- a/skills/data/tao-prepare-anomalygennext-inputs/references/skill_info.yaml
+++ b/skills/data/tao-prepare-anomalygennext-inputs/references/skill_info.yaml
@@ -47,3 +47,18 @@ actions:
     args:
       config: --config {config}
       prepared_root: --prepared-root {prepared_root}
+  finalize_inputs:
+    command: scripts/finalize_anomalygennext_inputs.py
+    mode: args
+    inputs:
+      prepared_root:
+        type: folder
+    outputs:
+      generation_plan:
+        type: file
+      prepared_inputs_manifest:
+        type: file
+    upload_excludes:
+    - inputs/
+    args:
+      prepared_root: --prepared-root {prepared_root}

--- a/skills/data/tao-prepare-anomalygennext-inputs/scripts/finalize_anomalygennext_inputs.py
+++ b/skills/data/tao-prepare-anomalygennext-inputs/scripts/finalize_anomalygennext_inputs.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Freeze successful AMP pairs into generation-ready AnomalyGenNext inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yaml
+from PIL import Image
+
+
+BRANCHES = {"fn_mask", "same_type_sampled_mask"}
+
+
+def _json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _amp_index(path: Path) -> dict[tuple[str, str], dict[str, Any]]:
+    result = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        mask = Path(row["mask_filename"])
+        key = (str(row["image_filename"]), mask.name.split("__seed", 1)[0])
+        if key in result:
+            raise ValueError(f"duplicate AMP output key: {key}")
+        result[key] = row
+    return result
+
+
+def _validate_mask(mask_path: Path, image_path: Path) -> str:
+    with Image.open(mask_path) as mask_image, Image.open(image_path) as image:
+        mask = np.asarray(mask_image.convert("L")) > 0
+        if mask.shape != (image.height, image.width):
+            raise ValueError("dimension_mismatch")
+    pixels = int(mask.sum())
+    if pixels == 0:
+        raise ValueError("empty")
+    if pixels == mask.size:
+        raise ValueError("full_image")
+    return _sha256(mask_path)
+
+
+def finalize(root: Path) -> dict[str, Any]:
+    prepared = root / "prepared_anomalygennext_inputs"
+    config = yaml.safe_load((prepared / "filtering_config.yaml").read_text())
+    candidates = pd.read_parquet(root / "manifests" / "knn_candidates.parquet")
+    masks = pd.read_parquet(root / "manifests" / "mask_selection.parquet")
+    amp = _amp_index(root / "amp" / "testcase.jsonl")
+    keep = int(config["retrieval"]["max_neighbors_per_fn"])
+    status_rows, selected_rows = [], []
+    generator: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    provenance: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for fn_id in candidates.sort_values("query_order").fn_id.drop_duplicates():
+        retained, used_clean = 0, set()
+        group = candidates[candidates.fn_id == fn_id].sort_values("neighbor_rank")
+        branch_rows = masks[masks.fn_id == fn_id]
+        if len(branch_rows) != 2 or set(branch_rows.branch.astype(str)) != BRANCHES:
+            raise ValueError(f"FN {fn_id} needs exactly two mask branches")
+        branch_rows = branch_rows.set_index("branch")
+        for candidate in group.to_dict("records"):
+            status = {**candidate, "selected": False,
+                      "selection_reason": str(candidate["gate_reason"])}
+            clean = str(candidate["clean_filepath"])
+            if retained >= keep:
+                status["selection_reason"] = "quota_reached"
+            elif not bool(candidate["eligible_for_amp"]):
+                pass
+            elif clean in used_clean:
+                status["selection_reason"] = "duplicate_clean_within_fn"
+            else:
+                placed = {}
+                for branch in sorted(BRANCHES):
+                    source = Path(str(branch_rows.loc[branch, "mask_path"]))
+                    row = amp.get((clean, source.stem))
+                    if row is None:
+                        status["selection_reason"] = f"amp_failure:{branch}"
+                        break
+                    try:
+                        _validate_mask(Path(row["mask_filename"]), Path(clean))
+                    except (FileNotFoundError, ValueError) as exc:
+                        reason = exc.args[0] if isinstance(exc, ValueError) else "missing"
+                        status["selection_reason"] = f"invalid_aligned_mask:{branch}:{reason}"
+                        break
+                    placed[branch] = row
+                if len(placed) == 2:
+                    pair = str(candidate["candidate_id"])
+                    dataset = str(candidate["dataset_id"])
+                    selected = {**candidate, "pair_id": pair}
+                    for branch, row in placed.items():
+                        source = Path(str(branch_rows.loc[branch, "mask_path"]))
+                        aligned = prepared / "aligned_masks" / dataset / f"{pair}__{branch}.png"
+                        aligned.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(row["mask_filename"], aligned)
+                        frozen = {**row, "mask_filename": str(aligned),
+                                  "anomaly_type": str(candidate["anomaly_type"]),
+                                  "num_generated_images": 1}
+                        index = len(generator[dataset])
+                        generator[dataset].append(frozen)
+                        provenance[dataset].append({
+                            "generation_index": index, "pair_id": pair, "fn_id": str(fn_id),
+                            "dataset_id": dataset, "anomaly_type": str(candidate["anomaly_type"]),
+                            "od_category": str(candidate["od_category"]), "mask_branch": branch,
+                            "source_mask": str(source), "source_mask_sha256": _sha256(source),
+                            "fn_filepath": str(candidate["fn_filepath"]), "clean_filepath": clean,
+                            "aligned_mask": str(aligned), "aligned_mask_sha256": _sha256(aligned),
+                            "neighbor_rank": int(candidate["neighbor_rank"]),
+                            "cosine_similarity": float(candidate["cosine_similarity"]),
+                            "source_tag": config.get("source_tag", "user_provided"),
+                        })
+                        selected[f"{branch}_aligned_mask"] = str(aligned)
+                    selected_rows.append(selected)
+                    used_clean.add(clean)
+                    retained += 1
+                    status.update(selected=True, selection_reason="selected")
+            status_rows.append(status)
+
+    status = pd.DataFrame(status_rows)
+    selected = pd.DataFrame(selected_rows)
+    status.to_parquet(root / "manifests" / "knn_roi_status.parquet", index=False)
+    selected.to_parquet(root / "manifests" / "selected_pairs.parquet", index=False)
+    plans, unified, artifacts = [], [], []
+    for dataset in sorted(generator):
+        directory = prepared / "anomalygen_inputs" / dataset
+        testcase, provenance_path = directory / "testcase.jsonl", directory / "provenance.jsonl"
+        _jsonl(testcase, generator[dataset])
+        _jsonl(provenance_path, provenance[dataset])
+        types = sorted({row["anomaly_type"] for row in provenance[dataset]})
+        mapping = config["datasets"][dataset]
+        plans.append({"dataset_id": dataset, "anomaly_types": types,
+                      "testcase": str(testcase), "provenance": str(provenance_path),
+                      "checkpoint": str(mapping["checkpoint"]), "recipe": str(mapping["recipe"]),
+                      "real_root": str(config["pool_dataset_root"]),
+                      "requested_rows": len(generator[dataset])})
+        unified.extend({**proof, "checkpoint": str(mapping["checkpoint"]),
+                        "recipe": str(mapping["recipe"]), "generator_input": request}
+                       for proof, request in zip(provenance[dataset], generator[dataset], strict=True))
+        artifacts.extend([testcase, provenance_path])
+    if not unified:
+        raise RuntimeError("prepared inputs contain no AnomalyGenNext generation rows")
+    unified_path = prepared / "anomalygen_inputs.jsonl"
+    plan_path = prepared / "anomalygen_next_generation_plan.json"
+    _jsonl(unified_path, unified)
+    _json(plan_path, plans)
+    artifacts.extend([unified_path, plan_path, prepared / "filtering_config.yaml",
+                      prepared / "input_contract.json"])
+    artifacts.extend(sorted((prepared / "aligned_masks").rglob("*.png")))
+    manifest = {
+        "schema_version": 2, "phase": "prepared_anomalygennext_inputs", "status": "COMPLETE",
+        "source_tag": config.get("source_tag", "user_provided"),
+        "selected_fn_count": int(selected.fn_id.nunique()), "selected_pair_count": len(selected),
+        "generator_row_count": len(unified), "generator_groups": plans,
+        "artifacts": [{"path": str(path), "sha256": _sha256(path), "bytes": path.stat().st_size}
+                      for path in artifacts],
+        "skip_counts": dict(Counter(status.selection_reason)), "generation_ready": True,
+        "training_pool_mutated": False,
+    }
+    _json(prepared / "prepared_inputs_manifest.json", manifest)
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prepared-root", required=True)
+    args = parser.parse_args()
+    result = finalize(Path(args.prepared_root).resolve())
+    print(json.dumps({key: result[key] for key in
+                      ("selected_fn_count", "selected_pair_count", "generator_row_count")},
+                     sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_finalize_anomalygennext_inputs.py
+++ b/skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_finalize_anomalygennext_inputs.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import yaml
+from PIL import Image
+
+
+SCRIPT = Path(__file__).parents[1] / "finalize_anomalygennext_inputs.py"
+SPEC = importlib.util.spec_from_file_location("finalize_anomalygennext_inputs", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def _image(path: Path, full: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.name.startswith("clean"):
+        value = np.full((16, 16, 3), 80, dtype=np.uint8)
+    else:
+        value = np.full((16, 16), 255 if full else 0, dtype=np.uint8)
+        if not full:
+            value[3:9, 4:10] = 255
+    Image.fromarray(value).save(path)
+
+
+def _fixture(root: Path, reject_first: bool = False) -> None:
+    manifests = root / "manifests"
+    prepared = root / "prepared_anomalygennext_inputs"
+    manifests.mkdir(parents=True)
+    prepared.mkdir()
+    checkpoint, recipe = root / "model.pt", root / "recipe.yaml"
+    checkpoint.write_bytes(b"model")
+    recipe.write_text("anomaly_types: [[texture, crack]]\n")
+    config = {"source_tag": "test", "pool_dataset_root": str(root / "pool"),
+              "datasets": {"dataset": {"checkpoint": str(checkpoint), "recipe": str(recipe)}},
+              "retrieval": {"max_neighbors_per_fn": 1}}
+    (prepared / "filtering_config.yaml").write_text(yaml.safe_dump(config))
+    (prepared / "input_contract.json").write_text('{"status":"COMPLETE"}\n')
+    clean_a, clean_b = root / "clean-a.png", root / "clean-b.png"
+    _image(clean_a)
+    _image(clean_b)
+    rows = []
+    for order, fn_id in enumerate(("fn-1", "fn-2")):
+        for rank, clean in enumerate((clean_a, clean_b), start=1):
+            rows.append({"candidate_id": f"{fn_id}-pair-{rank}", "fn_id": fn_id,
+                         "query_order": order, "dataset_id": "dataset",
+                         "anomaly_type": "texture+crack", "od_category": "defect",
+                         "fn_filepath": str(root / "defect.png"),
+                         "clean_filepath": str(clean), "neighbor_rank": rank,
+                         "cosine_similarity": 1.0 - rank / 10,
+                         "eligible_for_amp": True, "gate_reason": ""})
+    pd.DataFrame(rows).to_parquet(manifests / "knn_candidates.parquet")
+    mask_rows, amp_rows = [], []
+    for fn_id in ("fn-1", "fn-2"):
+        for branch in sorted(MODULE.BRANCHES):
+            source = root / "source" / f"{fn_id}__{branch}.png"
+            _image(source)
+            mask_rows.append({"fn_id": fn_id, "branch": branch, "mask_path": str(source)})
+            for clean in (clean_a, clean_b):
+                aligned = root / "amp" / clean.stem / f"{source.stem}__seed0.png"
+                _image(aligned, full=reject_first and fn_id == "fn-1" and clean == clean_a)
+                amp_rows.append({"image_filename": str(clean), "mask_filename": str(aligned),
+                                 "anomaly_type": "texture+crack"})
+    pd.DataFrame(mask_rows).to_parquet(manifests / "mask_selection.parquet")
+    (root / "amp" / "testcase.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in amp_rows)
+    )
+
+
+def test_finalize_preserves_same_clean_across_false_negatives(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    report = MODULE.finalize(tmp_path)
+    assert report["selected_fn_count"] == 2
+    assert report["selected_pair_count"] == 2
+    assert report["generator_row_count"] == 4
+    selected = pd.read_parquet(tmp_path / "manifests" / "selected_pairs.parquet")
+    assert selected.clean_filepath.nunique() == 1
+    assert report["training_pool_mutated"] is False
+    assert all(Path(row["path"]).is_file() for row in report["artifacts"])
+    assert all(MODULE._sha256(Path(row["path"])) == row["sha256"] for row in report["artifacts"])
+
+
+def test_finalize_rejects_full_image_mask_and_uses_next_neighbor(tmp_path: Path) -> None:
+    _fixture(tmp_path, reject_first=True)
+    MODULE.finalize(tmp_path)
+    selected = pd.read_parquet(tmp_path / "manifests" / "selected_pairs.parquet")
+    first = selected[selected.fn_id == "fn-1"].iloc[0]
+    assert Path(first.clean_filepath).name == "clean-b.png"
+    status = pd.read_parquet(tmp_path / "manifests" / "knn_roi_status.parquet")
+    rejected = status[(status.fn_id == "fn-1") & (status.neighbor_rank == 1)].iloc[0]
+    assert rejected.selection_reason.endswith(":full_image")


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds the `finalize_inputs` action to `tao-prepare-anomalygennext-inputs`. It validates native AMP results, selects successful clean/FN pairs, and freezes the exact inputs that a later AnomalyGenNext generation action may consume.

The finalizer:

- Requires both the isolated-FN and same-type-sampled aligned mask branches for a candidate pair.
- Verifies that each aligned mask exists, matches the clean image dimensions, is nonempty, and does not cover the full image.
- Retains the configured number of successful neighbors per false negative and falls through to the next ranked neighbor when an earlier AMP result is invalid.
- Prevents duplicate clean-image use within one false negative while allowing separate false negatives to reuse the same clean image.
- Copies accepted aligned masks into the prepared result root.
- Writes pair-level status and selection parquet files, per-dataset testcase and provenance JSONL, a unified generation-input JSONL, and a generation plan.
- Publishes a completion manifest containing SHA-256 hashes and byte sizes for the generation contract artifacts.
- Records explicitly that the detector training pool was not mutated.

Usage after `run_amp` completes:

```bash
python skills/data/tao-prepare-anomalygennext-inputs/scripts/finalize_anomalygennext_inputs.py \
  --prepared-root /absolute/path/to/prepared-result
```

This completes the reusable preparation leaf. A later stacked PR adds the generation leaf that consumes these frozen testcase, provenance, checkpoint, and recipe bindings.

### Why are the changes needed?

Successful process execution is not sufficient evidence that an AMP output is safe to send to generation. Missing outputs, dimension mismatches, empty masks, or full-image masks can produce invalid synthesis inputs. A ranked candidate may also fail even though a later neighbor is usable.

The finalization boundary prevents those failures from leaking into generation. It provides deterministic selection, preserves false-negative provenance, makes every accepted artifact integrity-checkable, and keeps preparation separate from mutation of a detector training pool.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, the preparation skill could run native AMP but did not qualify its aligned masks or publish a stable generation contract.

After this change, users can invoke `finalize_inputs` on a completed prepared root. They receive selected-pair and rejection status, copied aligned masks, per-dataset and unified generation inputs, provenance, a generation plan, and a hash-bound completion manifest.

This is additive. Existing preparation and AMP actions are unchanged. Generation callers should consume the finalized artifacts rather than reading AMP's raw output directly.

### How was this patch tested?

The branch-focused unit tests passed:

```text
$ .venv/deft/bin/python -m pytest -q \
    skills/data/tao-prepare-anomalygennext-inputs/scripts/tests/test_finalize_anomalygennext_inputs.py

..                                                                       [100%]
2 passed in 0.45s
```

The tests cover:

- Preserving two false negatives that legitimately select the same clean image.
- Confirming that the detector training pool remains unmodified.
- Verifying every emitted artifact against its recorded SHA-256 hash.
- Rejecting a full-image aligned mask and selecting the next ranked neighbor.
- Recording the precise rejection reason in the pair-status manifest.

The exact branch independently passed the skill-bank validator, and its stacked diff has no whitespace errors:

```text
$ VALIDATE_BASE_REF=dev/anomalygen-next-prepare-amp ./scripts/validate-skills.sh
✓ validate-skills passed

$ git diff --check dev/anomalygen-next-prepare-amp...dev/anomalygen-next-prepare-finalize
# no output
```

The full preparation path was also exercised on one H100 with `nvcr.io/nvidia/paidf-anomalygen:1.1.0`. Two explicit false negatives progressed through native AMP to two selected pairs and four generation rows. The finalizer published ten durable artifacts whose hashes were verified.

### Was this patch authored or co-authored using generative AI tooling?

Yes. This patch was co-authored using OpenAI Codex.

Generated-by: OpenAI Codex (GPT-5.6)

### Release note

```release-note
Added validation and hash-bound publication of generation-ready AnomalyGenNext input pairs.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded so the package still works without them (the action's runtime dependencies are loaded only when its standalone script is invoked)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that my commit author name and email become permanently public once merged

### Notes for reviewers

Suggested review order:

1. `references/input-contract.md` and the `finalize_inputs` entry in `references/skill_info.yaml`.
2. `scripts/finalize_anomalygennext_inputs.py`, especially aligned-mask validation and ranked fallback.
3. `scripts/tests/test_finalize_anomalygennext_inputs.py` for clean-image reuse, integrity, and invalid-mask behavior.
4. `SKILL.md` for the complete three-stage preparation flow.

The clean-image uniqueness rule is intentionally scoped to one false negative. Two distinct false negatives may reuse the same best-matching clean image without losing their separate identities or provenance.

This PR freezes generation inputs but does not generate images or admit synthetic samples into detector training. Those responsibilities remain in later stacked leaves and application integration.
