### PR TITLE
feat(data): prepare AnomalyGenNext fine-tuning recipes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,7 @@
       "skills": [
         "./skills/data/tao-generate-anomalies",
         "./skills/data/tao-prepare-anomalygennext-inputs",
+        "./skills/data/tao-finetune-anomalygennext",
         "./skills/applications/tao-run-automl-deft-pipeline",
         "./skills/applications/tao-train-single-step",
         "./skills/applications/tao-analyze-changenet-rca",

--- a/skills/data/tao-finetune-anomalygennext/SKILL.md
+++ b/skills/data/tao-finetune-anomalygennext/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: tao-finetune-anomalygennext
+description: >-
+  Validate a user AnomalyGenNext dataset and recipe, freeze its validation set,
+  and prepare a canonical texture fine-tuning recipe. Use when AnomalyGenNext
+  task weights do not yet exist. Do not use for ordinary defect generation.
+license: Apache-2.0
+compatibility: Requires the AnomalyGenNext 1.1 container and its model checkpoints.
+metadata:
+  author: NVIDIA Corporation
+  version: "0.1.0"
+allowed-tools: Read Bash
+tags: [tao, data, anomalygen-next, fine-tuning, synthetic-data]
+---
+
+# Fine-tune AnomalyGenNext
+
+This leaf prepares a user-owned dataset and optional recipe for task-specific
+AnomalyGenNext LoRA training. The pinned image is declared in
+`references/skill_info.yaml`; do not replace it with the older 1.0 release.
+
+## Inputs
+
+```text
+DATASET/
+  defect_spec.jsonl
+  TEXTURE/
+    clean_image/*
+    anomaly_image/DEFECT/*
+    mask/DEFECT/*
+VALIDATION/testcase.jsonl
+```
+
+Also supply the Cosmos3-Nano base checkpoint directory, `Wan2.2_VAE.pth`, and
+a local `facebook/dinov2-large` checkpoint directory. The validation JSONL must
+contain `image_filename`, `mask_filename`, and `anomaly_type`; each trained
+`TEXTURE+DEFECT` needs at least three rows. A separately stored defect spec is
+accepted with `--defect-spec`.
+
+An optional user `recipe.yaml` is a template. Custom training settings remain,
+while dataset, checkpoint, validation, type order, and iteration-zero validation
+are replaced by validated identities. Without a template, the packaged recipe
+uses the established 5000-step defaults.
+
+## Prepare
+
+After the common launch review, run the `prepare_recipe` action:
+
+```bash
+scripts/prepare_finetune_recipe.py \
+  --dataset-root /data/my_dataset \
+  --validation-testcase /data/validation/testcase.jsonl \
+  --base-checkpoint /models/Cosmos3-Nano \
+  --vae-path /models/Wan2.2_VAE.pth \
+  --nn-backbone /models/facebook/dinov2-large \
+  --dataset-name my_dataset \
+  --recipe-template /data/recipe.yaml \
+  --output /results/canonical_recipe.yaml
+```
+
+The action freezes absolute validation paths, validates anomaly images and
+masks, checks type agreement with `defect_spec.jsonl`, refuses output reuse,
+and emits a recipe plus metadata. `validation_iter` must be a multiple of
+`save_iter`; `max_iter` must reach a post-baseline validation.
+
+The training action and strict `Average.nn_score` completion gate are added by
+the next review slice. Preparation alone is not evidence of successful model
+training.

--- a/skills/data/tao-finetune-anomalygennext/assets/default_recipe.yaml
+++ b/skills/data/tao-finetune-anomalygennext/assets/default_recipe.yaml
@@ -1,0 +1,29 @@
+task_type: texture_ft
+experiment: anomalygen_texture_ft
+model_size: nano
+per_class_lora_rank: 8
+per_class_lora_alpha: 8
+max_iter: 5000
+validation_iter: 1000
+run_validation_on_start: true
+save_iter: 1000
+cycle_lengths: 15000
+warm_up_steps: 500
+logging_iter: 10
+seed: 42
+lr: 0.001
+betas: [0.9, 0.95]
+eps: 0.000001
+weight_decay: 0.0
+image_size: [512, 512]
+batch_size: 4
+num_workers: 4
+ratio_range: [1.5, 8.0]
+model_input_size: 512
+shift: 5.0
+validation_batch_size: 16
+early_stop_enabled: false
+early_stop_metric: nn
+early_stop_patience: 5
+early_stop_min_delta: 0.0
+early_stop_min_delta_mode: rel

--- a/skills/data/tao-finetune-anomalygennext/evals/evals.json
+++ b/skills/data/tao-finetune-anomalygennext/evals/evals.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "prepare-anomalygennext-finetune-recipe",
+    "question": "How should I prepare a user dataset and recipe to fine-tune AnomalyGenNext? Do not run anything.",
+    "expected_skill": "tao-finetune-anomalygennext",
+    "ground_truth": "Validate the paired anomaly/mask/clean layout, defect specification and frozen validation rows, preserve custom recipe knobs, replace run identities, and require iteration-zero validation.",
+    "expected_behavior": [
+      "Select tao-finetune-anomalygennext",
+      "Require the dataset, validation JSONL, base checkpoint, VAE, and NN backbone",
+      "Preserve custom recipe settings while replacing run identity fields",
+      "Require aligned validation and checkpoint intervals"
+    ],
+    "expected_script": "scripts/prepare_finetune_recipe.py"
+  }
+]

--- a/skills/data/tao-finetune-anomalygennext/references/skill_info.yaml
+++ b/skills/data/tao-finetune-anomalygennext/references/skill_info.yaml
@@ -1,0 +1,38 @@
+network_arch: tao-finetune-anomalygennext
+type: data
+container_image: nvcr.io/nvidia/paidf-anomalygen:1.1.0  # versions-key: images.metropolis_sdg.anomalygen_next
+execution_environment: container
+gpu_spec_key: num_gpus
+required_credentials: []
+optional_credentials:
+- name: NGC_KEY
+  source: env_var
+  only_when: the selected platform requires authenticated access to nvcr.io
+actions:
+  prepare_recipe:
+    command: scripts/prepare_finetune_recipe.py
+    mode: args
+    inputs:
+      dataset_root: {type: folder}
+      validation_testcase: {type: file}
+      base_checkpoint: {type: folder}
+      vae_path: {type: file}
+      nn_backbone: {type: folder}
+      defect_spec: {type: file, optional: true}
+      recipe_template: {type: file, optional: true}
+    outputs:
+      recipe: {type: file}
+      normalized_validation: {type: file}
+      metadata: {type: file}
+    upload_excludes:
+    - inputs/
+    args:
+      dataset_root: --dataset-root {dataset_root}
+      validation_testcase: --validation-testcase {validation_testcase}
+      base_checkpoint: --base-checkpoint {base_checkpoint}
+      vae_path: --vae-path {vae_path}
+      nn_backbone: --nn-backbone {nn_backbone}
+      defect_spec: --defect-spec {defect_spec}
+      recipe_template: --recipe-template {recipe_template}
+      dataset_name: --dataset-name {dataset_name}
+      output: --output {recipe}

--- a/skills/data/tao-finetune-anomalygennext/scripts/prepare_finetune_recipe.py
+++ b/skills/data/tao-finetune-anomalygennext/scripts/prepare_finetune_recipe.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Validate AnomalyGenNext fine-tuning inputs and freeze a canonical recipe."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+IMAGES = {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+DEFAULT_RECIPE = Path(__file__).resolve().parents[1] / "assets" / "default_recipe.yaml"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _images(path: Path) -> list[Path]:
+    return sorted(item for item in path.iterdir() if item.is_file() and item.suffix.lower() in IMAGES)
+
+
+def _pairs(root: Path) -> list[list[str]]:
+    result = []
+    for texture in sorted(item for item in root.iterdir() if item.is_dir()):
+        anomaly_root = texture / "anomaly_image"
+        if not anomaly_root.is_dir():
+            continue
+        if not (texture / "clean_image").is_dir() or not _images(texture / "clean_image"):
+            raise ValueError(f"texture has no clean images: {texture.name}")
+        for defect in sorted(item for item in anomaly_root.iterdir() if item.is_dir()):
+            anomalies = _images(defect)
+            if not anomalies:
+                continue
+            mask_root = texture / "mask" / defect.name
+            if not mask_root.is_dir():
+                raise ValueError(f"missing mask directory: {mask_root}")
+            for image in anomalies:
+                choices = (mask_root / f"{image.stem}_mask{image.suffix}",
+                           mask_root / f"{image.stem}_mask.png", mask_root / image.name)
+                if not any(path.is_file() for path in choices):
+                    raise ValueError(f"anomaly lacks matching mask: {image}")
+            result.append([texture.name, defect.name])
+    if not result:
+        raise ValueError(f"no TEXTURE/anomaly_image/DEFECT inputs under {root}")
+    return result
+
+
+def _declared_types(path: Path) -> set[str]:
+    result = set()
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        name = str(row.get("defect_type") or row.get("anomaly_type") or "")
+        if not name:
+            raise ValueError(f"missing defect_type at {path}:{number}")
+        if row.get("spatial_dependency") == "text" and not row.get("roi_prompt_defect_location"):
+            raise ValueError(f"text-routed {name} lacks roi_prompt_defect_location")
+        result.add(name)
+    return result
+
+
+def _validation_path(raw: str, testcase: Path, dataset: Path, name: str) -> Path:
+    path = Path(raw)
+    choices = [path] if path.is_absolute() else [testcase.parent / path, dataset / path]
+    parts = path.parts
+    if not path.is_absolute() and len(parts) > 2 and parts[:2] == ("datasets", name):
+        choices.append(dataset / Path(*parts[2:]))
+    for choice in choices:
+        if choice.is_file():
+            return choice.resolve()
+    raise ValueError(f"cannot resolve validation path: {raw}")
+
+
+def _validation(path: Path, dataset: Path, name: str) -> tuple[list[dict[str, Any]], Counter]:
+    rows, counts = [], Counter()
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        anomaly = str(row.get("anomaly_type") or "")
+        if not anomaly:
+            raise ValueError(f"missing anomaly_type at {path}:{number}")
+        for key in ("image_filename", "mask_filename"):
+            if not row.get(key):
+                raise ValueError(f"missing {key} at {path}:{number}")
+            row[key] = str(_validation_path(str(row[key]), path, dataset, name))
+        rows.append(row)
+        counts[anomaly] += 1
+    if not rows:
+        raise ValueError("validation testcase is empty")
+    return rows, counts
+
+
+def prepare(args: argparse.Namespace) -> dict[str, Any]:
+    required = (("dataset root", args.dataset_root, True),
+                ("validation testcase", args.validation_testcase, False),
+                ("base checkpoint", args.base_checkpoint, True),
+                ("VAE", args.vae_path, False), ("NN backbone", args.nn_backbone, True))
+    for label, path, directory in required:
+        if not (path.is_dir() if directory else path.is_file()):
+            raise ValueError(f"{label} is missing: {path}")
+    if not SAFE_NAME.fullmatch(args.dataset_name) or not SAFE_NAME.fullmatch(args.job_name):
+        raise ValueError("dataset and job names may contain only letters, numbers, dot, dash, underscore")
+    recipe = yaml.safe_load(DEFAULT_RECIPE.read_text())
+    if args.recipe_template:
+        template = yaml.safe_load(args.recipe_template.read_text())
+        if not isinstance(template, dict):
+            raise ValueError("recipe template must be a YAML mapping")
+        recipe.update(template)
+    discovered = _pairs(args.dataset_root.resolve())
+    pairs = recipe.get("anomaly_types", discovered)
+    if not isinstance(pairs, list) or not pairs or any(
+            not isinstance(pair, list) or len(pair) != 2 or not all(isinstance(v, str) and v for v in pair)
+            for pair in pairs):
+        raise ValueError("anomaly_types must be nonempty [texture, defect] pairs")
+    if len({tuple(pair) for pair in pairs}) != len(pairs):
+        raise ValueError("anomaly_types contains duplicates")
+    missing = sorted(set(map(tuple, pairs)) - set(map(tuple, discovered)))
+    if missing:
+        raise ValueError(f"recipe types absent from dataset: {missing}")
+    types = [f"{texture}+{defect}" for texture, defect in pairs]
+    defect_spec = (args.defect_spec or args.dataset_root / "defect_spec.jsonl").resolve()
+    if not defect_spec.is_file():
+        raise ValueError(f"defect spec is missing: {defect_spec}")
+    undefined = sorted(set(types) - _declared_types(defect_spec))
+    if undefined:
+        raise ValueError(f"recipe types absent from defect spec: {undefined}")
+    rows, counts = _validation(args.validation_testcase.resolve(), args.dataset_root.resolve(),
+                               args.dataset_name)
+    insufficient = {name: counts[name] for name in types if counts[name] < args.min_validation_per_type}
+    extra = sorted(set(counts) - set(types))
+    if insufficient or extra:
+        raise ValueError(f"validation coverage mismatch: insufficient={insufficient}, extra={extra}")
+    if args.max_iter is not None:
+        recipe["max_iter"] = args.max_iter
+    if args.validation_iter is not None:
+        recipe["validation_iter"] = args.validation_iter
+    if args.save_iter is not None:
+        recipe["save_iter"] = args.save_iter
+    for key in ("max_iter", "validation_iter", "save_iter"):
+        if not isinstance(recipe.get(key), int) or isinstance(recipe[key], bool) or recipe[key] <= 0:
+            raise ValueError(f"{key} must be a positive integer")
+    if recipe["validation_iter"] % recipe["save_iter"] or recipe["max_iter"] < recipe["validation_iter"]:
+        raise ValueError("validation/save intervals must align and max_iter must reach validation")
+    normalized = args.output.with_suffix(".validation.jsonl")
+    metadata = args.output.with_suffix(".metadata.json")
+    if any(path.exists() for path in (args.output, normalized, metadata)):
+        raise FileExistsError("refusing to overwrite recipe outputs")
+    normalized.parent.mkdir(parents=True, exist_ok=True)
+    normalized.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
+    recipe.update({"task_type": "texture_ft", "experiment": "anomalygen_texture_ft",
+                   "job_name": args.job_name, "dataset_name": args.dataset_name,
+                   "anomaly_types": pairs, "dataset_path": str(args.dataset_root.resolve()),
+                   "testcase_jsonl": str(normalized.resolve()), "model_size": "nano",
+                   "base_checkpoint_path": str(args.base_checkpoint.resolve()),
+                   "vae_path": str(args.vae_path.resolve()), "run_validation_on_start": True,
+                   "early_stop_metric": "nn"})
+    args.output.write_text(yaml.safe_dump(recipe, sort_keys=False))
+    report = {"status": "COMPLETE", "recipe": str(args.output.resolve()),
+              "recipe_sha256": _sha256(args.output), "validation_testcase": str(normalized.resolve()),
+              "dataset_root": str(args.dataset_root.resolve()), "defect_spec": str(defect_spec),
+              "nn_backbone": str(args.nn_backbone.resolve()), "anomaly_types": types,
+              "validation_counts": {name: counts[name] for name in types},
+              "metric": "Average.nn_score", "direction": "max"}
+    metadata.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--validation-testcase", type=Path, required=True)
+    parser.add_argument("--base-checkpoint", type=Path, required=True)
+    parser.add_argument("--vae-path", type=Path, required=True)
+    parser.add_argument("--nn-backbone", type=Path, required=True)
+    parser.add_argument("--dataset-name", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--defect-spec", type=Path)
+    parser.add_argument("--recipe-template", type=Path)
+    parser.add_argument("--job-name", default="anomalygen_texture_ft")
+    parser.add_argument("--min-validation-per-type", type=int, default=3)
+    parser.add_argument("--max-iter", type=int)
+    parser.add_argument("--validation-iter", type=int)
+    parser.add_argument("--save-iter", type=int)
+    args = parser.parse_args()
+    print(json.dumps(prepare(args), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/data/tao-finetune-anomalygennext/scripts/tests/test_prepare_finetune_recipe.py
+++ b/skills/data/tao-finetune-anomalygennext/scripts/tests/test_prepare_finetune_recipe.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+SCRIPT = Path(__file__).parents[1] / "prepare_finetune_recipe.py"
+
+
+def _fixture(root: Path) -> list[str]:
+    dataset = root / "dataset"
+    for path in (dataset / "texture" / "anomaly_image" / "defect" / "a.png",
+                 dataset / "texture" / "mask" / "defect" / "a_mask.png",
+                 dataset / "texture" / "clean_image" / "clean.png"):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"image")
+    (dataset / "defect_spec.jsonl").write_text(
+        json.dumps({"defect_type": "texture+defect", "spatial_dependency": "text",
+                    "roi_prompt_defect_location": "on the surface"}) + "\n"
+    )
+    validation = root / "validation.jsonl"
+    validation.write_text("".join(json.dumps({
+        "image_filename": str(dataset / "texture" / "clean_image" / "clean.png"),
+        "mask_filename": str(dataset / "texture" / "mask" / "defect" / "a_mask.png"),
+        "anomaly_type": "texture+defect"}) + "\n" for _ in range(3)))
+    base, nn = root / "Cosmos3-Nano", root / "dinov2-large"
+    base.mkdir()
+    nn.mkdir()
+    vae = root / "Wan2.2_VAE.pth"
+    vae.write_bytes(b"model")
+    return ["--dataset-root", str(dataset), "--validation-testcase", str(validation),
+            "--base-checkpoint", str(base), "--vae-path", str(vae),
+            "--nn-backbone", str(nn), "--dataset-name", "fixture",
+            "--output", str(root / "out" / "recipe.yaml")]
+
+
+def test_prepare_preserves_custom_knobs_and_freezes_identities(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    template = tmp_path / "template.yaml"
+    template.write_text(yaml.safe_dump({"anomaly_types": [["texture", "defect"]],
+                                        "batch_size": 7, "custom_knob": "kept"}))
+    result = subprocess.run([sys.executable, str(SCRIPT), *args,
+                             "--recipe-template", str(template), "--max-iter", "1000"],
+                            capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    recipe = yaml.safe_load((tmp_path / "out" / "recipe.yaml").read_text())
+    assert recipe["batch_size"] == 7 and recipe["custom_knob"] == "kept"
+    assert recipe["dataset_name"] == "fixture"
+    assert recipe["max_iter"] == recipe["save_iter"] == recipe["validation_iter"] == 1000
+    assert recipe["run_validation_on_start"] is True
+    rows = [json.loads(line) for line in
+            (tmp_path / "out" / "recipe.validation.jsonl").read_text().splitlines()]
+    assert len(rows) == 3
+    assert all(Path(row["image_filename"]).is_absolute() for row in rows)
+    metadata = json.loads((tmp_path / "out" / "recipe.metadata.json").read_text())
+    assert metadata["anomaly_types"] == ["texture+defect"]
+
+
+def test_prepare_rejects_undercovered_validation(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    validation = Path(args[args.index("--validation-testcase") + 1])
+    validation.write_text(validation.read_text().splitlines()[0] + "\n")
+    result = subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "validation coverage mismatch" in result.stderr


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds the new `tao-finetune-anomalygennext` data skill and its `prepare_recipe` action. The action validates a user-owned texture anomaly dataset, freezes a validation testcase, and emits a canonical AnomalyGenNext fine-tuning recipe for the pinned public 1.1 container.

The action:

- Discovers `TEXTURE/anomaly_image/DEFECT` types and requires clean images and a matching mask for every anomaly image.
- Accepts `defect_spec.jsonl` in the dataset root or as an explicit input.
- Validates every trained `TEXTURE+DEFECT` type against the dataset, defect specification, and validation testcase.
- Requires the placement prompt for text-routed defect types.
- Resolves supported validation paths and freezes them as absolute paths.
- Requires configurable minimum validation coverage per anomaly type and rejects undeclared extra types.
- Accepts an optional user recipe as a template, preserving supported custom training knobs while replacing dataset identity, paths, type order, checkpoint paths, and validation settings with verified values.
- Provides established 5,000-step defaults when no template is supplied.
- Enforces positive, aligned save/validation intervals and requires at least one post-baseline validation.
- Refuses to overwrite a recipe, normalized validation testcase, or metadata output.
- Records the canonical recipe hash, anomaly-type order, validation counts, and `Average.nn_score` optimization direction.

The PR also registers the skill in the marketplace and declares its structured `prepare_recipe` action contract.

Example:

```bash
python skills/data/tao-finetune-anomalygennext/scripts/prepare_finetune_recipe.py \
  --dataset-root /data/my_dataset \
  --validation-testcase /data/validation/testcase.jsonl \
  --base-checkpoint /models/Cosmos3-Nano \
  --vae-path /models/Wan2.2_VAE.pth \
  --nn-backbone /models/facebook/dinov2-large \
  --dataset-name my_dataset \
  --recipe-template /data/recipe.yaml \
  --output /results/canonical_recipe.yaml
```

The following stacked PR adds container-native training and the strict post-training NN-score acceptance gate. A later DEFT OD AOI integration PR uses this leaf only when synthesis is requested and compatible AnomalyGenNext task weights are missing.

### Why are the changes needed?

AnomalyGenNext generation normally requires a compatible task-specific adapter and its exact training recipe. Users with a new dataset may not have either. Passing an arbitrary recipe directly to the trainer can silently mismatch anomaly-type order, dataset paths, validation coverage, or model assets, producing an adapter that cannot be safely paired with later generation.

This skill establishes a reusable validation and canonicalization boundary. It lets users provide their own dataset, defect specification, validation testcase, and optional recipe without embedding DEFT-specific routing or customer-specific layout assumptions in the training leaf.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, TAO Skill Bank had no standalone skill for validating AnomalyGenNext fine-tuning inputs or producing a canonical recipe when task-specific weights were missing.

After this change, users can invoke `tao-finetune-anomalygennext` to validate the dataset, defect specification, model assets, validation coverage, and recipe timing before launching GPU training. The action emits a canonical recipe, normalized validation JSONL, and metadata report.

This is an additive capability. It does not change existing generation workflows, and this PR does not launch training by itself.

### How was this patch tested?

The branch-focused unit tests passed:

```text
$ .venv/deft/bin/python -m pytest -q \
    skills/data/tao-finetune-anomalygennext/scripts/tests/test_prepare_finetune_recipe.py

..                                                                       [100%]
2 passed in 0.17s
```

The tests cover:

- Preserving user-provided recipe knobs while freezing validated dataset and model identities.
- Preserving the declared anomaly-type order.
- Resolving validation image and mask paths to absolute paths.
- Enabling iteration-zero validation and aligning a 1,000-step smoke recipe's save and validation intervals.
- Emitting anomaly-type and validation metadata.
- Rejecting validation sets with fewer than the required rows per trained type.

The exact branch independently passed the skill-bank validator, and its stacked diff has no whitespace errors:

```text
$ VALIDATE_BASE_REF=dev/anomalygen-next-prepare-finalize ./scripts/validate-skills.sh
✓ validate-skills passed

$ git diff --check dev/anomalygen-next-prepare-finalize...dev/anomalygen-next-finetune-recipe
# no output
```

The emitted canonical recipe was also consumed unchanged by the follow-up training implementation in a one-H100, 1,000-step smoke with `nvcr.io/nvidia/paidf-anomalygen:1.1.0`. The run completed both iteration-zero and post-training validation; training and acceptance behavior are part of the next PR.

### Was this patch authored or co-authored using generative AI tooling?

Yes. This patch was co-authored using OpenAI Codex.

Generated-by: OpenAI Codex (GPT-5.6)

### Release note

```release-note
Added a skill for validating user AnomalyGenNext datasets and preparing canonical task-specific fine-tuning recipes.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded so the package still works without them (the new dependencies are loaded only when the standalone action is invoked)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that my commit author name and email become permanently public once merged

### Notes for reviewers

Suggested review order:

1. `SKILL.md` for the intended user workflow and scope.
2. `references/skill_info.yaml` and `assets/default_recipe.yaml` for the action contract and defaults.
3. `scripts/prepare_finetune_recipe.py` for dataset discovery, validation, and canonicalization.
4. `scripts/tests/test_prepare_finetune_recipe.py` for custom-template and undercoverage cases.

The user recipe is intentionally treated as a template rather than an unchecked pass-through. Custom training settings are retained, but dataset identity, model assets, validation testcase, anomaly-type order, and iteration-zero validation are always bound to the verified inputs.

This leaf is intentionally independent of DEFT. The DEFT OD AOI application integration appears later in the stack and may call it as a one-time prerequisite when a synthesis route lacks compatible task weights.
