### PR TITLE
feat(data): train and qualify AnomalyGenNext adapters

### DIFF
--- a/skills/data/tao-finetune-anomalygennext/SKILL.md
+++ b/skills/data/tao-finetune-anomalygennext/SKILL.md
@@ -18,6 +18,8 @@ tags: [tao, data, anomalygen-next, fine-tuning, synthetic-data]
 This leaf prepares a user-owned dataset and optional recipe for task-specific
 AnomalyGenNext LoRA training. The pinned image is declared in
 `references/skill_info.yaml`; do not replace it with the older 1.0 release.
+Read `references/input-contract.md` when validating a dataset or adapting a
+recipe, and `references/container-runtime.md` before submission.
 
 ## Inputs
 

--- a/skills/data/tao-finetune-anomalygennext/references/container-runtime.md
+++ b/skills/data/tao-finetune-anomalygennext/references/container-runtime.md
@@ -1,0 +1,34 @@
+# Container runtime
+
+Read this before submitting AnomalyGenNext fine-tuning.
+
+The action uses the public image declared by `skill_info.yaml`:
+
+```text
+nvcr.io/nvidia/paidf-anomalygen:1.1.0
+```
+
+Use the source tree and Python environment baked into that image at
+`/workspace/paidf-anomalygen`. Do not overlay a host checkout or virtualenv.
+Mount or stage the dataset, canonical recipe, validation JSONL, Cosmos3-Nano
+checkpoint, VAE, optional Hugging Face cache, and durable results directory.
+
+The image does not contain the DINOv2 checkpoint used by the validation
+callback. Expose the selected directory read-only at:
+
+```text
+/workspace/paidf-anomalygen/checkpoints/facebook/dinov2-large
+```
+
+It must contain `config.json` and either `model.safetensors` or
+`pytorch_model.bin`. For offline execution, preflight the cache supplied with
+`--hf-cache` for the Qwen tokenizer required by the pinned image.
+
+The selected platform owns image import, execution storage, cache placement,
+GPU allocation, and result publication. Keep credentials out of recipes,
+commands, logs, and job records. Preserve only the canonical recipe, selected
+adapter, validation metrics, status, training curves, and
+`training_handoff.json` declared by the action.
+
+A 1000-step run is the minimum quality smoke because it includes iteration-zero
+and later validation. Shorter runs demonstrate wiring only.

--- a/skills/data/tao-finetune-anomalygennext/references/input-contract.md
+++ b/skills/data/tao-finetune-anomalygennext/references/input-contract.md
@@ -1,0 +1,46 @@
+# Fine-tuning input contract
+
+Read this reference when validating a user dataset or adapting an existing
+AnomalyGenNext recipe.
+
+## Dataset layout
+
+```text
+DATASET_ROOT/
+  defect_spec.jsonl
+  TEXTURE/
+    clean_image/*
+    anomaly_image/DEFECT/*
+    mask/DEFECT/<anomaly-stem>_mask.png
+    cad_mask/DEFECT/*              # only for spatial_dependency=cad
+VALIDATION_ROOT/testcase.jsonl
+```
+
+The defect specification may be supplied separately with `--defect-spec`.
+Each row identifies `defect_type` as `TEXTURE+DEFECT`, selects
+`spatial_dependency` (`free`, `text`, or `cad`), and provides the
+placement fields required by that mode. Text-routed defects require a nonempty
+`roi_prompt_defect_location`.
+
+Each validation row must contain `image_filename`, `mask_filename`, and
+`anomaly_type`. Freeze at least three rows per trained type. The builder
+resolves supported relative paths, verifies every file, and emits a normalized
+validation JSONL with absolute paths.
+
+## Type and recipe identity
+
+The recipe's `anomaly_types` order defines model class IDs. Resolve the order
+from an explicit list first, then the user template, otherwise lexical dataset
+discovery. Every type must exist in the dataset and defect specification.
+
+A user recipe is a template, not an unchecked pass-through. Preserve supported
+training knobs, but replace dataset identity, paths, validation testcase,
+base/VAE checkpoints, anomaly-type order, and iteration-zero validation with
+the verified values. Preserve the emitted canonical recipe beside the selected
+adapter; generation must use that pair unchanged.
+
+The dataset root, defect specification, validation testcase, optional template,
+Cosmos3-Nano checkpoint, VAE, and DINOv2 backbone may live at separate absolute
+paths. The selected platform must expose all of them to the container. The
+DINOv2 directory needs a Transformers-compatible `config.json` and model
+weights.


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR completes `tao-finetune-anomalygennext` by adding the container-native `train` action and a strict `Average.nn_score` completion gate.

The training wrapper:

- Uses the upstream AnomalyGenNext trainer already present at `/workspace/paidf-anomalygen` in the pinned public 1.1 image.
- Supports explicit GPU count, DDP or FSDP parallelism, compile enablement, an optional Hugging Face cache, and explicit resume behavior.
- Requires iteration-zero validation in the canonical recipe.
- Verifies the mounted DINOv2 configuration and weights before starting training.
- Refuses existing publication outputs and refuses an existing runtime directory unless `--resume` is supplied.
- Keeps optimizer, scheduler, and trainer checkpoint state out of published results.

The post-training validator:

- Reads the `Average` column from the `nn_score` row of AnomalyGenNext's validation KPI files.
- Requires a finite iteration-zero baseline and at least one later scored model checkpoint.
- Requires `best_checkpoint.txt` to select the maximum eligible NN score.
- Requires the selected score to improve strictly beyond the baseline plus the configured minimum.
- Publishes only the selected adapter and canonical recipe after all gates pass.
- Emits a status file, NN-improvement summary, and `training_handoff.json` with the exact anomaly-type order and SHA-256 hashes binding the adapter to its recipe.
- Emits `ERROR` metadata without publishing an adapter when qualification fails.

The PR also adds detailed public references for the dataset contract, container runtime, and NN-score completion contract.

Example after preparing the canonical recipe:

```bash
bash skills/data/tao-finetune-anomalygennext/scripts/finetune_anomalygennext.sh \
  --recipe /results/canonical_recipe.yaml \
  --results-dir /results/training \
  --num-gpus 1 \
  --min-nn-improvement 0.0
```

Later stacked PRs allow AnomalyGenNext generation and the DEFT OD AOI application to consume the hash-bound handoff. Fine-tuning is performed once before an iterative synthesis workflow, not inside each iteration.

### Why are the changes needed?

A trainer exit code or the existence of a latest checkpoint does not demonstrate that fine-tuning improved the model. Downstream synthesis also needs an unambiguous checkpoint/recipe pair with the same anomaly-type ordering used during training.

This PR turns training into a qualified handoff: it compares the post-training metric against an iteration-zero baseline, verifies that the pointer selects the best scored checkpoint, and cryptographically binds the published adapter to the canonical recipe. This prevents downstream workflows from accepting regressions, stale pointers, incomplete validation, or mismatched recipes.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, `tao-finetune-anomalygennext` could validate inputs and prepare a canonical recipe but could not launch the upstream trainer or qualify its output.

After this change, users can submit the `train` action through a supported platform and receive either:

- A `COMPLETE` handoff containing a hash-bound selected adapter and canonical recipe after strict NN-score improvement, or
- An `ERROR` summary explaining which training-completion gate failed, without publishing an unqualified adapter.

This is additive. Existing recipe preparation remains unchanged. Users must expose the selected DINOv2 directory at the action's declared container path and provide the required base checkpoint, VAE, dataset, and validation inputs.

### How was this patch tested?

The branch-focused fine-tuning tests passed:

```text
$ .venv/deft/bin/python -m pytest -q \
    skills/data/tao-finetune-anomalygennext/scripts/tests/test_prepare_finetune_recipe.py \
    skills/data/tao-finetune-anomalygennext/scripts/tests/test_nn_improvement.py

.....                                                                    [100%]
5 passed in 0.37s
```

The tests cover:

- Publishing a `COMPLETE`, hash-bound handoff when `Average.nn_score` improves.
- Preserving the canonical anomaly-type order and copied adapter contents.
- Rejecting a post-training regression, emitting an `ERROR` report, and withholding the adapter.
- Exposing the optional offline Hugging Face cache input in the training wrapper.
- Re-running the preparation coverage so the training action remains compatible with its canonical recipe producer.

The exact branch independently passed the skill-bank validator, and its stacked diff has no whitespace errors:

```text
$ VALIDATE_BASE_REF=dev/anomalygen-next-finetune-recipe ./scripts/validate-skills.sh
✓ validate-skills passed

$ git diff --check dev/anomalygen-next-finetune-recipe...dev/anomalygen-next-finetune-train
# no output
```

The complete path was also run on one H100 for 1,000 steps using `nvcr.io/nvidia/paidf-anomalygen:1.1.0`, the minimum quality smoke that includes iteration-zero and later validation:

```text
status: COMPLETE
baseline Average.nn_score: 0.2871624678
best Average.nn_score:     0.4209174290
improvement:               0.1337549612
```

The selected checkpoint and canonical recipe were copied to durable outputs and both recorded hashes were verified. Runtime-state directories were not published as final artifacts.

### Was this patch authored or co-authored using generative AI tooling?

Yes. This patch was co-authored using OpenAI Codex.

Generated-by: OpenAI Codex (GPT-5.6)

### Release note

```release-note
Added container-native AnomalyGenNext adapter training with strict NN-score qualification and a hash-bound checkpoint/recipe handoff.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded so the package still works without them (the training dependencies remain inside the declared container action)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that my commit author name and email become permanently public once merged

### Notes for reviewers

Suggested review order:

1. `references/nn-score-contract.md` for the success definition.
2. `references/skill_info.yaml` for declared inputs, outputs, defaults, and publication exclusions.
3. `scripts/finetune_anomalygennext.sh` for preflight and upstream trainer invocation.
4. `scripts/validate_nn_improvement.py` for checkpoint selection and handoff publication.
5. `scripts/tests/test_nn_improvement.py` for acceptance and regression behavior.
6. `references/input-contract.md`, `references/container-runtime.md`, and `SKILL.md` for the operator-facing contract.

The acceptance metric is deliberately `Average.nn_score`, not training loss, a single anomaly-type column, or the existence of `latest_checkpoint.txt`. A shorter-than-1,000-step run may demonstrate wiring but cannot satisfy the documented quality smoke because it lacks both baseline and post-training validation.

The DEFT OD AOI application integration is intentionally outside this leaf. A later stacked PR consumes `training_handoff.json` only when a synthesis route is missing compatible task weights.
