### PR TITLE
feat(data): generate validated AnomalyGenNext OD defects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,7 @@
         "./skills/data/tao-generate-anomalies",
         "./skills/data/tao-prepare-anomalygennext-inputs",
         "./skills/data/tao-finetune-anomalygennext",
+        "./skills/data/tao-generate-od-defects",
         "./skills/applications/tao-run-automl-deft-pipeline",
         "./skills/applications/tao-train-single-step",
         "./skills/applications/tao-analyze-changenet-rca",

--- a/skills/data/tao-generate-od-defects/SKILL.md
+++ b/skills/data/tao-generate-od-defects/SKILL.md
@@ -18,6 +18,8 @@ tags: [tao, data, anomalygen-next, object-detection, synthetic-data, coco]
 This leaf uses the upstream generator and pseudo-labeler in the pinned public
 container. It does not prepare detector gaps, run AMP, train AnomalyGenNext, or
 append outputs to a detector training set.
+Read `references/execution-contract.md` when adapting input or completion
+behavior, and `references/container-runtime.md` before submission.
 
 ## Inputs
 

--- a/skills/data/tao-generate-od-defects/SKILL.md
+++ b/skills/data/tao-generate-od-defects/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tao-generate-od-defects
+description: >-
+  Run AnomalyGenNext 1.1 inference from a native testcase or a prepared
+  generation plan, then publish validated fine-grained and binary COCO labels.
+  Use for synthetic object-detection defect generation, not model training.
+license: Apache-2.0
+compatibility: Requires the AnomalyGenNext 1.1 container, CUDA GPUs, base and task checkpoints.
+metadata:
+  author: NVIDIA Corporation
+  version: "0.1.0"
+allowed-tools: Read Bash
+tags: [tao, data, anomalygen-next, object-detection, synthetic-data, coco]
+---
+
+# Generate AnomalyGenNext OD Defects
+
+This leaf uses the upstream generator and pseudo-labeler in the pinned public
+container. It does not prepare detector gaps, run AMP, train AnomalyGenNext, or
+append outputs to a detector training set.
+
+## Inputs
+
+Pass either:
+
+- `--inputs-dir` pointing to the completed output of
+  `tao-prepare-anomalygennext-inputs`; or
+- `--input-data-path`, `--checkpoint`, and matching `--recipe` for a native
+  AnomalyGenNext testcase.
+
+Also provide the Cosmos3-Nano base checkpoint and one or more GPUs. Every
+testcase image and aligned mask must exist, every anomaly type must occur in the
+recipe, and the requested row count must match the testcase. When a prepared
+integrity manifest exists, every recorded hash is verified before generation.
+
+## Run
+
+Invoke `tao-launch-workflow`, review the exact image, mounts, GPU shape, runtime,
+and output directory, then submit the `generate` action:
+
+```bash
+scripts/generate_od_defects.py \
+  --inputs-dir /results/prepared_inputs \
+  --base-checkpoint /models/Cosmos3-Nano/model \
+  --output-dir /new/generation \
+  --num-gpus 1
+```
+
+The action deliberately exposes no switch that disables the image's default
+guardrail path. An optional Hugging Face cache can provide the tokenizer and
+guardrail assets for offline execution.
+
+## Completion
+
+For each dataset, `generated + guardrail_blocked` must equal requested rows.
+The pseudo-label count must match generated images, each image needs an
+annotation, categories must be declared anomaly types, and every COCO bbox must
+be positive and inside its image. The action emits:
+
+```text
+DATASET/raw/
+DATASET/pseudo_labels/coco_annotations.json
+pseudo_labels/coco_annotations.json
+pseudo_labels/coco_annotations_od_defect.json
+validation_summary.json
+status.json
+```
+
+The native COCO preserves `TEXTURE+DEFECT` categories. The binary file maps all
+annotations to `defect`. Only a calling application may admit these outputs to
+training; this leaf always reports `training_pool_mutated=false`.

--- a/skills/data/tao-generate-od-defects/evals/evals.json
+++ b/skills/data/tao-generate-od-defects/evals/evals.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "generate-anomalygennext-od-defects",
+    "question": "Generate OD defect images from my prepared AnomalyGenNext inputs. Do not execute anything yet.",
+    "expected_skill": "tao-generate-od-defects",
+    "ground_truth": "Use the pinned AnomalyGenNext 1.1 container, validate the plan or native testcase, run upstream generation and pseudo-labeling, and publish validated native and binary COCO.",
+    "expected_behavior": [
+      "Select tao-generate-od-defects",
+      "Invoke tao-launch-workflow before submission",
+      "Require matching recipe and task checkpoint",
+      "Verify generated plus blocked accounting and COCO integrity"
+    ],
+    "expected_script": "scripts/generate_od_defects.py"
+  }
+]

--- a/skills/data/tao-generate-od-defects/references/container-runtime.md
+++ b/skills/data/tao-generate-od-defects/references/container-runtime.md
@@ -1,0 +1,39 @@
+# AnomalyGenNext 1.1 container runtime
+
+Read this before submitting generation.
+
+Resolve the image through `references/skill_info.yaml`:
+
+```text
+nvcr.io/nvidia/paidf-anomalygen:1.1.0
+```
+
+The image contains AnomalyGenNext 1.1 and its runtime at
+`/workspace/paidf-anomalygen`. Do not substitute the older 1.0 image and do
+not overlay an external checkout or host virtualenv.
+
+Expose the testcase or prepared-input result, task checkpoint and recipe,
+Cosmos3-Nano base checkpoint, optional real-image root, optional Hugging Face
+cache, this skill directory, and a new durable output directory. Preserve
+absolute paths or rewrite all related paths consistently inside the compute
+frame. The platform owns writable temporary storage and caches.
+
+For offline use, preflight the selected Hugging Face cache for the tokenizer
+and guardrail assets resolved by the pinned image. Missing assets can fail
+before sampling. Keep registry and Hugging Face credentials out of specs,
+commands, logs, and job records.
+
+Invoke the command declared in `skill_info.yaml`, for example inside the
+container:
+
+```bash
+python /opt/tao-generate-od-defects/scripts/generate_od_defects.py \
+  --inputs-dir /inputs/prepared \
+  --base-checkpoint /models/Cosmos3-Nano/model \
+  --output-dir /results/generation \
+  --num-gpus 1
+```
+
+The exposed GPU count must match `--num-gpus`. The output directory must not
+already exist. Read `execution-contract.md` for the completion and accounting
+gates.

--- a/skills/data/tao-generate-od-defects/references/execution-contract.md
+++ b/skills/data/tao-generate-od-defects/references/execution-contract.md
@@ -1,0 +1,42 @@
+# AnomalyGenNext OD generation contract
+
+Read this when adapting generation to a new platform or AnomalyGenNext release.
+This action performs inference only and requires an existing task checkpoint
+with its matching canonical recipe.
+
+## Input modes
+
+Exactly one input mode is allowed:
+
+- Prepared mode: `--inputs-dir` points to a completed
+  `tao-prepare-anomalygennext-inputs` result containing
+  `anomalygen_next_generation_plan.json`.
+- Native mode: pass `--input-data-path`, `--checkpoint`, and `--recipe`;
+  optional dataset and anomaly-type selectors may narrow existing rows.
+
+Every testcase image and mask must exist. Each `anomaly_type` must be present
+in the recipe, and the requested count must equal the testcase row count.
+Prepared-input hashes are verified when the integrity manifest is present.
+
+## Native stages
+
+From the release source baked into the image, the wrapper invokes generation,
+optional evaluation and quality refinement when a real-image root is present,
+and pseudo-labeling. Generation uses `torchrun` with the requested GPU count;
+AnomalyGenNext owns distributed row partitioning and rank-zero metadata merge.
+
+## Completion accounting
+
+For every dataset:
+
+```text
+generated + guardrail_blocked == requested
+```
+
+Every generated image must have exactly one pseudo-label image record and at
+least one valid in-bounds annotation. The native COCO retains the exact
+fine-grained anomaly categories. The binary companion maps every annotation to
+category id 1 named `defect`.
+
+The leaf never admits generated images into a detector training pool. That
+decision belongs to the calling application.

--- a/skills/data/tao-generate-od-defects/references/skill_info.yaml
+++ b/skills/data/tao-generate-od-defects/references/skill_info.yaml
@@ -1,0 +1,44 @@
+network_arch: tao-generate-od-defects
+type: data
+container_image: nvcr.io/nvidia/paidf-anomalygen:1.1.0  # versions-key: images.metropolis_sdg.anomalygen_next
+execution_environment: container
+gpu_spec_key: num_gpus
+required_credentials: []
+optional_credentials:
+- name: HF_TOKEN
+  source: env_var
+  only_when: a required Hugging Face asset is not already cached
+- name: NGC_KEY
+  source: env_var
+  only_when: the selected platform requires authenticated access to nvcr.io
+actions:
+  generate:
+    command: scripts/generate_od_defects.py
+    mode: args
+    inputs:
+      prepared_inputs_root: {type: folder, optional: true}
+      input_data_path: {type: file, optional: true}
+      checkpoint: {type: file, optional: true}
+      recipe: {type: file, optional: true}
+      base_checkpoint: {type: folder}
+      hf_cache: {type: folder, optional: true}
+    outputs:
+      results_dir: {type: folder}
+      validation_summary: {type: file}
+      native_coco: {type: file}
+      binary_coco: {type: file}
+      status: {type: file}
+    upload_excludes:
+    - inputs/
+    args:
+      inputs_dir: --inputs-dir {prepared_inputs_root}
+      input_data_path: --input-data-path {input_data_path}
+      checkpoint: --checkpoint {checkpoint}
+      recipe: --recipe {recipe}
+      base_checkpoint: --base-checkpoint {base_checkpoint}
+      output_dir: --output-dir {results_dir}
+      datasets: --datasets {datasets}
+      num_gpus: --num-gpus {num_gpus}
+      hf_cache: --hf-cache {hf_cache}
+    defaults:
+      num_gpus: 1

--- a/skills/data/tao-generate-od-defects/scripts/generate_od_defects.py
+++ b/skills/data/tao-generate-od-defects/scripts/generate_od_defects.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run AnomalyGenNext inference and publish merged OD defect labels."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def _sha(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _rows(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _validate_manifest(root: Path) -> None:
+    manifest = root / "prepared_anomalygennext_inputs" / "prepared_inputs_manifest.json"
+    if not manifest.is_file():
+        return
+    value = json.loads(manifest.read_text())
+    if value.get("status") != "COMPLETE" or not value.get("generation_ready"):
+        raise ValueError("prepared-input manifest is not generation-ready")
+    for artifact in value.get("artifacts", []):
+        path = Path(artifact["path"])
+        if not path.is_file() or _sha(path) != artifact["sha256"]:
+            raise ValueError(f"prepared-input artifact changed or is missing: {path}")
+
+
+def _normalize(group: dict[str, Any]) -> dict[str, Any]:
+    result = {"dataset_id": str(group.get("dataset_id") or "default"),
+              "testcase": str(group["testcase"]), "checkpoint": str(group["checkpoint"]),
+              "recipe": str(group["recipe"]),
+              "anomaly_types": [str(value) for value in group.get("anomaly_types", [])]}
+    if not SAFE_ID.fullmatch(result["dataset_id"]):
+        raise ValueError(f"unsafe dataset id: {result['dataset_id']!r}")
+    for key in ("testcase", "checkpoint", "recipe"):
+        if not Path(result[key]).is_file():
+            raise FileNotFoundError(f"{key} not found: {result[key]}")
+    rows = _rows(Path(result["testcase"]))
+    if not rows:
+        raise ValueError("generation testcase is empty")
+    if not result["anomaly_types"]:
+        result["anomaly_types"] = list(dict.fromkeys(str(row.get("anomaly_type") or "") for row in rows))
+    if not all(result["anomaly_types"]):
+        raise ValueError("generation rows need anomaly_type")
+    recipe = yaml.safe_load(Path(result["recipe"]).read_text())
+    recipe_types = {f"{pair[0]}+{pair[1]}" for pair in recipe.get("anomaly_types", [])}
+    if set(result["anomaly_types"]) - recipe_types:
+        raise ValueError("generation anomaly types are absent from the recipe")
+    for row in rows:
+        if str(row.get("anomaly_type") or "") not in result["anomaly_types"]:
+            raise ValueError("testcase contains an undeclared anomaly type")
+        for key in ("image_filename", "mask_filename"):
+            if not Path(str(row.get(key) or "")).is_file():
+                raise FileNotFoundError(f"testcase {key} is missing: {row.get(key)}")
+    requested = int(group.get("requested_rows", len(rows)))
+    if requested != len(rows):
+        raise ValueError(f"requested/testcase row mismatch: {requested} != {len(rows)}")
+    result["requested_rows"] = requested
+    return result
+
+
+def groups(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if bool(args.inputs_dir) == bool(args.input_data_path):
+        raise ValueError("pass exactly one of --inputs-dir and --input-data-path")
+    if args.inputs_dir:
+        root = args.inputs_dir.resolve()
+        _validate_manifest(root)
+        plan = root / "prepared_anomalygennext_inputs" / "anomalygen_next_generation_plan.json"
+        if not plan.is_file():
+            plan = root / "anomalygen_next_generation_plan.json"
+        values = json.loads(plan.read_text())
+        if not isinstance(values, list) or not values:
+            raise ValueError("generation plan is empty")
+        if args.datasets:
+            requested = {value.strip() for value in args.datasets.split(",") if value.strip()}
+            available = {str(row.get("dataset_id")) for row in values}
+            if requested - available:
+                raise ValueError(f"unknown dataset ids: {sorted(requested - available)}")
+            values = [row for row in values if str(row.get("dataset_id")) in requested]
+    else:
+        if not args.checkpoint or not args.recipe:
+            raise ValueError("native input requires --checkpoint and --recipe")
+        values = [{"dataset_id": args.dataset_id, "testcase": str(args.input_data_path),
+                   "checkpoint": str(args.checkpoint), "recipe": str(args.recipe),
+                   "anomaly_types": [value.strip() for value in args.anomaly_types.split(",")
+                                     if value.strip()]}]
+    result = [_normalize(value) for value in values]
+    if len({group["dataset_id"] for group in result}) != len(result):
+        raise ValueError("generation plan contains duplicate dataset ids")
+    return result
+
+
+def _csv_count(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    with path.open(newline="") as stream:
+        return sum(1 for _ in csv.DictReader(stream))
+
+
+def _run_group(group: dict[str, Any], output: Path, args: argparse.Namespace) -> dict[str, Any]:
+    raw, labels = output / "raw", output / "pseudo_labels"
+    raw.mkdir(parents=True)
+    command = ["torchrun", f"--nproc_per_node={args.num_gpus}",
+               str(args.repo / "anomalygen/scripts/texture/generate.py"),
+               "--checkpoint", group["checkpoint"], "--recipe", group["recipe"],
+               "--base_checkpoint", str(args.base_checkpoint),
+               "--input_data_path", group["testcase"], "--output_dir", str(raw)]
+    subprocess.run(command, check=True)
+    subprocess.run([sys.executable, str(args.repo / "anomalygen/scripts/texture/pseudo_label.py"),
+                    "--gen_root", str(raw), "--output_dir", str(labels), "--no_caption"], check=True)
+    generated = _csv_count(raw / "texture_ft_generation_result.csv")
+    blocked = _csv_count(raw / "guardrail_blocked.csv")
+    if generated + blocked != group["requested_rows"]:
+        raise ValueError("generated + guardrail-blocked does not equal requested rows")
+    coco = json.loads((labels / "coco_annotations.json").read_text())
+    if len(coco.get("images", [])) != generated:
+        raise ValueError("pseudo-label image count does not equal generated count")
+    return {"group": group, "coco": coco, "generated": generated, "blocked": blocked,
+            "image_root": raw / "reconstructed_image"}
+
+
+def _merge(results: list[dict[str, Any]], output: Path) -> dict[str, Any]:
+    images, annotations, category_ids, status = [], [], {}, []
+    next_image = next_annotation = 1
+    for result in results:
+        group, coco = result["group"], result["coco"]
+        expected = set(group["anomaly_types"])
+        categories = {int(row["id"]): str(row["name"]) for row in coco.get("categories", [])}
+        if set(categories.values()) - expected:
+            raise ValueError("pseudo-label output contains unexpected categories")
+        local_images = {int(row["id"]): row for row in coco.get("images", [])}
+        image_map = {}
+        per_image = Counter()
+        for old_id, row in sorted(local_images.items()):
+            source = Path(str(row["file_name"]))
+            if not source.is_file():
+                source = result["image_root"] / source.name
+            if not source.is_file():
+                raise FileNotFoundError(source)
+            image_map[old_id] = next_image
+            images.append({**row, "id": next_image, "file_name": str(source.resolve()),
+                           "dataset_id": group["dataset_id"]})
+            next_image += 1
+        for row in coco.get("annotations", []):
+            old_image, old_category = int(row["image_id"]), int(row["category_id"])
+            if old_image not in image_map or old_category not in categories:
+                raise ValueError("annotation references an unknown image or category")
+            x, y, width, height = map(float, row["bbox"])
+            image = local_images[old_image]
+            if min(x, y) < 0 or width <= 0 or height <= 0 or x + width > image["width"] or y + height > image["height"]:
+                raise ValueError("annotation bbox is invalid or outside its image")
+            name = categories[old_category]
+            category = category_ids.setdefault(name, len(category_ids) + 1)
+            annotations.append({**row, "id": next_annotation, "image_id": image_map[old_image],
+                                "category_id": category})
+            next_annotation += 1
+            per_image[old_image] += 1
+        if any(per_image[old_id] == 0 for old_id in local_images):
+            raise ValueError("one or more generated images have no annotation")
+        status.append({"dataset_id": group["dataset_id"], "requested": group["requested_rows"],
+                       "generated": result["generated"], "guardrail_blocked": result["blocked"]})
+    labels = output / "pseudo_labels"
+    native = {"images": images, "annotations": annotations,
+              "categories": [{"id": value, "name": key} for key, value in category_ids.items()]}
+    binary = {"images": images, "annotations": [{**row, "category_id": 1} for row in annotations],
+              "categories": [{"id": 1, "name": "defect"}]}
+    _json(labels / "coco_annotations.json", native)
+    _json(labels / "coco_annotations_od_defect.json", binary)
+    report = {"status": "COMPLETE", "groups": status, "generated": len(images),
+              "annotations": len(annotations), "training_pool_mutated": False}
+    _json(output / "validation_summary.json", report)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inputs-dir", type=Path)
+    parser.add_argument("--input-data-path", type=Path)
+    parser.add_argument("--checkpoint", type=Path)
+    parser.add_argument("--recipe", type=Path)
+    parser.add_argument("--anomaly-types", default="")
+    parser.add_argument("--dataset-id", default="default")
+    parser.add_argument("--datasets")
+    parser.add_argument("--base-checkpoint", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--num-gpus", type=int, default=1)
+    parser.add_argument("--hf-cache", type=Path)
+    parser.add_argument("--repo", type=Path, default=Path("/workspace/paidf-anomalygen"))
+    args = parser.parse_args()
+    if args.output_dir.exists() or args.num_gpus < 1 or not args.base_checkpoint.exists():
+        raise ValueError("output must be new; GPU count positive; base checkpoint must exist")
+    if not args.repo.is_dir():
+        raise FileNotFoundError(args.repo)
+    env = os.environ
+    if args.hf_cache:
+        if not args.hf_cache.is_dir():
+            raise FileNotFoundError(args.hf_cache)
+        env["HF_HOME"] = str(args.hf_cache.resolve())
+    selected = groups(args)
+    args.output_dir.mkdir(parents=True)
+    try:
+        report = _merge([_run_group(group, args.output_dir / group["dataset_id"], args)
+                         for group in selected], args.output_dir)
+        _json(args.output_dir / "status.json", {"status": "COMPLETE"})
+    except Exception as exc:
+        _json(args.output_dir / "status.json", {"status": "ERROR", "message": str(exc)})
+        raise
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/data/tao-generate-od-defects/scripts/tests/test_generate_od_defects.py
+++ b/skills/data/tao-generate-od-defects/scripts/tests/test_generate_od_defects.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+SCRIPT = Path(__file__).parents[1] / "generate_od_defects.py"
+SPEC = importlib.util.spec_from_file_location("generate_od_defects", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def _inputs(root: Path) -> argparse.Namespace:
+    clean, mask = root / "clean.png", root / "mask.png"
+    clean.write_bytes(b"image")
+    mask.write_bytes(b"mask")
+    testcase = root / "testcase.jsonl"
+    testcase.write_text(json.dumps({"image_filename": str(clean), "mask_filename": str(mask),
+                                    "anomaly_type": "texture+defect"}) + "\n")
+    checkpoint, recipe = root / "adapter.pt", root / "recipe.yaml"
+    checkpoint.write_bytes(b"adapter")
+    recipe.write_text(yaml.safe_dump({"anomaly_types": [["texture", "defect"]]}))
+    return argparse.Namespace(inputs_dir=None, input_data_path=testcase, checkpoint=checkpoint,
+                              recipe=recipe, anomaly_types="", dataset_id="default", datasets=None)
+
+
+def test_native_contract_infers_and_validates_types(tmp_path: Path) -> None:
+    selected = MODULE.groups(_inputs(tmp_path))
+    assert selected[0]["anomaly_types"] == ["texture+defect"]
+    assert selected[0]["requested_rows"] == 1
+
+
+def test_contract_rejects_type_absent_from_recipe(tmp_path: Path) -> None:
+    args = _inputs(tmp_path)
+    args.recipe.write_text(yaml.safe_dump({"anomaly_types": [["texture", "other"]]}))
+    with pytest.raises(ValueError, match="absent from the recipe"):
+        MODULE.groups(args)
+
+
+def test_merge_validates_boxes_and_writes_binary_projection(tmp_path: Path) -> None:
+    image = tmp_path / "generated.png"
+    image.write_bytes(b"image")
+    result = {"group": {"dataset_id": "d", "requested_rows": 1,
+                        "anomaly_types": ["texture+defect"]},
+              "generated": 1, "blocked": 0, "image_root": tmp_path,
+              "coco": {"images": [{"id": 7, "file_name": str(image),
+                                      "width": 20, "height": 10}],
+                       "annotations": [{"id": 9, "image_id": 7, "category_id": 4,
+                                        "bbox": [1, 2, 5, 6], "area": 30}],
+                       "categories": [{"id": 4, "name": "texture+defect"}]}}
+    report = MODULE._merge([result], tmp_path / "out")
+    assert report["status"] == "COMPLETE" and report["training_pool_mutated"] is False
+    binary = json.loads((tmp_path / "out/pseudo_labels/coco_annotations_od_defect.json").read_text())
+    assert binary["categories"] == [{"id": 1, "name": "defect"}]
+    assert binary["annotations"][0]["category_id"] == 1


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds the `tao-generate-od-defects` data skill for running AnomalyGenNext 1.1 inference and publishing validated object-detection labels.

The new `generate` action:

- Accepts either a completed `tao-prepare-anomalygennext-inputs` result or a native AnomalyGenNext testcase with its matching task checkpoint and recipe.
- Verifies prepared-input integrity hashes when an integrity manifest is available.
- Validates testcase rows, image/mask paths, requested row counts, dataset identifiers, and recipe anomaly-type coverage before generation.
- Invokes the generator and pseudo-labeler supplied by the pinned public AnomalyGenNext 1.1 container.
- Accounts for every requested row as either generated or guardrail-blocked.
- Rejects missing labels, unknown categories, invalid boxes, and boxes outside their images.
- Publishes both native fine-grained COCO labels and a binary `defect` projection for object-detection applications.
- Keeps detector training-pool admission outside the leaf and reports `training_pool_mutated=false`.

The PR also adds the skill's container and execution contracts, structured action metadata, evaluation cases, tests, and marketplace registration.

Prepared-input usage:

```bash
python skills/data/tao-generate-od-defects/scripts/generate_od_defects.py \
  --inputs-dir /absolute/path/to/prepared-inputs \
  --base-checkpoint /absolute/path/to/Cosmos3-Nano/model \
  --output-dir /absolute/path/to/new/generation \
  --num-gpus 1
```

Native AnomalyGenNext testcase usage is also supported by passing `--input-data-path`, `--checkpoint`, and `--recipe` instead of `--inputs-dir`.

This is the final AnomalyGenNext data-leaf slice in the stack. Later DEFT OD AOI PRs optionally consume the binary COCO output and decide whether generated samples are admitted to detector training.

### Why are the changes needed?

AnomalyGenNext's native generation output is not, by itself, a safe detector-training boundary. A calling workflow needs deterministic input validation, complete generated-versus-blocked accounting, valid object-detection annotations, a binary category projection, and an explicit guarantee that generation does not silently mutate its training pool.

Without this leaf, each application would need to reproduce the AnomalyGenNext invocation and validation logic. That would make behavior inconsistent across workflows and could allow malformed or partially generated outputs into later detector-training stages.

This skill makes inference reusable while preserving a clear separation of responsibility: AnomalyGenNext generates and validates synthetic defects; the calling application controls admission.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, TAO Skill Bank did not provide a reusable action for running AnomalyGenNext object-detection generation and publishing validated native and binary COCO outputs.

After this change, users can invoke `tao-generate-od-defects` with either prepared inputs or a native testcase. Successful runs publish validated fine-grained labels, a binary `defect` projection, completion accounting, and machine-readable status.

This is additive and does not break existing usage. It requires the public AnomalyGenNext 1.1 container, a Cosmos3-Nano base checkpoint, and a compatible task checkpoint/recipe pair.

### How was this patch tested?

The branch-focused unit tests passed:

```text
$ .venv/deft/bin/python -m pytest -q \
    skills/data/tao-generate-od-defects/scripts/tests/test_generate_od_defects.py

...                                                                      [100%]
3 passed in 0.06s
```

The tests cover:

- Inferring and validating anomaly types for native testcase input.
- Rejecting an anomaly type absent from the selected recipe.
- Validating generated image/annotation relationships and in-bounds boxes.
- Preserving native fine-grained categories while producing the binary `defect` projection.
- Reporting that the detector training pool was not mutated.

The exact generation implementation was also exercised in a one-GPU smoke test using `nvcr.io/nvidia/paidf-anomalygen:1.1.0`. Four testcase rows produced four generated images and four valid pseudo-label annotations, with zero blocked rows; both native and binary COCO outputs passed validation. The container's text screening and face blurring paths were enabled. The public 1.1 preset did not provide an enforcing image-safety model, so that smoke reported `image_guardrail_enforcing=false`.

The skill-bank validator and patch checks also passed for this branch:

```text
$ VALIDATE_BASE_REF=dev/anomalygen-next-finetune-train ./scripts/validate-skills.sh

✓ validate-skills passed

$ git diff --check dev/anomalygen-next-finetune-train...dev/anomalygen-next-generate

# no output
```

### Was this patch authored or co-authored using generative AI tooling?

Yes. This patch was co-authored using OpenAI Codex.

Generated-by: OpenAI Codex (GPT-5.6)

### Release note

```release-note
Added an AnomalyGenNext generation skill that validates inference results and publishes fine-grained and binary object-detection COCO labels.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

The most useful review order is:

1. `skills/data/tao-generate-od-defects/SKILL.md` for the user-facing boundary.
2. `skills/data/tao-generate-od-defects/references/execution-contract.md` for input modes and completion accounting.
3. `skills/data/tao-generate-od-defects/references/skill_info.yaml` for the structured action contract.
4. `skills/data/tao-generate-od-defects/scripts/generate_od_defects.py` for validation, native invocation, and COCO publication.
5. `skills/data/tao-generate-od-defects/scripts/tests/test_generate_od_defects.py` for positive and negative behavior.

The leaf intentionally does not run AnomalyGenNext fine-tuning, prepare detector gaps, or admit generated images into detector training. Those responsibilities remain in the preceding fine-tuning/preparation leaves and the later DEFT OD AOI integration PRs.
